### PR TITLE
Better error message for request function.

### DIFF
--- a/plankapy.py
+++ b/plankapy.py
@@ -79,7 +79,19 @@ class Planka:
             raise InvalidToken("Invalid API credentials")
 
         if response.status_code not in [200, 201]:
-            raise InvalidToken(f"Failed to {method} {url} with status code {response.status_code}")
+            try:
+                error_response = response.json()
+            
+                error_code = error_response.get("code")
+                error_message = error_response.get("message")
+                error_problems = '\n\t'.join(error_response.get("problems"))
+
+                full_message = f"[{error_code}] {error_message}\n{error_problems}"
+
+            except requests.exceptions.JSONDecodeError:
+                error_response = response.text
+
+            raise InvalidToken(f"Failed to {method} {url} with status code {response.status_code}, error message:\n{full_message}")
 
         try:
             return response.json()

--- a/plankapy.py
+++ b/plankapy.py
@@ -89,7 +89,7 @@ class Planka:
                 full_message = f"[{error_code}] {error_message}\n{error_problems}"
 
             except requests.exceptions.JSONDecodeError:
-                error_response = response.text
+                full_message = response.text
 
             raise InvalidToken(f"Failed to {method} {url} with status code {response.status_code}, error message:\n{full_message}")
 


### PR DESCRIPTION
The current error message is a bit confusing me when I use the tool. For example when I try to create a card with empty description, it just show an error message like:

```
plankapy.InvalidToken: Failed to POST https://task.mycompany.com/api/lists/1305112070412305423/cards with status code 400.
```

And I really confuse why my information cause 400 at beginning. This PR contain a full error message from the API for user to better understand what is going on. The new message will become:

```
plankapy.InvalidToken: Failed to POST https://task.mycompany.com/api/lists/1305112070412305423/cards with status code 400, error message:
[E_MISSING_OR_INVALID_PARAMS] The server could not fulfill this request (`POST /api/lists/1305112070412305423/cards`) due to 1 missing or invalid parameter.
Invalid "description":
  · Value ('') was an empty string.
```
