### PR TITLE
fix setup.py for pip install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,1 +1,9 @@
-## TODO
+#!/bin/python3
+from setuptools import setup, find_packages
+
+setup(
+    name='plankapy',
+    version='1.0.0',
+    description='Python library for Planka API',
+    packages=find_packages(),
+)


### PR DESCRIPTION
Both those get error cuz setup.py is empty

`pip install .`
`pip install git+https://github.com/hwelch-fle/plankapy.git`

