### PR TITLE
Add dependency on requests module

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,10 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 
+dependencies = [
+    "requests",
+]
+
 [project.urls]
 Homepage = "https://github.com/hwelch-fle/plankapy"
 Documentation = "https://hwelch-fle.github.io/plankapy/plankapy.html"


### PR DESCRIPTION
`plankapy` uses the Python `requests` module, but doesn't declare a dependency. This pull request adds that to `pyproject.toml`.