### PR TITLE
Change endpoint for validation

### DIFF
--- a/plankapy/plankapy.py
+++ b/plankapy/plankapy.py
@@ -46,7 +46,7 @@ class Planka:
         - **return:** True if successful, False if not
         """
         try:
-            self.request("GET", "/*")
+            self.request("GET", "/api/users/me")
             return True
         except Exception as e:
             raise InvalidToken(f"Invalid API credentials\n{self.__repr__()}")


### PR DESCRIPTION
The endpoint `/*` previously used for validation returns `text/html`, and since `Planka.request` unconditionally tries to interpret all response data as JSON, the request appears to fail, when in fact it works.

Therefore, let's request the logged in user's information to validate the authorization/authentication instead.