### PR TITLE
[PATCH]: Update API to 2.0.1

### DIFF
--- a/src/plankapy/v2/api/__init__.py
+++ b/src/plankapy/v2/api/__init__.py
@@ -1,8 +1,8 @@
-"""PLANKA API (2.0.0) - Generated on Wed Jan 21 2026"""
+"""PLANKA API (2.0.1) - Generated on Wed Mar 11 2026"""
 
 from .schemas import *
 from .paths import *
 from .async_paths import *
 from .errors import *
 
-__version__ = "2.0.0"
+__version__ = "2.0.1"

--- a/src/plankapy/v2/api/async_paths.py
+++ b/src/plankapy/v2/api/async_paths.py
@@ -1051,7 +1051,7 @@ class AsyncPlankaEndpoints:
             Forbidden: 403 
             NotFound: 404 
         """
-        resp = await self.client.patch(f"api/cards/{cardId}/custom-field-values/customFieldGroupId:{customFieldGroupId}:customFieldId:${customFieldId}", json=kwargs)
+        resp = await self.client.patch(f"api/cards/{cardId}/custom-field-values/customFieldGroupId:{customFieldGroupId}:customFieldId:{customFieldId}", json=kwargs)
         await raise_planka_err(resp)
         return resp.json()
 
@@ -1074,7 +1074,7 @@ class AsyncPlankaEndpoints:
             Forbidden: 403 
             NotFound: 404 
         """
-        resp = await self.client.delete(f"api/cards/{cardId}/custom-field-value/customFieldGroupId:{customFieldGroupId}:customFieldId:${customFieldId}")
+        resp = await self.client.delete(f"api/cards/{cardId}/custom-field-value/customFieldGroupId:{customFieldGroupId}:customFieldId:{customFieldId}")
         await raise_planka_err(resp)
         return resp.json()
 

--- a/src/plankapy/v2/api/async_paths.py
+++ b/src/plankapy/v2/api/async_paths.py
@@ -27,7 +27,8 @@ class AsyncPlankaEndpoints:
 
         Args:
             pendingToken (str): Pending token received from the authentication flow
-            signature (str): Terms signature hash based on user role
+            signature (str): Terms signature hash
+            initialLanguage (Literal['ar-YE', 'bg-BG', 'ca-ES', 'cs-CZ', 'da-DK', 'de-DE', 'el-GR', 'en-GB', 'en-US', 'es-ES', 'et-EE', 'fa-IR', 'fi-FI', 'fr-FR', 'hu-HU', 'id-ID', 'it-IT', 'ja-JP', 'ko-KR', 'nl-NL', 'pl-PL', 'pt-BR', 'pt-PT', 'ro-RO', 'ru-RU', 'sk-SK', 'sr-Cyrl-RS', 'sr-Latn-RS', 'sv-SE', 'tr-TR', 'uk-UA', 'uz-UZ', 'vi-VN', 'zh-CN', 'zh-TW'] | None): Preferred language for user interface and notifications (used only if user language is not set)
 
         Note:
             All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
@@ -514,6 +515,13 @@ class AsyncPlankaEndpoints:
         await raise_planka_err(resp)
         return resp.json()
 
+    async def getBootstrap(self) -> Response_getBootstrap:
+        """Retrieves the application bootstrap.
+        """
+        resp = await self.client.get("api/bootstrap")
+        await raise_planka_err(resp)
+        return resp.json()
+
     async def createCardLabel(self, cardId: str, **kwargs: Unpack[Request_createCardLabel]) -> Response_createCardLabel:
         """Adds a label to a card. Requires board editor permissions.
 
@@ -638,10 +646,11 @@ class AsyncPlankaEndpoints:
 
         Args:
             listId (str): ID of the list to get cards from (must be an endless list))
-            before (str): Pagination cursor (JSON object with id and listChangedAt)) (optional)
+            before[listChangedAt] (str): Pagination cursor field `listChangedAt` (use together with `before[id]`)) (optional)
+            before[id] (str): Pagination cursor field `id` (use together with `before[listChangedAt]`)) (optional)
             search (str): Search term to filter cards) (optional)
-            filterUserIds (str): Comma-separated user IDs to filter by members) (optional)
-            filterLabelIds (str): Comma-separated label IDs to filter by labels) (optional)
+            userIds (str): Comma-separated user IDs to filter by members or task assignees) (optional)
+            labelIds (str): Comma-separated label IDs to filter by labels) (optional)
 
         Note:
             All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
@@ -653,7 +662,7 @@ class AsyncPlankaEndpoints:
             Unauthorized: 401 
             NotFound: 404 
         """
-        valid_params = ('before', 'search', 'filterUserIds', 'filterLabelIds')
+        valid_params = ('before[listChangedAt]', 'before[id]', 'search', 'userIds', 'labelIds')
         passed_params = {k: v for k, v in kwargs.items() if k in valid_params if isinstance(v, str | int | float)}
         resp = await self.client.get(f"api/lists/{listId}/cards", params=passed_params)
         await raise_planka_err(resp)
@@ -709,7 +718,7 @@ class AsyncPlankaEndpoints:
             listId (str): ID of the list to move the card to
             coverAttachmentId (str | None): ID of the attachment used as cover
             type (Literal['project', 'story']): Type of the card
-            position (int | None): Position of the card within the list
+            position (int | None): Position of the card within the list (required when moving card to new list)
             name (str): Name/title of the card
             description (str | None): Detailed description of the card
             dueDate (str | None): Due date for the card
@@ -738,8 +747,10 @@ class AsyncPlankaEndpoints:
 
         Args:
             id (str): ID of the card to duplicate)
-            position (int): Position for the duplicated card within the list
-            name (str): Name/title for the duplicated card
+            boardId (str): ID of the board to duplicate the card to
+            listId (str): ID of the list to duplicate the card to
+            position (int | None): Position for the duplicated card within the list
+            name (str | None): Name/title for the duplicated card
 
         Note:
             All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
@@ -751,6 +762,7 @@ class AsyncPlankaEndpoints:
             Unauthorized: 401 
             Forbidden: 403 
             NotFound: 404 
+            UnprocessableEntity: 422 
         """
         resp = await self.client.post(f"api/cards/{id}/duplicate", json=kwargs)
         await raise_planka_err(resp)
@@ -865,9 +877,42 @@ class AsyncPlankaEndpoints:
         return resp.json()
 
     async def getConfig(self) -> Response_getConfig:
-        """Retrieves the application configuration.
+        """Retrieves the application configuration. Requires admin privileges.
         """
         resp = await self.client.get("api/config")
+        await raise_planka_err(resp)
+        return resp.json()
+
+    async def updateConfig(self, **kwargs: Unpack[Request_updateConfig]) -> Response_updateConfig:
+        """Updates the application configuration. Requires admin privileges.
+
+        Args:
+            smtpHost (str | None): Hostname or IP address of the SMTP server
+            smtpPort (int | None): Port number of the SMTP server
+            smtpName (str | None): AsyncClient hostname used in the EHLO command for SMTP
+            smtpSecure (bool): Whether to use a secure connection for SMTP
+            smtpTlsRejectUnauthorized (bool): Whether to reject unauthorized or self-signed TLS certificates for SMTP connections
+            smtpUser (str | None): Username for authenticating with the SMTP server
+            smtpPassword (str | None): Password for authenticating with the SMTP server
+            smtpFrom (str | None): Default "from" used for outgoing SMTP emails
+        """
+        resp = await self.client.patch("api/config", json=kwargs)
+        await raise_planka_err(resp)
+        return resp.json()
+
+    async def testSmtpConfig(self) -> Response_testSmtpConfig:
+        """Sends a test email to verify the SMTP is configured correctly. Only available when SMTP is configured via the UI.
+
+        Note:
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
+            If a matching PlankaError exists, it will be raised (see `api.errors`) 
+            Planka internal status codes and names are included here for disambiguation
+
+        Raises:
+            Unauthorized: 401 
+            Forbidden: 403 
+        """
+        resp = await self.client.post("api/config/test-smtp")
         await raise_planka_err(resp)
         return resp.json()
 
@@ -1583,7 +1628,7 @@ class AsyncPlankaEndpoints:
         """Creates a project. The current user automatically becomes a project manager.
 
         Args:
-            type (Literal['public', 'private']): Type of the project
+            type (Literal['private', 'shared']): Type of the project
             name (str): Name/title of the project
             description (str | None): Detailed description of the project
 
@@ -1852,12 +1897,11 @@ class AsyncPlankaEndpoints:
         await raise_planka_err(resp)
         return resp.json()
 
-    async def getTerms(self, type: Literal['general', 'extended'], **kwargs: Unpack[Request_getTerms]) -> Response_getTerms:
+    async def getTerms(self, **kwargs: Unpack[Request_getTerms]) -> Response_getTerms:
         """Retrieves terms and conditions in the specified language.
 
         Args:
-            type (Literal['general', 'extended']): Type of terms to retrieve)
-            language (Literal['de-DE', 'en-US']): Language code for terms localization) (optional)
+            language (str): Language code for terms localization) (optional)
 
         Note:
             All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
@@ -1871,7 +1915,27 @@ class AsyncPlankaEndpoints:
         """
         valid_params = ('language',)
         passed_params = {k: v for k, v in kwargs.items() if k in valid_params if isinstance(v, str | int | float)}
-        resp = await self.client.get(f"api/terms/{type}", params=passed_params)
+        resp = await self.client.get("api/terms", params=passed_params)
+        await raise_planka_err(resp)
+        return resp.json()
+
+    async def createUserApiKey(self, id: str) -> Response_createUserApiKey:
+        """Generates a user's API key. The full API key is returned only once and cannot be retrieved again.
+
+        Args:
+            id (str): ID of the user to create API key for)
+
+        Note:
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
+            If a matching PlankaError exists, it will be raised (see `api.errors`) 
+            Planka internal status codes and names are included here for disambiguation
+
+        Raises:
+            ValidationError: 400 
+            Unauthorized: 401 
+            NotFound: 404 
+        """
+        resp = await self.client.post(f"api/users/{id}/api-key")
         await raise_planka_err(resp)
         return resp.json()
 
@@ -1886,7 +1950,7 @@ class AsyncPlankaEndpoints:
             username (str | None): Unique username for user identification
             phone (str | None): Contact phone number
             organization (str | None): Organization or company name
-            language (Literal['ar-YE', 'bg-BG', 'cs-CZ', 'da-DK', 'de-DE', 'el-GR', 'en-GB', 'en-US', 'es-ES', 'et-EE', 'fa-IR', 'fi-FI', 'fr-FR', 'hu-HU', 'id-ID', 'it-IT', 'ja-JP', 'ko-KR', 'nl-NL', 'pl-PL', 'pt-BR', 'pt-PT', 'ro-RO', 'ru-RU', 'sk-SK', 'sr-Cyrl-RS', 'sr-Latn-RS', 'sv-SE', 'tr-TR', 'uk-UA', 'uz-UZ', 'zh-CN', 'zh-TW'] | None): Preferred language for user interface and notifications
+            language (Literal['ar-YE', 'bg-BG', 'ca-ES', 'cs-CZ', 'da-DK', 'de-DE', 'el-GR', 'en-GB', 'en-US', 'es-ES', 'et-EE', 'fa-IR', 'fi-FI', 'fr-FR', 'hu-HU', 'id-ID', 'it-IT', 'ja-JP', 'ko-KR', 'nl-NL', 'pl-PL', 'pt-BR', 'pt-PT', 'ro-RO', 'ru-RU', 'sk-SK', 'sr-Cyrl-RS', 'sr-Latn-RS', 'sv-SE', 'tr-TR', 'uk-UA', 'uz-UZ', 'vi-VN', 'zh-CN', 'zh-TW'] | None): Preferred language for user interface and notifications (if null - will be set automatically on the first login)
             subscribeToOwnCards (bool): Whether the user subscribes to their own cards
             subscribeToCardWhenCommenting (bool): Whether the user subscribes to cards when commenting
             turnOffRecentCardHighlighting (bool): Whether recent card highlighting is disabled
@@ -1977,7 +2041,8 @@ class AsyncPlankaEndpoints:
             avatar (dict[str, Any] | None): Avatar of the user (only null value to remove avatar)
             phone (str | None): Contact phone number
             organization (str | None): Organization or company name
-            language (Literal['ar-YE', 'bg-BG', 'cs-CZ', 'da-DK', 'de-DE', 'el-GR', 'en-GB', 'en-US', 'es-ES', 'et-EE', 'fa-IR', 'fi-FI', 'fr-FR', 'hu-HU', 'id-ID', 'it-IT', 'ja-JP', 'ko-KR', 'nl-NL', 'pl-PL', 'pt-BR', 'pt-PT', 'ro-RO', 'ru-RU', 'sk-SK', 'sr-Cyrl-RS', 'sr-Latn-RS', 'sv-SE', 'tr-TR', 'uk-UA', 'uz-UZ', 'zh-CN', 'zh-TW'] | None): Preferred language for user interface and notifications
+            language (Literal['ar-YE', 'bg-BG', 'ca-ES', 'cs-CZ', 'da-DK', 'de-DE', 'el-GR', 'en-GB', 'en-US', 'es-ES', 'et-EE', 'fa-IR', 'fi-FI', 'fr-FR', 'hu-HU', 'id-ID', 'it-IT', 'ja-JP', 'ko-KR', 'nl-NL', 'pl-PL', 'pt-BR', 'pt-PT', 'ro-RO', 'ru-RU', 'sk-SK', 'sr-Cyrl-RS', 'sr-Latn-RS', 'sv-SE', 'tr-TR', 'uk-UA', 'uz-UZ', 'vi-VN', 'zh-CN', 'zh-TW']): Preferred language for user interface and notifications
+            apiKey (dict[str, Any] | None): API key of the user (only null value to remove API key)
             subscribeToOwnCards (bool): Whether the user subscribes to their own cards
             subscribeToCardWhenCommenting (bool): Whether the user subscribes to cards when commenting
             turnOffRecentCardHighlighting (bool): Whether recent card highlighting is disabled
@@ -1985,6 +2050,7 @@ class AsyncPlankaEndpoints:
             defaultEditorMode (Literal['wysiwyg', 'markup']): Default markdown editor mode
             defaultHomeView (Literal['gridProjects', 'groupedProjects']): Default view mode for the home page
             defaultProjectsOrder (Literal['byDefault', 'alphabetically', 'byCreationTime']): Default sort order for projects display
+            isSsoUser (bool): Whether the user is SSO user (only false value to unlink SSO, for admins)
             isDeactivated (bool): Whether the user account is deactivated and cannot log in (for admins)
 
         Note:

--- a/src/plankapy/v2/api/paths.py
+++ b/src/plankapy/v2/api/paths.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 from typing import (
-    Literal,
     Unpack,
 )
 from httpx import Client, Response, HTTPStatusError
@@ -541,7 +540,7 @@ class PlankaEndpoints:
         raise_planka_err(resp)
         return resp.json()
 
-    def getBootstrap(self) -> Response_getBootstrap:
+    def getBootstrap(self) -> Bootstrap:
         """Retrieves the application bootstrap.
         """
         resp = self.client.get("api/bootstrap")

--- a/src/plankapy/v2/api/paths.py
+++ b/src/plankapy/v2/api/paths.py
@@ -672,8 +672,8 @@ class PlankaEndpoints:
 
         Args:
             listId (str): ID of the list to get cards from (must be an endless list))
-            before[listChangedAt] (str): Pagination cursor field `listChangedAt` (use together with `before[id]`)) (optional)
-            before[id] (str): Pagination cursor field `id` (use together with `before[listChangedAt]`)) (optional)
+            before_listChangedAt (str): Pagination cursor field `listChangedAt` (use together with `before_id`)) (optional)
+            before_id (str): Pagination cursor field `id` (use together with `before_listChangedAt`)) (optional)
             search (str): Search term to filter cards) (optional)
             userIds (str): Comma-separated user IDs to filter by members or task assignees) (optional)
             labelIds (str): Comma-separated label IDs to filter by labels) (optional)
@@ -688,6 +688,12 @@ class PlankaEndpoints:
             Unauthorized: 401 
             NotFound: 404 
         """
+        # Monkey patch since brackets cannot be used in varaible names
+        if 'before_listChangedAt' in kwargs:
+            kwargs['before[listChangedAt]'] = kwargs.pop('before_listChangedAt') # type: ignore
+        if 'before_id' in kwargs:
+            kwargs['before[id]'] = kwargs.pop('before_id') # type: ignore
+            
         valid_params = ('before[listChangedAt]', 'before[id]', 'search', 'userIds', 'labelIds')
         passed_params = {k: v for k, v in kwargs.items() if k in valid_params if isinstance(v, str | int | float)}
         resp = self.client.get(f"api/lists/{listId}/cards", params=passed_params)

--- a/src/plankapy/v2/api/paths.py
+++ b/src/plankapy/v2/api/paths.py
@@ -1083,7 +1083,7 @@ class PlankaEndpoints:
             Forbidden: 403 
             NotFound: 404 
         """
-        resp = self.client.patch(f"api/cards/{cardId}/custom-field-values/customFieldGroupId:{customFieldGroupId}:customFieldId:${customFieldId}", json=kwargs)
+        resp = self.client.patch(f"api/cards/{cardId}/custom-field-values/customFieldGroupId:{customFieldGroupId}:customFieldId:{customFieldId}", json=kwargs)
         raise_planka_err(resp)
         return resp.json()
 
@@ -1106,7 +1106,7 @@ class PlankaEndpoints:
             Forbidden: 403 
             NotFound: 404 
         """
-        resp = self.client.delete(f"api/cards/{cardId}/custom-field-value/customFieldGroupId:{customFieldGroupId}:customFieldId:${customFieldId}")
+        resp = self.client.delete(f"api/cards/{cardId}/custom-field-value/customFieldGroupId:{customFieldGroupId}:customFieldId:{customFieldId}")
         raise_planka_err(resp)
         return resp.json()
 

--- a/src/plankapy/v2/api/paths.py
+++ b/src/plankapy/v2/api/paths.py
@@ -30,7 +30,8 @@ class PlankaEndpoints:
 
         Args:
             pendingToken (str): Pending token received from the authentication flow
-            signature (str): Terms signature hash based on user role
+            signature (str): Terms signature hash
+            initialLanguage (Literal['ar-YE', 'bg-BG', 'ca-ES', 'cs-CZ', 'da-DK', 'de-DE', 'el-GR', 'en-GB', 'en-US', 'es-ES', 'et-EE', 'fa-IR', 'fi-FI', 'fr-FR', 'hu-HU', 'id-ID', 'it-IT', 'ja-JP', 'ko-KR', 'nl-NL', 'pl-PL', 'pt-BR', 'pt-PT', 'ro-RO', 'ru-RU', 'sk-SK', 'sr-Cyrl-RS', 'sr-Latn-RS', 'sv-SE', 'tr-TR', 'uk-UA', 'uz-UZ', 'vi-VN', 'zh-CN', 'zh-TW'] | None): Preferred language for user interface and notifications (used only if user language is not set)
 
         Note:
             All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
@@ -540,6 +541,13 @@ class PlankaEndpoints:
         raise_planka_err(resp)
         return resp.json()
 
+    def getBootstrap(self) -> Response_getBootstrap:
+        """Retrieves the application bootstrap.
+        """
+        resp = self.client.get("api/bootstrap")
+        raise_planka_err(resp)
+        return resp.json()
+
     def createCardLabel(self, cardId: str, **kwargs: Unpack[Request_createCardLabel]) -> Response_createCardLabel:
         """Adds a label to a card. Requires board editor permissions.
 
@@ -664,9 +672,10 @@ class PlankaEndpoints:
 
         Args:
             listId (str): ID of the list to get cards from (must be an endless list))
-            before (str): Pagination cursor (JSON object with id and listChangedAt)) (optional)
+            before[listChangedAt] (str): Pagination cursor field `listChangedAt` (use together with `before[id]`)) (optional)
+            before[id] (str): Pagination cursor field `id` (use together with `before[listChangedAt]`)) (optional)
             search (str): Search term to filter cards) (optional)
-            userIds (str): Comma-separated user IDs to filter by members) (optional)
+            userIds (str): Comma-separated user IDs to filter by members or task assignees) (optional)
             labelIds (str): Comma-separated label IDs to filter by labels) (optional)
 
         Note:
@@ -679,7 +688,7 @@ class PlankaEndpoints:
             Unauthorized: 401 
             NotFound: 404 
         """
-        valid_params = ('before', 'search', 'userIds', 'labelIds')
+        valid_params = ('before[listChangedAt]', 'before[id]', 'search', 'userIds', 'labelIds')
         passed_params = {k: v for k, v in kwargs.items() if k in valid_params if isinstance(v, str | int | float)}
         resp = self.client.get(f"api/lists/{listId}/cards", params=passed_params)
         raise_planka_err(resp)
@@ -735,7 +744,7 @@ class PlankaEndpoints:
             listId (str): ID of the list to move the card to
             coverAttachmentId (str | None): ID of the attachment used as cover
             type (Literal['project', 'story']): Type of the card
-            position (int | None): Position of the card within the list
+            position (int | None): Position of the card within the list (required when moving card to new list)
             name (str): Name/title of the card
             description (str | None): Detailed description of the card
             dueDate (str | None): Due date for the card
@@ -764,8 +773,10 @@ class PlankaEndpoints:
 
         Args:
             id (str): ID of the card to duplicate)
-            position (int): Position for the duplicated card within the list
-            name (str): Name/title for the duplicated card
+            boardId (str): ID of the board to duplicate the card to
+            listId (str): ID of the list to duplicate the card to
+            position (int | None): Position for the duplicated card within the list
+            name (str | None): Name/title for the duplicated card
 
         Note:
             All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
@@ -777,6 +788,7 @@ class PlankaEndpoints:
             Unauthorized: 401 
             Forbidden: 403 
             NotFound: 404 
+            UnprocessableEntity: 422 
         """
         resp = self.client.post(f"api/cards/{id}/duplicate", json=kwargs)
         raise_planka_err(resp)
@@ -891,9 +903,42 @@ class PlankaEndpoints:
         return resp.json()
 
     def getConfig(self) -> Response_getConfig:
-        """Retrieves the application configuration.
+        """Retrieves the application configuration. Requires admin privileges.
         """
         resp = self.client.get("api/config")
+        raise_planka_err(resp)
+        return resp.json()
+
+    def updateConfig(self, **kwargs: Unpack[Request_updateConfig]) -> Response_updateConfig:
+        """Updates the application configuration. Requires admin privileges.
+
+        Args:
+            smtpHost (str | None): Hostname or IP address of the SMTP server
+            smtpPort (int | None): Port number of the SMTP server
+            smtpName (str | None): Client hostname used in the EHLO command for SMTP
+            smtpSecure (bool): Whether to use a secure connection for SMTP
+            smtpTlsRejectUnauthorized (bool): Whether to reject unauthorized or self-signed TLS certificates for SMTP connections
+            smtpUser (str | None): Username for authenticating with the SMTP server
+            smtpPassword (str | None): Password for authenticating with the SMTP server
+            smtpFrom (str | None): Default "from" used for outgoing SMTP emails
+        """
+        resp = self.client.patch("api/config", json=kwargs)
+        raise_planka_err(resp)
+        return resp.json()
+
+    def testSmtpConfig(self) -> Response_testSmtpConfig:
+        """Sends a test email to verify the SMTP is configured correctly. Only available when SMTP is configured via the UI.
+
+        Note:
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
+            If a matching PlankaError exists, it will be raised (see `api.errors`) 
+            Planka internal status codes and names are included here for disambiguation
+
+        Raises:
+            Unauthorized: 401 
+            Forbidden: 403 
+        """
+        resp = self.client.post("api/config/test-smtp")
         raise_planka_err(resp)
         return resp.json()
 
@@ -1609,7 +1654,7 @@ class PlankaEndpoints:
         """Creates a project. The current user automatically becomes a project manager.
 
         Args:
-            type (Literal['public', 'private']): Type of the project
+            type (Literal['private', 'shared']): Type of the project
             name (str): Name/title of the project
             description (str | None): Detailed description of the project
 
@@ -1878,12 +1923,11 @@ class PlankaEndpoints:
         raise_planka_err(resp)
         return resp.json()
 
-    def getTerms(self, type: Literal['general', 'extended'], **kwargs: Unpack[Request_getTerms]) -> Response_getTerms:
+    def getTerms(self, **kwargs: Unpack[Request_getTerms]) -> Response_getTerms:
         """Retrieves terms and conditions in the specified language.
 
         Args:
-            type (Literal['general', 'extended']): Type of terms to retrieve)
-            language (Literal['de-DE', 'en-US']): Language code for terms localization) (optional)
+            language (str): Language code for terms localization) (optional)
 
         Note:
             All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
@@ -1897,7 +1941,27 @@ class PlankaEndpoints:
         """
         valid_params = ('language',)
         passed_params = {k: v for k, v in kwargs.items() if k in valid_params if isinstance(v, str | int | float)}
-        resp = self.client.get(f"api/terms/{type}", params=passed_params)
+        resp = self.client.get("api/terms", params=passed_params)
+        raise_planka_err(resp)
+        return resp.json()
+
+    def createUserApiKey(self, id: str) -> Response_createUserApiKey:
+        """Generates a user's API key. The full API key is returned only once and cannot be retrieved again.
+
+        Args:
+            id (str): ID of the user to create API key for)
+
+        Note:
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
+            If a matching PlankaError exists, it will be raised (see `api.errors`) 
+            Planka internal status codes and names are included here for disambiguation
+
+        Raises:
+            ValidationError: 400 
+            Unauthorized: 401 
+            NotFound: 404 
+        """
+        resp = self.client.post(f"api/users/{id}/api-key")
         raise_planka_err(resp)
         return resp.json()
 
@@ -1912,7 +1976,7 @@ class PlankaEndpoints:
             username (str | None): Unique username for user identification
             phone (str | None): Contact phone number
             organization (str | None): Organization or company name
-            language (Literal['ar-YE', 'bg-BG', 'cs-CZ', 'da-DK', 'de-DE', 'el-GR', 'en-GB', 'en-US', 'es-ES', 'et-EE', 'fa-IR', 'fi-FI', 'fr-FR', 'hu-HU', 'id-ID', 'it-IT', 'ja-JP', 'ko-KR', 'nl-NL', 'pl-PL', 'pt-BR', 'pt-PT', 'ro-RO', 'ru-RU', 'sk-SK', 'sr-Cyrl-RS', 'sr-Latn-RS', 'sv-SE', 'tr-TR', 'uk-UA', 'uz-UZ', 'zh-CN', 'zh-TW'] | None): Preferred language for user interface and notifications
+            language (Literal['ar-YE', 'bg-BG', 'ca-ES', 'cs-CZ', 'da-DK', 'de-DE', 'el-GR', 'en-GB', 'en-US', 'es-ES', 'et-EE', 'fa-IR', 'fi-FI', 'fr-FR', 'hu-HU', 'id-ID', 'it-IT', 'ja-JP', 'ko-KR', 'nl-NL', 'pl-PL', 'pt-BR', 'pt-PT', 'ro-RO', 'ru-RU', 'sk-SK', 'sr-Cyrl-RS', 'sr-Latn-RS', 'sv-SE', 'tr-TR', 'uk-UA', 'uz-UZ', 'vi-VN', 'zh-CN', 'zh-TW'] | None): Preferred language for user interface and notifications (if null - will be set automatically on the first login)
             subscribeToOwnCards (bool): Whether the user subscribes to their own cards
             subscribeToCardWhenCommenting (bool): Whether the user subscribes to cards when commenting
             turnOffRecentCardHighlighting (bool): Whether recent card highlighting is disabled
@@ -2003,7 +2067,8 @@ class PlankaEndpoints:
             avatar (dict[str, Any] | None): Avatar of the user (only null value to remove avatar)
             phone (str | None): Contact phone number
             organization (str | None): Organization or company name
-            language (Literal['ar-YE', 'bg-BG', 'cs-CZ', 'da-DK', 'de-DE', 'el-GR', 'en-GB', 'en-US', 'es-ES', 'et-EE', 'fa-IR', 'fi-FI', 'fr-FR', 'hu-HU', 'id-ID', 'it-IT', 'ja-JP', 'ko-KR', 'nl-NL', 'pl-PL', 'pt-BR', 'pt-PT', 'ro-RO', 'ru-RU', 'sk-SK', 'sr-Cyrl-RS', 'sr-Latn-RS', 'sv-SE', 'tr-TR', 'uk-UA', 'uz-UZ', 'zh-CN', 'zh-TW'] | None): Preferred language for user interface and notifications
+            language (Literal['ar-YE', 'bg-BG', 'ca-ES', 'cs-CZ', 'da-DK', 'de-DE', 'el-GR', 'en-GB', 'en-US', 'es-ES', 'et-EE', 'fa-IR', 'fi-FI', 'fr-FR', 'hu-HU', 'id-ID', 'it-IT', 'ja-JP', 'ko-KR', 'nl-NL', 'pl-PL', 'pt-BR', 'pt-PT', 'ro-RO', 'ru-RU', 'sk-SK', 'sr-Cyrl-RS', 'sr-Latn-RS', 'sv-SE', 'tr-TR', 'uk-UA', 'uz-UZ', 'vi-VN', 'zh-CN', 'zh-TW']): Preferred language for user interface and notifications
+            apiKey (dict[str, Any] | None): API key of the user (only null value to remove API key)
             subscribeToOwnCards (bool): Whether the user subscribes to their own cards
             subscribeToCardWhenCommenting (bool): Whether the user subscribes to cards when commenting
             turnOffRecentCardHighlighting (bool): Whether recent card highlighting is disabled
@@ -2011,6 +2076,7 @@ class PlankaEndpoints:
             defaultEditorMode (Literal['wysiwyg', 'markup']): Default markdown editor mode
             defaultHomeView (Literal['gridProjects', 'groupedProjects']): Default view mode for the home page
             defaultProjectsOrder (Literal['byDefault', 'alphabetically', 'byCreationTime']): Default sort order for projects display
+            isSsoUser (bool): Whether the user is SSO user (only false value to unlink SSO, for admins)
             isDeactivated (bool): Whether the user account is deactivated and cannot log in (for admins)
 
         Note:

--- a/src/plankapy/v2/api/paths.py
+++ b/src/plankapy/v2/api/paths.py
@@ -540,7 +540,7 @@ class PlankaEndpoints:
         raise_planka_err(resp)
         return resp.json()
 
-    def getBootstrap(self) -> Bootstrap:
+    def getBootstrap(self) -> Response_getBootstrap:
         """Retrieves the application bootstrap.
         """
         resp = self.client.get("api/bootstrap")

--- a/src/plankapy/v2/api/schemas.py
+++ b/src/plankapy/v2/api/schemas.py
@@ -174,6 +174,8 @@ class Card(TypedDict):
     """When the card was created"""
     updatedAt: str
     """When the card was last updated"""
+    isSubscribed: NotRequired[bool]
+    """If the current user is subscribed to the card"""
 
 class CardLabel(TypedDict):
     id: str
@@ -386,6 +388,8 @@ class Project(TypedDict):
     """When the project was created"""
     updatedAt: str
     """When the project was last updated"""
+    isFavorite: NotRequired[bool]
+    """If the project is in the current user's favorites"""
 
 class ProjectManager(TypedDict):
     id: str
@@ -490,6 +494,8 @@ class User(TypedDict):
 class Webhook(TypedDict):
     id: str
     """Unique identifier for the webhook"""
+    boardId: NotRequired[str]
+    """ID of the board associated with the webhook"""
     name: str
     """Name/title of the webhook"""
     url: str

--- a/src/plankapy/v2/api/schemas.py
+++ b/src/plankapy/v2/api/schemas.py
@@ -29,6 +29,7 @@ __all__ = (
     "User",
     "Webhook",
     "Stopwatch",
+    "Bootstrap",
 )
 
 class Action(TypedDict):
@@ -136,6 +137,27 @@ class BoardMembership(TypedDict):
     """When the board membership was created"""
     updatedAt: str
     """When the board membership was last updated"""
+
+class Bootstrap(TypedDict):
+    oidc: OIDC
+    "OpenID Connect configuration (null if not configured)"
+    version: str
+    "Current version of the PLANKA application"
+    activeUsersLimit: NotRequired[int]
+    "Maximum number of active users allowed (conditionally added for admins if configured)"
+    customerPanelUrl: NotRequired[str]
+    "URL to the customer management panel (conditionally added for admins if configured)"
+    termsLanguages: NotRequired[list[str]]
+    "List of available language codes for terms localization"
+    
+class OIDC(TypedDict):
+    """OIDC response schema"""
+    authorizationUrl: str
+    "OIDC authorization URL for initiating authentication"
+    endSessionUrl: str | None
+    "OIDC end session URL for logout (null if not supported by provider)"
+    isEnforced: bool
+    "Whether OIDC authentication is enforced (users must use OIDC to login)"
 
 class Card(TypedDict):
     id: str

--- a/src/plankapy/v2/api/schemas.py
+++ b/src/plankapy/v2/api/schemas.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 from typing import TypedDict, NotRequired, Any, Literal
 
-from .events import WebhookEvent
+from .events import PlankaEvent
 
 __all__ = (
     "Action",
@@ -72,10 +72,10 @@ class BackgroundImage(TypedDict):
     """Unique identifier for the background image"""
     projectId: str
     """ID of the project the background image belongs to"""
-    sizeInBytes: str # Change to `size` after next release
+    size: str
     """File size of the background image in bytes"""
     url: str
-    """URL to access the full-size background image"""
+    """URL to the full-size background image"""
     thumbnailUrls: dict[str, Any]
     """URLs for different thumbnail sizes of the background image"""
     createdAt: str
@@ -214,12 +214,28 @@ class Comment(TypedDict):
     """When the comment was last updated"""
 
 class Config(TypedDict):
-    version: str
-    """Current version of the PLANKA application"""
-    activeUsersLimit: NotRequired[int]
-    """Maximum number of active users allowed (conditionally added for admins if configured)"""
-    oidc: dict[str, Any]
-    """OpenID Connect configuration (null if not configured)"""
+    id: str
+    """Unique identifier for the config (always set to '1')"""
+    smtpHost: NotRequired[str]
+    """Hostname or IP address of the SMTP server"""
+    smtpPort: NotRequired[int]
+    """Port number of the SMTP server"""
+    smtpName: NotRequired[str]
+    """Client hostname used in the EHLO command for SMTP"""
+    smtpSecure: NotRequired[bool]
+    """Whether to use a secure connection for SMTP"""
+    smtpTlsRejectUnauthorized: NotRequired[bool]
+    """Whether to reject unauthorized or self-signed TLS certificates for SMTP connections"""
+    smtpUser: NotRequired[str]
+    """Username for authenticating with the SMTP server"""
+    smtpPassword: NotRequired[str]
+    """Password for authenticating with the SMTP server"""
+    smtpFrom: NotRequired[str]
+    """Default "from" used for outgoing SMTP emails"""
+    createdAt: NotRequired[str]
+    """When the config was created"""
+    updatedAt: NotRequired[str]
+    """When the config was last updated"""
 
 class CustomField(TypedDict):
     id: str
@@ -440,8 +456,10 @@ class User(TypedDict):
     """Contact phone number"""
     organization: str
     """Organization or company name"""
-    language: NotRequired[Literal['ar-YE', 'bg-BG', 'cs-CZ', 'da-DK', 'de-DE', 'el-GR', 'en-GB', 'en-US', 'es-ES', 'et-EE', 'fa-IR', 'fi-FI', 'fr-FR', 'hu-HU', 'id-ID', 'it-IT', 'ja-JP', 'ko-KR', 'nl-NL', 'pl-PL', 'pt-BR', 'pt-PT', 'ro-RO', 'ru-RU', 'sk-SK', 'sr-Cyrl-RS', 'sr-Latn-RS', 'sv-SE', 'tr-TR', 'uk-UA', 'uz-UZ', 'zh-CN', 'zh-TW']]
+    language: NotRequired[Literal['ar-YE', 'bg-BG', 'ca-ES', 'cs-CZ', 'da-DK', 'de-DE', 'el-GR', 'en-GB', 'en-US', 'es-ES', 'et-EE', 'fa-IR', 'fi-FI', 'fr-FR', 'hu-HU', 'id-ID', 'it-IT', 'ja-JP', 'ko-KR', 'nl-NL', 'pl-PL', 'pt-BR', 'pt-PT', 'ro-RO', 'ru-RU', 'sk-SK', 'sr-Cyrl-RS', 'sr-Latn-RS', 'sv-SE', 'tr-TR', 'uk-UA', 'uz-UZ', 'vi-VN', 'zh-CN', 'zh-TW']]
     """Preferred language for user interface and notifications (personal field)"""
+    apiKeyPrefix: NotRequired[str]
+    """Prefix of the API key for display purposes (private field)"""
     subscribeToOwnCards: NotRequired[bool]
     """Whether the user subscribes to their own cards (personal field)"""
     subscribeToCardWhenCommenting: NotRequired[bool]
@@ -456,8 +474,6 @@ class User(TypedDict):
     """Default view mode for the home page (personal field)"""
     defaultProjectsOrder: NotRequired[Literal['byDefault', 'alphabetically', 'byCreationTime']]
     """Default sort order for projects display (personal field)"""
-    termsType: Literal['general', 'extended']
-    """Type of terms applicable to the user based on role"""
     isSsoUser: NotRequired[bool]
     """Whether the user is SSO user (private field)"""
     isDeactivated: bool
@@ -470,23 +486,19 @@ class User(TypedDict):
     """When the user was created"""
     updatedAt: str
     """When the user was last updated"""
-    apiKeyPrefix: str | None
-    """The prefix for the user's API key if one is active"""
 
 class Webhook(TypedDict):
     id: str
     """Unique identifier for the webhook"""
-    boardId: str
-    """The board that the webhook is associated with"""
     name: str
     """Name/title of the webhook"""
     url: str
     """URL endpoint for the webhook"""
     accessToken: str
     """Access token for webhook authentication"""
-    events: list[WebhookEvent]
+    events: list[PlankaEvent]
     """List of events that trigger the webhook"""
-    excludedEvents: list[WebhookEvent]
+    excludedEvents: list[PlankaEvent]
     """List of events excluded from the webhook"""
     createdAt: str
     """When the webhook was created"""

--- a/src/plankapy/v2/api/typ.py
+++ b/src/plankapy/v2/api/typ.py
@@ -649,7 +649,7 @@ class Included_getBoard(TypedDict):
     customFieldValues: list[CustomFieldValue]
 
 class Included_getBoard_all(Card):
-    isSubscribed: bool
+    isSubscribed: NotRequired[bool]
     """Whether the current user is subscribed to the card"""
 
 class Item_getBoard(Board):
@@ -659,28 +659,6 @@ class Item_getBoard(Board):
 class Response_updateBoard(TypedDict):
     """Board updated successfully"""
     item: Board
-
-class Response_getBootstrap(TypedDict):
-    """Bootstrap retrieved successfully"""
-    oidc: OIDC_conf
-    "OpenID Connect configuration (null if not configured)"
-    version: str
-    "Current version of the PLANKA application"
-    activeUsersLimit: NotRequired[int]
-    "Maximum number of active users allowed (conditionally added for admins if configured)"
-    customerPanelUrl: NotRequired[str]
-    "URL to the customer management panel (conditionally added for admins if configured)"
-    termsLanguages: NotRequired[str]
-    "List of available language codes for terms localization"
-    
-class OIDC_conf(TypedDict):
-    """OIDC response schema"""
-    authorizationUrl: str
-    "OIDC authorization URL for initiating authentication"
-    endSessionUrl: str | None
-    "OIDC end session URL for logout (null if not supported by provider)"
-    isEnforced: bool
-    "Whether OIDC authentication is enforced (users must use OIDC to login)"
   
 class Response_createCardLabel(TypedDict):
     """Label added to card successfully"""
@@ -719,7 +697,7 @@ class Included_getCards(TypedDict):
     customFieldValues: list[CustomFieldValue]
 
 class Items_getCards(Card):
-    isSubscribed: bool
+    isSubscribed: NotRequired[bool]
     """Whether the current user is subscribed to the card"""
 
 class Response_deleteCard(TypedDict):
@@ -743,7 +721,7 @@ class Included_getCard(TypedDict):
     customFieldValues: list[CustomFieldValue]
 
 class Item_getCard(Card):
-    isSubscribed: bool
+    isSubscribed: NotRequired[bool]
     """Whether the current user is subscribed to the card"""
 
 class Response_updateCard(TypedDict):
@@ -901,7 +879,7 @@ class Included_getList(TypedDict):
     customFieldValues: list[CustomFieldValue]
 
 class Included_getList_all(Card):
-    isSubscribed: bool
+    isSubscribed: NotRequired[bool]
     """Whether the current user is subscribed to the card"""
 
 class Response_updateList(TypedDict):
@@ -1001,7 +979,7 @@ class Included_getProjects(TypedDict):
     notificationServices: list[NotificationService]
 
 class Items_getProjects(Project):
-    isFavorite: bool
+    isFavorite: NotRequired[bool]
     """Whether the project is marked as favorite by the current user"""
 
 class Response_deleteProject(TypedDict):
@@ -1024,7 +1002,7 @@ class Included_getProject(TypedDict):
     notificationServices: list[NotificationService]
 
 class Item_getProject(Project):
-    isFavorite: bool
+    isFavorite: NotRequired[bool]
     """Whether the project is marked as favorite by the current user"""
 
 class Response_updateProject(TypedDict):

--- a/src/plankapy/v2/api/typ.py
+++ b/src/plankapy/v2/api/typ.py
@@ -1058,6 +1058,9 @@ class Response_createUserApiKey(TypedDict):
     item: User
     included: Included_createUserApiKey
 
+class Included_createUserApiKey(TypedDict):
+    apiKey: str
+
 class Response_createUser(TypedDict):
     """User created successfully"""
     item: User
@@ -1094,6 +1097,9 @@ class Response_updateUserPassword(TypedDict):
     """Password updated successfully"""
     item: User
     included: Included_updateUserPassword
+
+class Included_updateUserPassword(TypedDict):
+    accessToken: str
 
 class Response_updateUserUsername(TypedDict):
     """Username updated successfully"""

--- a/src/plankapy/v2/api/typ.py
+++ b/src/plankapy/v2/api/typ.py
@@ -147,12 +147,14 @@ class Request_createCard(TypedDict):
     """Stopwatch data for time tracking"""
 
 class Request_getCards(TypedDict):
-    before: NotRequired[str]
-    """Pagination cursor (JSON object with id and listChangedAt)"""
+    before_listChangedAt: NotRequired[str]
+    """Pagination cursor field `listChangedAt` (use together with `before_id`)"""
+    before_id: NotRequired[str]
+    """Pagination cursor field `id` (use together with `before_listChangedAt`)"""
     search: NotRequired[str]
     """Search term to filter cards"""
     userIds: NotRequired[str]
-    """Comma-separated user IDs to filter by members"""
+    """Comma-separated user IDs to filter by members or task assignees"""
     labelIds: NotRequired[str]
     """Comma-separated label IDs to filter by labels"""
 

--- a/src/plankapy/v2/api/typ.py
+++ b/src/plankapy/v2/api/typ.py
@@ -14,7 +14,9 @@ class Request_acceptTerms(TypedDict):
     pendingToken: str
     """Pending token received from the authentication flow"""
     signature: str
-    """Terms signature hash based on user role"""
+    """Terms signature hash"""
+    initialLanguage: NotRequired[Literal['ar-YE', 'bg-BG', 'ca-ES', 'cs-CZ', 'da-DK', 'de-DE', 'el-GR', 'en-GB', 'en-US', 'es-ES', 'et-EE', 'fa-IR', 'fi-FI', 'fr-FR', 'hu-HU', 'id-ID', 'it-IT', 'ja-JP', 'ko-KR', 'nl-NL', 'pl-PL', 'pt-BR', 'pt-PT', 'ro-RO', 'ru-RU', 'sk-SK', 'sr-Cyrl-RS', 'sr-Latn-RS', 'sv-SE', 'tr-TR', 'uk-UA', 'uz-UZ', 'vi-VN', 'zh-CN', 'zh-TW'] | None]
+    """Preferred language for user interface and notifications (used only if user language is not set)"""
 
 class Request_createAccessToken(TypedDict):
     emailOrUsername: str
@@ -168,7 +170,7 @@ class Request_updateCard(TypedDict):
     type: NotRequired[Literal['project', 'story']]
     """Type of the card"""
     position: NotRequired[int | None]
-    """Position of the card within the list"""
+    """Position of the card within the list (required when moving card to new list)"""
     name: NotRequired[str]
     """Name/title of the card"""
     description: NotRequired[str | None]
@@ -183,9 +185,13 @@ class Request_updateCard(TypedDict):
     """Whether the current user is subscribed to the card"""
 
 class Request_duplicateCard(TypedDict):
-    position: int
+    boardId: NotRequired[str]
+    """ID of the board to duplicate the card to"""
+    listId: NotRequired[str]
+    """ID of the list to duplicate the card to"""
+    position: NotRequired[int | None]
     """Position for the duplicated card within the list"""
-    name: str
+    name: NotRequired[str | None]
     """Name/title for the duplicated card"""
 
 class Request_createComment(TypedDict):
@@ -199,6 +205,24 @@ class Request_getComments(TypedDict):
 class Request_updateComments(TypedDict):
     text: NotRequired[str]
     """Content of the comment"""
+
+class Request_updateConfig(TypedDict):
+    smtpHost: NotRequired[str | None]
+    """Hostname or IP address of the SMTP server"""
+    smtpPort: NotRequired[int | None]
+    """Port number of the SMTP server"""
+    smtpName: NotRequired[str | None]
+    """Client hostname used in the EHLO command for SMTP"""
+    smtpSecure: NotRequired[bool]
+    """Whether to use a secure connection for SMTP"""
+    smtpTlsRejectUnauthorized: NotRequired[bool]
+    """Whether to reject unauthorized or self-signed TLS certificates for SMTP connections"""
+    smtpUser: NotRequired[str | None]
+    """Username for authenticating with the SMTP server"""
+    smtpPassword: NotRequired[str | None]
+    """Password for authenticating with the SMTP server"""
+    smtpFrom: NotRequired[str | None]
+    """Default "from" used for outgoing SMTP emails"""
 
 class Request_createBoardCustomFieldGroup(TypedDict):
     baseCustomFieldGroupId: NotRequired[str]
@@ -323,7 +347,7 @@ class Request_createProjectManager(TypedDict):
     """ID of the user who is assigned as project manager"""
 
 class Request_createProject(TypedDict):
-    type: Literal['shared', 'private']
+    type: Literal['private', 'shared']
     """Type of the project"""
     name: str
     """Name/title of the project"""
@@ -409,8 +433,8 @@ class Request_createUser(TypedDict):
     """Contact phone number"""
     organization: NotRequired[str | None]
     """Organization or company name"""
-    language: NotRequired[Literal['ar-YE', 'bg-BG', 'cs-CZ', 'da-DK', 'de-DE', 'el-GR', 'en-GB', 'en-US', 'es-ES', 'et-EE', 'fa-IR', 'fi-FI', 'fr-FR', 'hu-HU', 'id-ID', 'it-IT', 'ja-JP', 'ko-KR', 'nl-NL', 'pl-PL', 'pt-BR', 'pt-PT', 'ro-RO', 'ru-RU', 'sk-SK', 'sr-Cyrl-RS', 'sr-Latn-RS', 'sv-SE', 'tr-TR', 'uk-UA', 'uz-UZ', 'zh-CN', 'zh-TW'] | None]
-    """Preferred language for user interface and notifications"""
+    language: NotRequired[Literal['ar-YE', 'bg-BG', 'ca-ES', 'cs-CZ', 'da-DK', 'de-DE', 'el-GR', 'en-GB', 'en-US', 'es-ES', 'et-EE', 'fa-IR', 'fi-FI', 'fr-FR', 'hu-HU', 'id-ID', 'it-IT', 'ja-JP', 'ko-KR', 'nl-NL', 'pl-PL', 'pt-BR', 'pt-PT', 'ro-RO', 'ru-RU', 'sk-SK', 'sr-Cyrl-RS', 'sr-Latn-RS', 'sv-SE', 'tr-TR', 'uk-UA', 'uz-UZ', 'vi-VN', 'zh-CN', 'zh-TW'] | None]
+    """Preferred language for user interface and notifications (if null - will be set automatically on the first login)"""
     subscribeToOwnCards: NotRequired[bool]
     """Whether the user subscribes to their own cards"""
     subscribeToCardWhenCommenting: NotRequired[bool]
@@ -433,8 +457,10 @@ class Request_updateUser(TypedDict):
     """Contact phone number"""
     organization: NotRequired[str | None]
     """Organization or company name"""
-    language: NotRequired[Literal['ar-YE', 'bg-BG', 'cs-CZ', 'da-DK', 'de-DE', 'el-GR', 'en-GB', 'en-US', 'es-ES', 'et-EE', 'fa-IR', 'fi-FI', 'fr-FR', 'hu-HU', 'id-ID', 'it-IT', 'ja-JP', 'ko-KR', 'nl-NL', 'pl-PL', 'pt-BR', 'pt-PT', 'ro-RO', 'ru-RU', 'sk-SK', 'sr-Cyrl-RS', 'sr-Latn-RS', 'sv-SE', 'tr-TR', 'uk-UA', 'uz-UZ', 'zh-CN', 'zh-TW'] | None]
+    language: NotRequired[Literal['ar-YE', 'bg-BG', 'ca-ES', 'cs-CZ', 'da-DK', 'de-DE', 'el-GR', 'en-GB', 'en-US', 'es-ES', 'et-EE', 'fa-IR', 'fi-FI', 'fr-FR', 'hu-HU', 'id-ID', 'it-IT', 'ja-JP', 'ko-KR', 'nl-NL', 'pl-PL', 'pt-BR', 'pt-PT', 'ro-RO', 'ru-RU', 'sk-SK', 'sr-Cyrl-RS', 'sr-Latn-RS', 'sv-SE', 'tr-TR', 'uk-UA', 'uz-UZ', 'vi-VN', 'zh-CN', 'zh-TW']]
     """Preferred language for user interface and notifications"""
+    apiKey: NotRequired[dict[str, Any] | None]
+    """API key of the user (only null value to remove API key)"""
     subscribeToOwnCards: NotRequired[bool]
     """Whether the user subscribes to their own cards"""
     subscribeToCardWhenCommenting: NotRequired[bool]
@@ -449,6 +475,8 @@ class Request_updateUser(TypedDict):
     """Default view mode for the home page"""
     defaultProjectsOrder: NotRequired[Literal['byDefault', 'alphabetically', 'byCreationTime']]
     """Default sort order for projects display"""
+    isSsoUser: NotRequired[bool]
+    """Whether the user is SSO user (only false value to unlink SSO, for admins)"""
     isDeactivated: NotRequired[bool]
     """Whether the user account is deactivated and cannot log in (for admins)"""
 
@@ -632,6 +660,9 @@ class Response_updateBoard(TypedDict):
     """Board updated successfully"""
     item: Board
 
+class Response_getBootstrap(TypedDict):
+    """Bootstrap retrieved successfully"""
+
 class Response_createCardLabel(TypedDict):
     """Label added to card successfully"""
     item: CardLabel
@@ -745,6 +776,14 @@ class Response_updateComments(TypedDict):
 
 class Response_getConfig(TypedDict):
     """Configuration retrieved successfully"""
+    item: Config
+
+class Response_updateConfig(TypedDict):
+    """Configuration updated successfully"""
+    item: Config
+
+class Response_testSmtpConfig(TypedDict):
+    """Test email sent successfully"""
     item: Config
 
 class Response_createBoardCustomFieldGroup(TypedDict):
@@ -1010,17 +1049,21 @@ class Response_getTerms(TypedDict):
     item: Item_getTerms
 
 class Item_getTerms(TypedDict):
-    type: Literal['general', 'extended']
-    language: Literal['de-DE', 'en-US']
+    language: str
     content: str
     signature: str
+
+class Response_createUserApiKey(TypedDict):
+    """API key created successfully"""
+    item: User
+    included: Included_createUserApiKey
 
 class Response_createUser(TypedDict):
     """User created successfully"""
     item: User
 
 class Response_getUsers(TypedDict):
-    """List of users retrieved successfully"""
+    """Users retrieved successfully"""
     items: list[User]
 
 class Response_deleteUser(TypedDict):
@@ -1052,10 +1095,6 @@ class Response_updateUserPassword(TypedDict):
     item: User
     included: Included_updateUserPassword
 
-class Included_updateUserPassword(TypedDict):
-    accessTokens: list[str]
-    """New acces tokens (when updating own password)"""
-
 class Response_updateUserUsername(TypedDict):
     """Username updated successfully"""
     item: User
@@ -1065,7 +1104,7 @@ class Response_createWebhook(TypedDict):
     item: Webhook
 
 class Response_getWebhooks(TypedDict):
-    """List of webhooks retrieved successfully"""
+    """Webhooks retrieved successfully"""
     items: list[Webhook]
 
 class Response_deleteWebhook(TypedDict):

--- a/src/plankapy/v2/api/typ.py
+++ b/src/plankapy/v2/api/typ.py
@@ -662,7 +662,26 @@ class Response_updateBoard(TypedDict):
 
 class Response_getBootstrap(TypedDict):
     """Bootstrap retrieved successfully"""
-
+    oidc: OIDC_conf
+    "OpenID Connect configuration (null if not configured)"
+    version: str
+    "Current version of the PLANKA application"
+    activeUsersLimit: NotRequired[int]
+    "Maximum number of active users allowed (conditionally added for admins if configured)"
+    customerPanelUrl: NotRequired[str]
+    "URL to the customer management panel (conditionally added for admins if configured)"
+    termsLanguages: NotRequired[str]
+    "List of available language codes for terms localization"
+    
+class OIDC_conf(TypedDict):
+    """OIDC response schema"""
+    authorizationUrl: str
+    "OIDC authorization URL for initiating authentication"
+    endSessionUrl: str | None
+    "OIDC end session URL for logout (null if not supported by provider)"
+    isEnforced: bool
+    "Whether OIDC authentication is enforced (users must use OIDC to login)"
+  
 class Response_createCardLabel(TypedDict):
     """Label added to card successfully"""
     item: CardLabel

--- a/src/plankapy/v2/api/typ.py
+++ b/src/plankapy/v2/api/typ.py
@@ -659,7 +659,11 @@ class Item_getBoard(Board):
 class Response_updateBoard(TypedDict):
     """Board updated successfully"""
     item: Board
-  
+
+class Response_getBootstrap(TypedDict):
+    """Bootstrap retrieved successfully"""
+    item: Bootstrap
+
 class Response_createCardLabel(TypedDict):
     """Label added to card successfully"""
     item: CardLabel

--- a/src/plankapy/v2/interface.py
+++ b/src/plankapy/v2/interface.py
@@ -218,7 +218,7 @@ class Planka:
     @property
     def bootstrap(self):
         """Get the application bootstrap"""
-        return Config(self.endpoints.getBootstrap(), self)
+        return Config(self.endpoints.getBootstrap()['item'], self)
 
     @property
     @model_list

--- a/src/plankapy/v2/interface.py
+++ b/src/plankapy/v2/interface.py
@@ -218,7 +218,7 @@ class Planka:
     @property
     def bootstrap(self):
         """Get the application bootstrap"""
-        return self.endpoints.getBootstrap()
+        return Config(self.endpoints.getBootstrap(), self)
 
     @property
     @model_list
@@ -234,13 +234,13 @@ class Planka:
 
     @cached_property
     def config(self) -> Config:
-        """Get the configuration info for the current Planka server"""
-        return Config(self.endpoints.getConfig()['item'], self)
+        """(*deprecated: Use `Planka.bootstrap` instead*) Get the configuration info for the current Planka server"""
+        return self.bootstrap
     
     @property
     def smtp_config(self): 
         """Get the server SMTP config (this also tests the current config)"""
-        return self.endpoints.testSmtpConfig()
+        return self.endpoints.testSmtpConfig()['item']
 
     def update_smtp_config(self, **opts: Unpack[typ.Request_updateConfig]):
         """Update the server SMTP config (all args are optional and only passed args will be updated)

--- a/src/plankapy/v2/interface.py
+++ b/src/plankapy/v2/interface.py
@@ -46,16 +46,18 @@ from __future__ import annotations
 from functools import cached_property
 from collections.abc import Sequence
 from datetime import timezone
+from typing import Unpack
 
 from httpx import Client, HTTPStatusError, URL
 
 from .api import (
     PlankaEndpoints, 
     events,
+    typ,
 )
 from .models import *
 from .models._helpers import model_list
-from .models._literals import Language, TermsType, UserRole, ProjectType
+from .models._literals import Language, UserRole, ProjectType
 
 # Allow Users to set `PLANKA_LANG` environment variable with their language
 # Default to en-US if not set
@@ -229,6 +231,26 @@ class Planka:
     def config(self) -> Config:
         """Get the configuration info for the current Planka server"""
         return Config(self.endpoints.getConfig()['item'], self)
+    
+    @property
+    def smtp_config(self): 
+        """Get the server SMTP config (this also tests the curent config)"""
+        return self.endpoints.testSmtpConfig()
+
+    def update_smtp_config(self, **opts: Unpack[typ.Request_updateConfig]):
+        """Update the server SMTP config (all args are optional and only passed args will be updated)
+        
+        Args:
+            smtpHost: Hostname or IP address of the SMTP server
+            smtpPort: Port number of the SMTP server
+            smtpName: Client hostname used in the EHLO command for SMTP
+            smtpSecure: Whether to use a secure connection for SMTP
+            smtpTlsRejectUnauthorized: Whether to reject unauthorized or self-signed TLS certificates for SMTP connections
+            smtpUser: Username for authenticating with the SMTP server
+            smtpPassword: Password for authenticating with the SMTP server
+            smtpFrom: Default "from" used for outgoing SMTP emails
+        """
+        self.endpoints.updateConfig(**opts)
 
     @property
     @model_list
@@ -372,6 +394,4 @@ class Planka:
             args['accessToken'] = access_token
         return Webhook(self.endpoints.createWebhook(**args)['item'], self)
         
-    def test_smtp(self):
-        """Test the SMTP config and return the current SMTP configuration """
-        return self.endpoints.testSmtpConfig()
+        

--- a/src/plankapy/v2/interface.py
+++ b/src/plankapy/v2/interface.py
@@ -179,8 +179,7 @@ class Planka:
             terms_lang: If accepting terms, request them in this language
             
         Note:
-            After accepting the terms, please get an API key from the Planka server. If you need to accept extended terms, please 
-            set the `terms` flag to the terms you are accepting. These terms will be printed to `stdout` during the flow.
+            After logging in for the first time, please get an API key from the Planka server.
         """
         # API Key
         if api_key:

--- a/src/plankapy/v2/interface.py
+++ b/src/plankapy/v2/interface.py
@@ -372,3 +372,6 @@ class Planka:
             args['accessToken'] = access_token
         return Webhook(self.endpoints.createWebhook(**args)['item'], self)
         
+    def test_smtp(self):
+        """Test the SMTP config and return the current SMTP configuration """
+        return self.endpoints.testSmtpConfig()

--- a/src/plankapy/v2/interface.py
+++ b/src/plankapy/v2/interface.py
@@ -239,7 +239,7 @@ class Planka:
     
     @property
     def smtp_config(self): 
-        """Get the server SMTP config (this also tests the curent config)"""
+        """Get the server SMTP config (this also tests the current config)"""
         return self.endpoints.testSmtpConfig()
 
     def update_smtp_config(self, **opts: Unpack[typ.Request_updateConfig]):

--- a/src/plankapy/v2/interface.py
+++ b/src/plankapy/v2/interface.py
@@ -151,28 +151,31 @@ class Planka:
         self.current_role: UserRole | None = None
         self.current_id : str | None = None
     
-    def accept_terms(self, pending_token: str, terms_type: TermsType='general', lang: Language='en-US'):
+    def accept_terms(self, pending_token: str, lang: Language | None = None):
         """If the User has never logged on, or is required to accept new terms, allow them to do so"""
-        terms = self.endpoints.getTerms(type=terms_type, language=lang)['item']
+        if lang:
+            terms = self.endpoints.getTerms(language=lang)['item']
+        else:
+            terms = self.endpoints.getTerms()['item']
         print(terms['content'])
         sig = terms['signature']
         self.endpoints.acceptTerms(pendingToken=pending_token, signature=sig)
     
     def login(self, 
               *, 
-              username: str|None=None, 
-              password: str|None=None, 
-              api_key: str|None=None, 
-              accept_terms: TermsType | None=None,
-              terms_lang: Language='en-US') -> None:
+              username: str | None = None, 
+              password: str | None = None, 
+              api_key: str | None = None, 
+              accept_terms: bool | None = None,
+              terms_lang: Language | None = None) -> None:
         
         """Authenticate with the planka instance
         
         Args:
-            username (str | None): User username/email 
-            password (str | None): User password
-            api_key (str | None): User API Key
-            accept_terms (TermsType | None): If you user has not accepted the terms, run the term acceptance flow
+            username: User username/email 
+            password: User password
+            api_key: User API Key
+            accept_terms: Set to `True` to accept terms on first login
             terms_lang: If accepting terms, request them in this language
             
         Note:
@@ -190,9 +193,9 @@ class Planka:
                 token = self.endpoints.createAccessToken(emailOrUsername=username, password=password, withHttpOnlyToken=True)['item']
                 self.client.headers['Authorization'] = f'Bearer {token}'
             except HTTPStatusError as e:
-                if accept_terms is None:
-                    raise PermissionError(f'Please logon again with `accept_terms` set to the terms you must accept')
-                self.accept_terms(e.response.json()['pendingToken'], terms_type=accept_terms, lang=terms_lang)
+                if not accept_terms:
+                    raise PermissionError(f'Please logon again with `accept_terms` set to `True` to login the first time')
+                self.accept_terms(e.response.json()['pendingToken'], lang=terms_lang)
                 self.login(username=username, password=password)
         
         # Invalid Creds

--- a/src/plankapy/v2/interface.py
+++ b/src/plankapy/v2/interface.py
@@ -216,6 +216,11 @@ class Planka:
         return User(self.endpoints.getUser('me')['item'], self)
 
     @property
+    def bootstrap(self):
+        """Get the application bootstrap"""
+        return self.endpoints.getBootstrap()
+
+    @property
     @model_list
     def notifications(self) -> list[Notification]:
         """Get all notifications for the current User"""

--- a/src/plankapy/v2/models/_base.py
+++ b/src/plankapy/v2/models/_base.py
@@ -5,8 +5,8 @@ __all__ = ("PlankaModel", )
 import json
 import copy
 
-from typing import Any, Self, Callable
-from collections.abc import Mapping
+from typing import Any, Self
+from collections.abc import Mapping, Callable
 
 TYPE_CHECKING = False
 if TYPE_CHECKING:

--- a/src/plankapy/v2/models/_literals.py
+++ b/src/plankapy/v2/models/_literals.py
@@ -101,7 +101,7 @@ BackgroundGradient = Literal[
 BackgroundGradients = get_args(BackgroundGradient)
 
 Language = Literal[
-    'ar-YE', 'bg-BG', 'cs-CZ', 'da-DK', 'de-DE', 'el-GR', 'en-GB', 'en-US', 
+    'ar-YE', 'bg-BG', 'ca-ES', 'cs-CZ', 'da-DK', 'de-DE', 'el-GR', 'en-GB', 'en-US', 
     'es-ES', 'et-EE', 'fa-IR', 'fi-FI', 'fr-FR', 'hu-HU', 'id-ID', 'it-IT', 
     'ja-JP', 'ko-KR', 'nl-NL', 'pl-PL', 'pt-BR', 'pt-PT', 'ro-RO', 'ru-RU', 
     'sk-SK', 'sr-Cyrl-RS', 'sr-Latn-RS', 'sv-SE', 'tr-TR', 'uk-UA', 'uz-UZ', 

--- a/src/plankapy/v2/models/_literals.py
+++ b/src/plankapy/v2/models/_literals.py
@@ -105,7 +105,7 @@ Language = Literal[
     'es-ES', 'et-EE', 'fa-IR', 'fi-FI', 'fr-FR', 'hu-HU', 'id-ID', 'it-IT', 
     'ja-JP', 'ko-KR', 'nl-NL', 'pl-PL', 'pt-BR', 'pt-PT', 'ro-RO', 'ru-RU', 
     'sk-SK', 'sr-Cyrl-RS', 'sr-Latn-RS', 'sv-SE', 'tr-TR', 'uk-UA', 'uz-UZ', 
-    'zh-CN', 'zh-TW',
+    'vi-VN', 'zh-CN', 'zh-TW',
 ]
 Languages: tuple[Language, ...] = get_args(Language)
 

--- a/src/plankapy/v2/models/base_custom_field_group.py
+++ b/src/plankapy/v2/models/base_custom_field_group.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import Sequence
+from collections.abc import Sequence
 
 __all__ = ('BaseCustomFieldGroup', )
 

--- a/src/plankapy/v2/models/board.py
+++ b/src/plankapy/v2/models/board.py
@@ -54,13 +54,13 @@ class Board(PlankaModel[schemas.Board]):
     @model_list
     def trashed_cards(self) -> list[Card]:
         """Get all Cards in the Board trash list"""
-        return [Card(c, self.session) for c in self.endpoints.getCards(self.trash_list.id)['items']]
+        return self.trash_list.cards
     
     @property
     @model_list
     def archived_cards(self) -> list[Card]:
         """Get all Cards in the Board archive list"""
-        return [Card(c, self.session) for c in self.endpoints.getCards(self.archive_list.id)['items']]
+        return self.archive_list.cards
 
     @property
     @model_list

--- a/src/plankapy/v2/models/board.py
+++ b/src/plankapy/v2/models/board.py
@@ -66,7 +66,7 @@ class Board(PlankaModel[schemas.Board]):
     @model_list
     def subscribed_cards(self) -> list[Card]:
         """Get all Cards on the Board that the current User is subscribed to"""
-        return [Card(sc, self.session) for sc in self._included['cards'] if sc['isSubscribed']]
+        return [Card(sc, self.session) for sc in self._included['cards'] if sc.get('isSubscribed', False)]
     
     @property
     @model_list

--- a/src/plankapy/v2/models/card.py
+++ b/src/plankapy/v2/models/card.py
@@ -121,7 +121,7 @@ class Card(PlankaModel[schemas.Card]):
     @property
     def subscribed(self) -> bool:
         """If the current user is subscribed to the Card"""
-        return self.endpoints.getCard(self.id)['item']['isSubscribed']
+        return self.endpoints.getCard(self.id)['item'].get('isSubscribed', False)
     @subscribed.setter
     def subscribed(self, subscribed: bool) -> None:
         """Set subscription status on the Card for the current User"""

--- a/src/plankapy/v2/models/card.py
+++ b/src/plankapy/v2/models/card.py
@@ -351,19 +351,25 @@ class Card(PlankaModel[schemas.Card]):
         )
         return self
 
-    def duplicate(self, position: Position = 'top', *, name: str|None=None) -> Card:
+    def duplicate(self, position: Position = 'top', *, name: str | None = None, board: Board | None, lst: List | None) -> Card:
         """Duplicate the card in the current List
         
         Args:
             position (Position): The position to place the new Card in (default: `top`)
             name (str|None): An optional name to give the new Card (default `{name} (copy)`)
+            board: THe Board to duplicate the card to
+            lst: The List to duplicate the card to (if Board is unset, this List's Board will be used)
         """
         position = get_position(self.list.cards, position)
+        lst = lst or self.list
+        board = board or lst.board
         return Card(
             self.endpoints.duplicateCard(
                 self.id, 
                 position=position, 
-                name=name or f'{self.name} (copy)'
+                name=name or f'{self.name} (copy)',
+                boardId=board.id,
+                listId=lst.id,
             )['item'], 
             self.session
         )

--- a/src/plankapy/v2/models/config.py
+++ b/src/plankapy/v2/models/config.py
@@ -5,21 +5,17 @@ __all__ = ('Config', )
 from ._base import PlankaModel
 from ..api import schemas, events
 
-TYPE_CHECKING = False
-if TYPE_CHECKING:
-    from typing import Any
-    #from models import *
 
-
-class Config(PlankaModel[schemas.Config]):
+# NOTE: schemas.Config is now used for SMTP Config, App Config is now Bootstrap
+class Config(PlankaModel[schemas.Bootstrap]):
     """Python interface for Planka Config"""
     
     __events__ = events.ConfigEvents
 
     @property
-    def version(self) -> str:
+    def version(self) -> str | None:
         """Current version of the PLANKA application"""
-        return self.schema['version']
+        return self.schema.get('version')
     
     @property
     def activeUsersLimit(self) -> int | None:
@@ -27,6 +23,16 @@ class Config(PlankaModel[schemas.Config]):
         return self.schema.get('activeUsersLimit')
 
     @property
-    def oidc(self) -> dict[str, Any] | None:
+    def termsLanguages(self) -> list[str] | None:
+        """List of available languages for ToS"""
+        return self.schema.get('termsLanguages')
+
+    @property
+    def customerPanelUrl(self) -> str | None:
+        """URL to the customer management panel"""
+        return self.schema.get('customerPanelUrl')
+
+    @property
+    def oidc(self) -> schemas.OIDC | None:
         """OpenID Connect configuration (null if not configured)"""
         return self.schema.get('oidc')

--- a/src/plankapy/v2/models/list_.py
+++ b/src/plankapy/v2/models/list_.py
@@ -299,12 +299,10 @@ class List(PlankaModel[schemas.List]):
             if isinstance(labels, Label):
                 labels = [labels]
             kwargs['labelIds '] = ','.join(l.id for l in labels)
-        if card_before or changed_before:
-            kwargs['before'] = {}
         if card_before:
-            kwargs['before']['id'] = card_before.id
+            kwargs['before_id'] = card_before.id
         if changed_before:
-            kwargs['before']['listChangedAt'] = dttoiso(changed_before, default_timezone=self.session.timezone)
+            kwargs['before_listChangedAt'] = dttoiso(changed_before, default_timezone=self.session.timezone)
             
         return [
             Card(c, self.session) 

--- a/src/plankapy/v2/models/project.py
+++ b/src/plankapy/v2/models/project.py
@@ -81,7 +81,7 @@ class Project(PlankaModel[schemas.Project]):
     @property
     def favorite(self) -> bool:
         """Whether the project is in the current User's favorites"""
-        return self.endpoints.getProject(self.id)['item']['isFavorite']
+        return self.endpoints.getProject(self.id)['item'].get('isFavorite', False)
     @favorite.setter
     def favorite(self, is_favorite: bool) -> None:
         """Set/Unset the Project in the current User's favorites"""

--- a/src/plankapy/v2/models/user.py
+++ b/src/plankapy/v2/models/user.py
@@ -184,9 +184,9 @@ class User(PlankaModel[schemas.User]):
         self.update(defaultProjectsOrder=default_projects_order)
     
     @property
-    def terms_type(self) -> TermsType:
+    def terms_type(self) -> TermsType | None:
         """Type of terms applicable to the user based on role"""
-        return self.schema['termsType']
+        return self.schema.get('termsType')
     
     @property
     def is_sso_user(self) -> bool:
@@ -435,4 +435,25 @@ class User(PlankaModel[schemas.User]):
         if notification_service in self.notification_services:
             notification_service.delete()
     
+    def create_api_key(self, overwrite: bool = False) -> str | None:
+        """Generate an API key for the user (must be admin or logged in user)
+        
+        Args:
+            overwrite: If the user already has an API Key, this will overwrite it with a new one and return the new key
+            
+        Returns:
+            A new API Key for the user (This is only sent once! so make sure to save it somewhere)
+            
+        Raises:
+            PermissionError if the user already has a key and `overwrite` is unset
+        """
+        if self.schema.get('apiKeyPrefix'):
+            if overwrite:
+                self.update(apiKey=None)
+            else:
+                raise PermissionError('User already has an API Key, run again with `overwrite` enabled to create a new one')
+        else:
+            return self.endpoints.createUserApiKey(self.id)['included']['apiKey']
+    
 from .notification_service import NotificationService
+from . import Card, Board

--- a/src/plankapy/v2/models/user.py
+++ b/src/plankapy/v2/models/user.py
@@ -13,7 +13,7 @@ from ..api import schemas, paths, events
 
 TYPE_CHECKING = False
 if TYPE_CHECKING:
-    from typing import Any, Unpack
+    from typing import Any, Unpack, Literal
     #from models import *
     from ._literals import (
         UserRole, 
@@ -190,8 +190,11 @@ class User(PlankaModel[schemas.User]):
     
     @property
     def is_sso_user(self) -> bool:
-        """Whether the user is SSO user (private field)"""
+        """Whether the user is SSO user (private field, can be unlinked by admins)"""
         return self.schema.get('isSsoUser', False)
+    @is_sso_user.setter
+    def is_sso_user(self, is_sso_user: Literal[False]) -> None:
+        self.update(isSsoUser=is_sso_user)
     
     @property
     def is_deactivated(self) -> bool:

--- a/src/plankapy/v2/models/user.py
+++ b/src/plankapy/v2/models/user.py
@@ -459,4 +459,5 @@ class User(PlankaModel[schemas.User]):
             return self.endpoints.createUserApiKey(self.id)['included']['apiKey']
     
 from .notification_service import NotificationService
-from . import Card, Board
+from .card import Card
+from .board import Board

--- a/src/plankapy/v2/models/webhook.py
+++ b/src/plankapy/v2/models/webhook.py
@@ -36,12 +36,12 @@ class Webhook(PlankaModel[schemas.Webhook]):
         return self.schema['accessToken']
     
     @property
-    def events(self) -> list[_events.WebhookEvent]:
+    def events(self) -> list[_events.PlankaEvent]:
         """List of events that trigger the Webhook"""
         return self.schema['events']
     
     @property
-    def excluded_events(self) -> list[_events.WebhookEvent]:
+    def excluded_events(self) -> list[_events.PlankaEvent]:
         """List of events excluded from the Webhook"""
         return self.schema['excludedEvents']
     

--- a/src/plankapy/v2/utils.py
+++ b/src/plankapy/v2/utils.py
@@ -113,8 +113,12 @@ class PlankaSnapshot(TypedDict):
     """Notificaiton Service Schemas"""
     actions: list[schemas.Action]
     """Action Schemas"""
-    config: schemas.Config
+    config: schemas.Bootstrap
     """Config Schema"""
+    bootstrap: schemas.Bootstrap
+    """New name for Config"""
+    smtp_config: schemas.Config
+    """SMTP Configuration"""
 
 def _get_schema[M: PlankaModel[Any]](models: list[M]):
     return [m.schema for m in models]
@@ -179,7 +183,9 @@ def snapshot(planka: Planka) -> PlankaSnapshot:
         'labels': _get_schema(labels),
         'notification_services': _get_schema(notification_services),
         'actions': _get_schema(actions),
-        'config': config.schema
+        'config': config.schema,
+        'bootstrap': config.schema,
+        'smtp_config': planka.smtp_config
     }
     return snap
 


### PR DESCRIPTION
A new API spec has been released. This PR seeks to update the `api` module with the new/updated endpoints and patch any model interfaces that have been effected.

 This PR body will be updated with any modified methods

- `Card`
    - `duplicate`: Now supports setting a board and list
      - Note: Default behavior is still to duplicate at top of current list
    - `create_api_key`
      - New method for creating a new API key if the user does not already have one
        - Note: Admins can do this for any user, other can only do this for themselves
    - `is_sso_user`: Allows unsetting by setting to `False`

- `Planka`
  - `smtp_config`: property
    - Property to access current SMTP configuration
  - `update_smtp_config`
    - Add method to allow SMTP testing/configuration getting
  - `login`/`accept_terms`
    - Change behavior of `accept_terms`, truthy values will accept terms

`TODO`:
- [x] Add interface for `updateConfig` 
- [x] Add interface for `testSmtpConfig`
- [x] Add interface for `createUserApiKey`
- [x] Add interface for `getBootstrap`
- [x] Update `getCards` interface
- [x] Update `duplicateCard` interface
- [x] Update `acceptTerms` interface to use `initialLanguage` param
- [x] Update `getTerms` interface to not pass `type` param
- [x] Update `updateUser` interface with `isSsoUser` and `apiKey` params