### PR TITLE
Reformat v2 using Ruff rules

### DIFF
--- a/dev/build_api.py
+++ b/dev/build_api.py
@@ -154,7 +154,7 @@ def yield_paths() -> Generator[str]:
                     if prop["type"] == "array":
                         if '$ref' in prop['items']:
                             t = prop['items']['$ref'].split('/')[-1]
-                            resps[f'Included_{oid}'].append(f'{p_name}: list[{t}]')
+                            resps[f'Included_{oid}'].append(f'{p_name}: list[sch.{t}]')
                         elif 'allOf' in prop['items']:
                             base_type = prop['items']['allOf'][0]['$ref'].split('/')[-1]
                             additional_keys = [
@@ -165,13 +165,25 @@ def yield_paths() -> Generator[str]:
                                 for obj in prop['items']['allOf'][1:]
                                 for prop_name, prop in obj['properties'].items()
                             ]
-                            resps[f'Included_{oid}_all({base_type})'] = additional_keys
-                            resps[f'Included_{oid}'].append(f'{p_name}: list[Included_{oid}_all]{' | None' if prop.get('nullable') else ''}\n\t"""{prop["description"]}"""')
+                            resps[f'Included_{oid}_all(sch.{base_type})'] = additional_keys
+                            resps[f'Included_{oid}'].append(
+                                f'{p_name}: list[Included_{oid}_all]'
+                                f'{' | None' if prop.get('nullable') else ''}'
+                                f'\n\t"""{prop["description"]}"""'
+                            )
                         else:
                             if prop['type'] == 'array':
-                                resps[f'Included_{oid}'].append(f'{p_name}: list[{TYPES.get(prop['items']['type'], 'Any')}]{' | None' if prop.get('nullable') else ''}\n\t"""{prop['description']}"""')
+                                resps[f'Included_{oid}'].append(
+                                    f'{p_name}: list[{TYPES.get(prop['items']['type'], 'Any')}]'
+                                    f'{' | None' if prop.get('nullable') else ''}'
+                                    f'\n\t"""{prop['description']}"""'
+                                )
                             else:
-                                resps[f'Included_{oid}'].append(f'{p_name}: list[{TYPES.get(prop['type'], 'Any')}]{' | None' if prop.get('nullable') else ''}\n\t"""{prop['description']}"""')
+                                resps[f'Included_{oid}'].append(
+                                    f'{p_name}: list[{TYPES.get(prop['type'], 'Any')}]'
+                                    f'{' | None' if prop.get('nullable') else ''}'
+                                    f'\n\t"""{prop['description']}"""'
+                                )
 
             if 'item' in r_props:
                 has_item = True
@@ -188,11 +200,11 @@ def yield_paths() -> Generator[str]:
                         for obj in r_item['allOf'][1:]
                         for prop_name, prop in obj['properties'].items()
                     ]
-                    resps[f'Item_{oid}({base_type})'] = additional_keys
+                    resps[f'Item_{oid}(sch.{base_type})'] = additional_keys
 
                 elif '$ref' in r_item:
                     has_item = False  # Direct reference
-                    resps[f'Response_{oid}'].append(f"item: {r_item['$ref'].split('/')[-1]}")
+                    resps[f'Response_{oid}'].append(f"item: sch.{r_item['$ref'].split('/')[-1]}")
 
                 elif 'properties' in r_item:
                     resps[f'Item_{oid}'] = []
@@ -201,10 +213,17 @@ def yield_paths() -> Generator[str]:
                             t = f"Literal{prop['enum']}"
                         else:
                             t = TYPES.get(prop['type'], 'Any')
-                        resps[f'Item_{oid}'].append(f"{p_name}: {t}{' | None' if prop.get('nullable') else ''}")
+                        resps[f'Item_{oid}'].append(
+                            f"{p_name}: {t}"
+                            f"{' | None' if prop.get('nullable') else ''}"
+                        )
                 else:
                     has_item = False
-                    resps[f'Response_{oid}'].append(f'item: {TYPES.get(r_item["type"])}{' | None' if r_item.get('nullable') else ''}\n\t"""{r_item['description']}"""')
+                    resps[f'Response_{oid}'].append(
+                        f'item: {TYPES.get(r_item["type"])}'
+                        f'{' | None' if r_item.get('nullable') else ''}'
+                        f'\n\t"""{r_item['description']}"""'
+                    )
 
             if 'items' in r_props:
                 has_items = True
@@ -221,7 +240,7 @@ def yield_paths() -> Generator[str]:
                         for obj in r_items['items']['allOf'][1:]
                         for prop_name, prop in obj['properties'].items()
                     ]
-                    resps[f'Items_{oid}({base_type})'] = additional_keys
+                    resps[f'Items_{oid}(sch.{base_type})'] = additional_keys
 
                 else:
                     resps[f'Items_{oid}'] = []
@@ -230,7 +249,7 @@ def yield_paths() -> Generator[str]:
                         if '$ref' in r_items['items']:
                             has_items = False
                             t = r_items['items']['$ref'].split('/')[-1]
-                            resps[f'Response_{oid}'].append(f'items: list[{t}]')
+                            resps[f'Response_{oid}'].append(f'items: list[sch.{t}]')
 
             if has_items or has_item or has_included:
                 if has_item:
@@ -286,9 +305,9 @@ def yield_paths() -> Generator[str]:
                             p_type = TYPES.get(prop['type'], 'Any')
                             yield f"\t\t\t{name} ({p_type}{' | None' if prop.get('nullable') else ''}): {prop['description']}"
                             if name in kwarg_required:
-                                kwarg_reqs[r_typing].append(f'{name}: typ.{p_type}{' | None' if prop.get('nullable') else ''}\n\t"""{prop['description']}"""')
+                                kwarg_reqs[r_typing].append(f'{name}: {p_type}{' | None' if prop.get('nullable') else ''}\n\t"""{prop['description']}"""')
                             else:
-                                kwarg_reqs[r_typing].append(f'{name}: NotRequired[typ.{p_type}{' | None' if prop.get('nullable') else ''}]\n\t"""{prop['description']}"""')
+                                kwarg_reqs[r_typing].append(f'{name}: NotRequired[{p_type}{' | None' if prop.get('nullable') else ''}]\n\t"""{prop['description']}"""')
 
             errors = {code: r for code, r in info['responses'].items() if code != '200'}
             if errors:
@@ -357,51 +376,76 @@ def yield_async_paths() -> Generator[str]:
 
 def yield_types() -> Generator[str]:
     yield "from __future__ import annotations"
+    yield ""
     yield "from datetime import datetime"
     yield "from typing import ("
     yield "\tAny,"
     yield "\tLiteral,"
-    yield "\tTypedDict,"
     yield "\tNotRequired,"
-    yield ")"
-    yield "from .schemas import *"
+    yield "\tTypedDict,"
+    yield ")\n"
+    yield "from . import schemas as sch"
     yield ""
     if requests:
         yield ""
-        yield "# Request Typing"
+        # yield "# Request Typing"
         for c_name, attrs in requests.items():
             yield f"class {c_name}(TypedDict):"
             for attr in attrs:
+                if c_name == 'Request_getCards':
+                    attr = attr.replace('before[listChangedAt]', 'before_listChangedAt')
+                    attr = attr.replace('before[id]', 'before_id')
+                if 'file:' in attr.lower():
+                    if c_name != 'Request_createAttachment':
+                        attr = attr.replace('str', 'bytes')
+                    else:
+                        attr = attr.replace('str', 'str | bytes')
+                if 'dueDate:' in attr:
+                    if c_name != 'Request_updateCard':
+                        attr = attr.replace('str', 'str | datetime')
+                        attr = attr.replace(
+                            "Due date for the card",
+                            "Due date for the card (`datetime` only allowed when using `Card.create_card`, otherwise use ISO string)"
+                        )
+                if 'stopwatch:' in attr:
+                    if c_name == 'Request_updateCard':
+                        attr = attr.replace('dict[str, Any]', 'sch.Stopwatch')
                 yield f"\t{attr}"
-            yield ""
-        yield ""
+            yield "\n"
 
     if responses:
-        yield ""
-        yield "# Response Typing"
+        # yield "# Response Typing"
         for r_name, attrs in responses.items():
             if not attrs:
                 continue
             if '(' in r_name:
-                yield f"class {r_name}:"
+                yield f"\nclass {r_name}:"
             else:
-                yield f"class {r_name}(TypedDict):"
+                yield f"\nclass {r_name}(TypedDict):"
 
             for attr in attrs:
+                if 'isFavorite:' in attr:
+                    attr = attr.replace(': bool', ': NotRequired[bool]')
+                if 'isSubscribed:' in attr:
+                    attr = attr.replace(': bool', ': NotRequired[bool]')
                 yield f"\t{attr}"
+
+            # Bootstrap response
+            if r_name == 'Response_getBootstrap':
+                yield "\titem: sch.Bootstrap"
             yield ""
-        yield ""
+        # yield ""
 
 
 def yield_errors() -> Generator[str]:
     yield "from __future__ import annotations"
+    yield ""
     yield "from typing import Any"
+    yield ""
     yield "from httpx import HTTPStatusError"
     yield ""
     yield "__all__ = ("
-    yield '\t"PlankaError",'
-    yield '\t"ERRORS",'
-    for i in get_errors(SWG):
+    for i in ['ERRORS', *sorted([*get_errors(SWG), 'PlankaError'])]:
         yield f'\t"{i}",'
     yield ")\n\n"
     yield "class PlankaError(HTTPStatusError):"
@@ -416,6 +460,7 @@ def yield_errors() -> Generator[str]:
         yield f"\n\nclass {r}(PlankaError):"
         yield f'    """{rs["description"]}"""'
         errors[rs['content']['application/json']['schema']['properties']['code']['example']] = r
+    yield ""
     yield ""
     yield "ERRORS: dict[str, type[PlankaError]] = {"
     for e_name, e_class in errors.items():
@@ -439,7 +484,8 @@ def yield_init() -> Generator[str]:
 
 def yield_schema() -> Generator[str]:
     yield "from __future__ import annotations"
-    yield "from typing import TypedDict, NotRequired, Any, Literal"
+    yield ""
+    yield "from typing import Any, Literal, NotRequired, TypedDict"
     yield ""
     yield "from .events import PlankaEvent"
     yield ""
@@ -451,6 +497,7 @@ def yield_schema() -> Generator[str]:
     for c, prop in get_schemas(SWG).items():
         yield f"\n\nclass {c}(TypedDict):"
         for p, ps in prop["properties"].items():
+            p = p.replace('[', '_').replace(']', '')
             t = "Any"
             if "enum" in ps:
                 t = f"Literal{ps['enum']}"
@@ -469,7 +516,7 @@ def yield_schema() -> Generator[str]:
             yield f"    {p}: {t}"
             if "description" in ps:
                 yield f'    """{ps["description"]}"""'
-    yield ""
+    yield "\n"
     yield "class Stopwatch(TypedDict):"
     yield "    startedAt: str | None"
     yield '    """The time that a running stopwatch was started"""'
@@ -478,12 +525,14 @@ def yield_schema() -> Generator[str]:
     yield '\n'
 
 
-# INIT_MOD.write_text("\n".join(map(lambda l: l.replace('\t', '    '), yield_init())))
-# SCHEMA_MOD.write_text("\n".join(map(lambda l: l.replace('\t', '    '),yield_schema())))
-PATH_MOD.write_text("\n".join(line.replace('\t', '    ') for line in yield_paths()))
-ASYNC_PATH_MOD.write_text("\n".join(line.replace('\t', '    ') for line in yield_async_paths()))
-# ERRORS_MOD.write_text("\n".join(map(lambda l: l.replace('\t', '    '),yield_errors())))
-# TYP_MOD.write_text("\n".join(map(lambda l: l.replace('\t', '    '),yield_types())))
+# Populate paths
+_ = list(yield_paths())
+INIT_MOD.write_text("\n".join(line.replace('\t', '    ') for line in yield_init()))
+# SCHEMA_MOD.write_text("\n".join(line.replace('\t', '    ') for line in yield_schema()))
+# PATH_MOD.write_text("\n".join(line.replace('\t', '    ') for line in yield_paths()))
+# ASYNC_PATH_MOD.write_text("\n".join(line.replace('\t', '    ') for line in yield_async_paths()))
+# ERRORS_MOD.write_text("\n".join(line.replace('\t', '    ') for line in yield_errors()))
+TYP_MOD.write_text("\n".join(line.replace('\t', '    ') for line in yield_types()))
 # Delete the file after it is used
 # this ensures that the api typing module
 # is always up to date

--- a/dev/build_api.py
+++ b/dev/build_api.py
@@ -2,6 +2,7 @@
 a typing module using it
 """
 
+import datetime as dt
 import json
 from collections.abc import Generator
 from datetime import datetime
@@ -9,8 +10,6 @@ from pathlib import Path
 from typing import Any, Required, TypedDict
 
 import httpx
-
-import os
 
 HERE = Path(__file__).parent
 
@@ -20,12 +19,12 @@ SWAGGER_URL = "https://plankanban.github.io/planka/swagger-ui/swagger.json"
 SWAGGER_FILE = HERE / "swagger.json"
 
 INIT_MOD = API / "__init__.py"
-SCHEMA_MOD = API / "schemas.py" # Schema for each planka object
+SCHEMA_MOD = API / "schemas.py"  # Schema for each planka object
 
-PATH_MOD = API / "paths.py" # Endpoints
-ASYNC_PATH_MOD = API / "async_paths.py" # Async Endpoints
-TYP_MOD = API / "typ.py" # Typing for response/request json
-ERRORS_MOD = API / "errors.py" # Error implementations
+PATH_MOD = API / "paths.py"  # Endpoints
+ASYNC_PATH_MOD = API / "async_paths.py"  # Async Endpoints
+TYP_MOD = API / "typ.py"  # Typing for response/request json
+ERRORS_MOD = API / "errors.py"  # Error implementations
 
 TYPES = {
     "string": "str",
@@ -83,36 +82,38 @@ def get_schemas(swg: dict[str, Any]) -> dict[str, Schema]:
 def get_errors(swg: dict[str, Any]) -> dict[str, Response]:
     return swg["components"]["responses"]
 
+
 requests: dict[str, Any] | None = None
 responses: dict[str, Any] | None = None
+
+
 def yield_paths() -> Generator[str]:
     """This is a beautiful function. My god is it a mess I'm sorry"""
-    
+
     yield "from __future__ import annotations"
-    yield "from typing import ("
-    yield "\tLiteral,"
-    yield "\tUnpack,"
-    yield ")"
-    yield "from httpx import Client, Response, HTTPStatusError"
-    yield "from .schemas import *"
-    yield "from .typ import *"
-    yield "from .errors import *"
+    yield ""
+    yield "from typing import Unpack"
+    yield ""
+    yield "from httpx import Client, HTTPStatusError, Response"
+    yield ""
+    yield "from . import typ"
+    yield "from .errors import ERRORS, PlankaError"
     yield ""
     yield '__all__ = ("PlankaEndpoints",)'
-    yield ""
+    yield "\n"
     yield "def raise_planka_err(resp: Response) -> None:"
     yield "\ttry:"
     yield "\t\tresp.raise_for_status()"
     yield "\texcept HTTPStatusError as status_err:"
     yield "\t\tplanka_code = status_err.response.json().get('code')"
     yield "\t\tplanka_err = ERRORS.get(planka_code, PlankaError)"
-    yield "\t\traise planka_err(status_err)"
-    yield ""
+    yield "\t\traise planka_err(status_err) from status_err"
+    yield "\n"
     yield "class PlankaEndpoints:"
     yield "\tdef __init__(self, client: Client) -> None:"
     yield "\t\tself.client = client"
     yield ""
-    
+
     kwarg_reqs: dict[str, list[str]] = {}
     resps: dict[str, list[str]] = {}
     for r, rs in get_paths(SWG).items():
@@ -131,7 +132,7 @@ def yield_paths() -> Generator[str]:
             )
             optional_params = [p for p in params if not p.get('required', False)]
             body = info.get("requestBody")
-                    
+
             # Get item/includes type from here
             # assign a Item[type] or Includes[itemtype, *includetypes] return
             # may need additional response typeshed for includes keys per endpoint
@@ -150,7 +151,7 @@ def yield_paths() -> Generator[str]:
                 r_included = r_props['included']
                 r_i_props = r_included.get('properties')
                 for p_name, prop in r_i_props.items():
-                    if prop["type"] ==  "array":
+                    if prop["type"] == "array":
                         if '$ref' in prop['items']:
                             t = prop['items']['$ref'].split('/')[-1]
                             resps[f'Included_{oid}'].append(f'{p_name}: list[{t}]')
@@ -171,7 +172,7 @@ def yield_paths() -> Generator[str]:
                                 resps[f'Included_{oid}'].append(f'{p_name}: list[{TYPES.get(prop['items']['type'], 'Any')}]{' | None' if prop.get('nullable') else ''}\n\t"""{prop['description']}"""')
                             else:
                                 resps[f'Included_{oid}'].append(f'{p_name}: list[{TYPES.get(prop['type'], 'Any')}]{' | None' if prop.get('nullable') else ''}\n\t"""{prop['description']}"""')
-                                
+
             if 'item' in r_props:
                 has_item = True
                 r_item = r_props['item']
@@ -190,7 +191,7 @@ def yield_paths() -> Generator[str]:
                     resps[f'Item_{oid}({base_type})'] = additional_keys
 
                 elif '$ref' in r_item:
-                    has_item = False # Direct reference
+                    has_item = False  # Direct reference
                     resps[f'Response_{oid}'].append(f"item: {r_item['$ref'].split('/')[-1]}")
 
                 elif 'properties' in r_item:
@@ -204,12 +205,12 @@ def yield_paths() -> Generator[str]:
                 else:
                     has_item = False
                     resps[f'Response_{oid}'].append(f'item: {TYPES.get(r_item["type"])}{' | None' if r_item.get('nullable') else ''}\n\t"""{r_item['description']}"""')
-            
+
             if 'items' in r_props:
                 has_items = True
                 r_items = r_props['items']
                 r_i_props = r_items.get('properties')
-                
+
                 if 'allOf' in r_items['items']:
                     base_type = r_items['items']['allOf'][0]['$ref'].split('/')[-1]
                     additional_keys = [
@@ -221,16 +222,16 @@ def yield_paths() -> Generator[str]:
                         for prop_name, prop in obj['properties'].items()
                     ]
                     resps[f'Items_{oid}({base_type})'] = additional_keys
-            
+
                 else:
                     resps[f'Items_{oid}'] = []
-                    #for p_name, prop in r_items.get('properties', {}).items():
+                    # for p_name, prop in r_items.get('properties', {}).items():
                     if r_items['type'] == 'array':
                         if '$ref' in r_items['items']:
                             has_items = False
                             t = r_items['items']['$ref'].split('/')[-1]
                             resps[f'Response_{oid}'].append(f'items: list[{t}]')
-            
+
             if has_items or has_item or has_included:
                 if has_item:
                     resps[f'Response_{oid}'].append(f'item: Item_{oid}')
@@ -238,15 +239,15 @@ def yield_paths() -> Generator[str]:
                     resps[f'Response_{oid}'].append(f'items: list[Items_{oid}]')
                 if has_included:
                     resps[f'Response_{oid}'].append(f'included: Included_{oid}')
-            
+
             if not body and not optional_params:
-                yield f"\tdef {oid}({', '.join(header)}) -> Response_{oid}:"
+                yield f"\tdef {oid}({', '.join(header)}) -> typ.Response_{oid}:"
             else:
-                yield f"\tdef {oid}({', '.join(header)}, **kwargs: Unpack[Request_{oid}]) -> Response_{oid}:"
+                yield f"\tdef {oid}({', '.join(header)}, **kwargs: Unpack[typ.Request_{oid}]) -> typ.Response_{oid}:"
             yield f'\t\t"""{info["description"]}'
             if params or body:
                 yield ""
-                yield f"\t\tArgs:"
+                yield "\t\tArgs:"
             if params:
                 for p in params:
                     if "enum" in p["schema"]:
@@ -254,10 +255,10 @@ def yield_paths() -> Generator[str]:
                     else:
                         t = p["schema"]["type"]
                     if p.get('required', False):
-                        yield f"\t\t\t{p['name']} ({TYPES.get(t, t)}{' | None' if p.get('nullable') else ''}): {p['description']})"
+                        yield f"\t\t\t{p['name']} ({TYPES.get(t, t)}{' | None' if p.get('nullable') else ''}): {p['description'].strip()})"
                     else:
-                        yield f"\t\t\t{p['name']} ({TYPES.get(t, t)}{' | None' if p.get('nullable') else ''}): {p['description']}) (optional)"
-                        
+                        yield f"\t\t\t{p['name']} ({TYPES.get(t, t)}{' | None' if p.get('nullable') else ''}): {p['description'].strip()}) (optional)"
+
             if body or optional_params:
                 r_typing = f"Request_{oid}"
                 kwarg_reqs[r_typing] = []
@@ -273,7 +274,7 @@ def yield_paths() -> Generator[str]:
                         schema = body["content"]["application/json"]["schema"]
                     except KeyError:
                         schema = body["content"]["multipart/form-data"]["schema"]
-                    kwarg_required = schema.get('required', []) 
+                    kwarg_required = schema.get('required', [])
                     for name, prop in schema["properties"].items():
                         if "enum" in prop:
                             yield f"\t\t\t{name} (Literal{prop['enum']}{' | None' if prop.get('nullable') else ''}): {prop['description']}"
@@ -285,22 +286,21 @@ def yield_paths() -> Generator[str]:
                             p_type = TYPES.get(prop['type'], 'Any')
                             yield f"\t\t\t{name} ({p_type}{' | None' if prop.get('nullable') else ''}): {prop['description']}"
                             if name in kwarg_required:
-                                kwarg_reqs[r_typing].append(f'{name}: {p_type}{' | None' if prop.get('nullable') else ''}\n\t"""{prop['description']}"""')
+                                kwarg_reqs[r_typing].append(f'{name}: typ.{p_type}{' | None' if prop.get('nullable') else ''}\n\t"""{prop['description']}"""')
                             else:
-                                kwarg_reqs[r_typing].append(f'{name}: NotRequired[{p_type}{' | None' if prop.get('nullable') else ''}]\n\t"""{prop['description']}"""')
-            
+                                kwarg_reqs[r_typing].append(f'{name}: NotRequired[typ.{p_type}{' | None' if prop.get('nullable') else ''}]\n\t"""{prop['description']}"""')
+
             errors = {code: r for code, r in info['responses'].items() if code != '200'}
             if errors:
                 yield ""
                 yield "\t\tNote:"
-                yield "\t\t\tAll status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). "
-                yield "\t\t\tIf a matching PlankaError exists, it will be raised (see `api.errors`) "
-                yield "\t\t\tPlanka internal status codes and names are included here for disambiguation"
+                yield "\t\t\tAll status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`)."
+                yield "\t\t\t If a matching PlankaError exists, it will be raised (see `api.errors`)"
+                yield "\t\t\t Planka internal status codes and names are included here for disambiguation"
                 yield ""
                 yield "\t\tRaises:"
                 for e_code, e in errors.items():
-                    yield f"\t\t\t{e.get('$ref', 'Error').split('/')[-1]}: {int(e_code)} " + e.get('description', '')
-                    
+                    yield "\t\t\t" + (f"{e.get('$ref', 'Error').split('/')[-1]}: {int(e_code)} " + e.get('description', '')).strip()
             yield '\t\t"""'
             if not body and not optional_params:
                 if '{' in r:
@@ -314,8 +314,8 @@ def yield_paths() -> Generator[str]:
                     yield f'\t\tresp = self.client.{typ}("api{r}", json=kwargs)'
             elif optional_params or body:
                 if optional_params:
-                    yield f'\t\tvalid_params = {tuple([p['name'] for p in optional_params])}'
-                    yield f'\t\tpassed_params = ''{k: v for k, v in kwargs.items() if k in valid_params if isinstance(v, str | int | float)}'
+                    yield f'\t\tvalid_params = {tuple(p['name'] for p in optional_params)}'
+                    yield '\t\tpassed_params = ''{k: v for k, v in kwargs.items() if k in valid_params if isinstance(v, str | int | float)}'
                 if optional_params and body:
                     if '{' in r:
                         yield f'\t\tresp = self.client.{typ}(f"api{r}", params=passed_params, json=kwargs)'
@@ -331,7 +331,7 @@ def yield_paths() -> Generator[str]:
                         yield f'\t\tresp = self.client.{typ}(f"api{r}", json=kwargs)'
                     else:
                         yield f'\t\tresp = self.client.{typ}("api{r}", json=kwargs)'
-            
+
             yield "\t\traise_planka_err(resp)"
             yield "\t\treturn resp.json()"
             yield ""
@@ -341,17 +341,19 @@ def yield_paths() -> Generator[str]:
     requests = kwarg_reqs
     responses = resps
 
+
 def yield_async_paths() -> Generator[str]:
     for line in yield_paths():
-        if '__init__' not in line:
+        if '__init__' not in line and 'def raise_planka_err' not in line:
             line = line.replace('def ', 'async def ')
         if 'PlankaEndpoints' in line:
             line = line.replace('PlankaEndpoints', 'AsyncPlankaEndpoints')
         line = line.replace(': Client', ': AsyncClient')
         line = line.replace('import Client', 'import AsyncClient')
         line = line.replace('resp = ', 'resp = await ')
-        line = line.replace('raise_planka_err(resp)', 'await raise_planka_err(resp)')
+        # line = line.replace('raise_planka_err(resp)', 'await raise_planka_err(resp)')
         yield line
+
 
 def yield_types() -> Generator[str]:
     yield "from __future__ import annotations"
@@ -384,11 +386,12 @@ def yield_types() -> Generator[str]:
                 yield f"class {r_name}:"
             else:
                 yield f"class {r_name}(TypedDict):"
-            
+
             for attr in attrs:
                 yield f"\t{attr}"
             yield ""
         yield ""
+
 
 def yield_errors() -> Generator[str]:
     yield "from __future__ import annotations"
@@ -400,8 +403,7 @@ def yield_errors() -> Generator[str]:
     yield '\t"ERRORS",'
     for i in get_errors(SWG):
         yield f'\t"{i}",'
-    yield ")"
-    yield ""
+    yield ")\n\n"
     yield "class PlankaError(HTTPStatusError):"
     yield "    def __init__(self, parent: HTTPStatusError, *args: Any, **kwargs: Any) -> None:"
     yield "        response_json: dict[str, str] = parent.response.json()"
@@ -409,11 +411,10 @@ def yield_errors() -> Generator[str]:
     yield "        super().__init__(message, request=parent.request, response=parent.response)"
     yield "        for problem in response_json.get('problems', []):"
     yield "            self.add_note(problem)"
-    yield ""
     errors: dict[str, str] = {}
     for r, rs in get_errors(SWG).items():
-        yield f"\nclass {r}(PlankaError): ..."
-        yield f'"""{rs["description"]}"""'
+        yield f"\n\nclass {r}(PlankaError):"
+        yield f'    """{rs["description"]}"""'
         errors[rs['content']['application/json']['schema']['properties']['code']['example']] = r
     yield ""
     yield "ERRORS: dict[str, type[PlankaError]] = {"
@@ -422,16 +423,17 @@ def yield_errors() -> Generator[str]:
     yield "}"
     yield ""
 
+
 def yield_init() -> Generator[str]:
-    _version: str = SWG["info"]["version"]
-    yield f'"""{SWG["info"]["title"]} ({_version}) - Generated on {datetime.now().strftime("%a %b %d %Y")}"""'
+    version: str = SWG["info"]["version"]
+    yield f'"""{SWG["info"]["title"]} ({version}) - Generated on {datetime.now(tz=dt.UTC).strftime("%a %b %d %Y")}"""'
     yield ""
     yield "from .schemas import *"
     yield "from .paths import *"
     yield "from .async_paths import *"
     yield "from .errors import *"
     yield ""
-    yield f'__version__ = "{_version}"'
+    yield f'__version__ = "{version}"'
     yield ""
 
 
@@ -439,15 +441,15 @@ def yield_schema() -> Generator[str]:
     yield "from __future__ import annotations"
     yield "from typing import TypedDict, NotRequired, Any, Literal"
     yield ""
-    yield "from .events import WebhookEvent"
+    yield "from .events import PlankaEvent"
     yield ""
     yield "__all__ = ("
-    for c in get_schemas(SWG):
+    schms = sorted([*get_schemas(SWG), "Stopwatch"])
+    for c in schms:
         yield f'\t"{c}",'
-    yield '\t"Stopwatch",'
     yield ")"
     for c, prop in get_schemas(SWG).items():
-        yield f"\nclass {c}(TypedDict):"
+        yield f"\n\nclass {c}(TypedDict):"
         for p, ps in prop["properties"].items():
             t = "Any"
             if "enum" in ps:
@@ -473,15 +475,16 @@ def yield_schema() -> Generator[str]:
     yield '    """The time that a running stopwatch was started"""'
     yield "    total: int"
     yield '    """The number of seconds that the stopwatch has been running"""'
+    yield '\n'
 
 
-#INIT_MOD.write_text("\n".join(map(lambda l: l.replace('\t', '    '), yield_init())))
-#SCHEMA_MOD.write_text("\n".join(map(lambda l: l.replace('\t', '    '),yield_schema())))
-PATH_MOD.write_text("\n".join(map(lambda l: l.replace('\t', '    '),yield_paths())))
-ASYNC_PATH_MOD.write_text("\n".join(map(lambda l: l.replace('\t', '    '),yield_async_paths())))
-#ERRORS_MOD.write_text("\n".join(map(lambda l: l.replace('\t', '    '),yield_errors())))
-#TYP_MOD.write_text("\n".join(map(lambda l: l.replace('\t', '    '),yield_types())))
+# INIT_MOD.write_text("\n".join(map(lambda l: l.replace('\t', '    '), yield_init())))
+# SCHEMA_MOD.write_text("\n".join(map(lambda l: l.replace('\t', '    '),yield_schema())))
+PATH_MOD.write_text("\n".join(line.replace('\t', '    ') for line in yield_paths()))
+ASYNC_PATH_MOD.write_text("\n".join(line.replace('\t', '    ') for line in yield_async_paths()))
+# ERRORS_MOD.write_text("\n".join(map(lambda l: l.replace('\t', '    '),yield_errors())))
+# TYP_MOD.write_text("\n".join(map(lambda l: l.replace('\t', '    '),yield_types())))
 # Delete the file after it is used
 # this ensures that the api typing module
 # is always up to date
-os.remove(SWAGGER_FILE)
+Path(SWAGGER_FILE).unlink()

--- a/dev/build_api.py
+++ b/dev/build_api.py
@@ -473,10 +473,10 @@ def yield_init() -> Generator[str]:
     version: str = SWG["info"]["version"]
     yield f'"""{SWG["info"]["title"]} ({version}) - Generated on {datetime.now(tz=dt.UTC).strftime("%a %b %d %Y")}"""'
     yield ""
-    yield "from .schemas import *"
-    yield "from .paths import *"
     yield "from .async_paths import *"
     yield "from .errors import *"
+    yield "from .paths import *"
+    yield "from .schemas import *"
     yield ""
     yield f'__version__ = "{version}"'
     yield ""

--- a/dev/build_test_project.py
+++ b/dev/build_test_project.py
@@ -3,10 +3,21 @@ import sys
 sys.path.append('../src')
 sys.path.append('src')
 
-from random import choices, choice
+from random import choice
 
-from plankapy.v2.models import Project, Board, List, Task, Comment, Label, Attachment, Card, CustomField
 from plankapy.v2 import Planka
+from plankapy.v2.models import (
+    Attachment,
+    Board,
+    Card,
+    Comment,
+    CustomField,
+    Label,
+    List,
+    Project,
+    Task,
+)
+
 
 def create_test_project(planka: Planka, name: str = 'plankapy Test Project') -> Project:
     # Delete any existing test projects
@@ -16,14 +27,15 @@ def create_test_project(planka: Planka, name: str = 'plankapy Test Project') -> 
         tp.delete()
     return planka.create_project(name=name, type='shared')
 
-def create_test_users(planka: Planka, *users: str, default_password: str='plankapy999'):
+
+def create_test_users(planka: Planka, *users: str, default_password: str = 'plankapy999'):
     # Delete any existing test users:
     for user in planka.users[{'name': lambda n: n in users}]:
         user.delete()
     return [
         planka.create_user(
-            email=f'{name}@test.com', 
-            name=name, 
+            email=f'{name}@test.com',
+            name=name,
             password=default_password,
             username=name,
             role='boardUser',
@@ -31,11 +43,13 @@ def create_test_users(planka: Planka, *users: str, default_password: str='planka
         for name in users
     ]
 
+
 def create_test_boards(project: Project, *boards: str) -> list[Board]:
     return [
         project.create_board(name=board)
         for board in boards
     ]
+
 
 def create_test_labels(boards: list[Board], *labels: str) -> list[Label]:
     return [
@@ -44,12 +58,14 @@ def create_test_labels(boards: list[Board], *labels: str) -> list[Label]:
         for l in labels
     ]
 
+
 def create_test_lists(boards: list[Board], *lists: str) -> list[List]:
     return [
         b.create_list(name=l, color='random')
         for b in boards
         for l in lists
     ]
+
 
 def create_test_cards(lists: list[List], *cards: str) -> list[Card]:
     return [
@@ -58,12 +74,14 @@ def create_test_cards(lists: list[List], *cards: str) -> list[Card]:
         for c in cards
     ]
 
+
 def create_test_attachments(cards: list[Card], *attachments: str) -> list[Attachment]:
     return [
         c.add_attachment(a, cover=True, download_url=True)
         for c in cards
         for a in attachments
     ]
+
 
 def create_test_fields_on_boards(boards: list[Board], *fields: str) -> list[CustomField]:
     return [
@@ -72,6 +90,7 @@ def create_test_fields_on_boards(boards: list[Board], *fields: str) -> list[Cust
         if (cfg := b.create_field_group('Fields'))
         for f in fields
     ]
+
 
 def create_test_tasks(cards: list[Card], *tasks: dict[str, list[str]]) -> list[Task]:
     return [
@@ -83,6 +102,7 @@ def create_test_tasks(cards: list[Card], *tasks: dict[str, list[str]]) -> list[T
         for v in tl_tasks
     ]
 
+
 def create_test_comments(cards: list[Card], *comments: str) -> list[Comment]:
     return [
         card.comment(comment, mentions=card.board.users)
@@ -90,12 +110,13 @@ def create_test_comments(cards: list[Card], *comments: str) -> list[Comment]:
         for comment in comments
     ]
 
+
 def main():
     test_project_name = 'plankapy Test Project'
     test_users = [
-        'plankapy1', 
-        'plankapy2', 
-        'plankapy3', 
+        'plankapy1',
+        'plankapy2',
+        'plankapy3',
         'plankapy4',
     ]
     test_boards = [
@@ -150,7 +171,8 @@ def main():
         task.assignee = choice(users)
     comments = create_test_comments(cards, *['THIS IS A COMMENT', 'MENTION EVERYONE'])
 
+
 if __name__ == '__main__':
-    #planka = Planka('http://localhost:1337')
-    #planka.login(username='demo', password='demo')
-    main()
+    planka = Planka('https://pro.demo.planka.cloud/')
+    planka.login(username='influencer@demo.com', password='DemoPass123!')
+    #main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,3 +37,55 @@ Homepage = "https://github.com/hwelch-fle/plankapy"
 Documentation = "https://hwelch-fle.github.io/plankapy/plankapy.html"
 Issues = "https://github.com/hwelch-fle/plankapy/issues"
 Discussions = "https://github.com/hwelch-fle/plankapy/discussions"
+
+
+
+[tool.ruff.lint.per-file-ignores]
+"tests/*" = ["S101"]
+"*/__init__.py" = ["F403"] # Allow * imports for __init__ (Ensure that __all__ is defined in target)
+"src/plankapy/v2/models/*" = ["E402"] # Defer imports for models
+
+[tool.ruff.lint]
+ignore = [
+    "RUF001", # ruff-specific rules ambiguous-unicode-character-string
+    "S101",   # flake8-bandit assert
+    "S308",   # flake8-bandit suspicious-mark-safe-usage
+    "S603",   # flake8-bandit subprocess-without-shell-equals-true
+    "S607",   # flake8-bandit start-process-with-partial-path
+    "E501",   # pycodestyle line-too-long
+    "PTH123",
+]
+select = [
+    "B",   # flake8-bugbear
+    "C4",  # flake8-comprehensions
+    "DTZ", # flake8-datetimez
+    "E",   # pycodestyle errors
+    "EXE", # flake8-executable
+    "F",   # pyflakes
+    "I",   # isort
+    "INT", # flake8-gettext
+    "PIE", # flake8-pie
+    "PLC", # pylint convention
+    "PLE", # pylint errors
+    "PT",  # flake8-pytest-style
+    "PTH", # flake8-use-pathlib
+    "RSE", # flake8-raise
+    "RUF", # ruff-specific rules
+    "S",   # flake8-bandit
+    "UP",  # pyupgrade
+    "W",   # pycodestyle warnings
+]
+
+[tool.ruff.lint.flake8-pytest-style]
+fixture-parentheses = false
+mark-parentheses = false
+
+[tool.ruff.lint.isort]
+# force-single-line = true
+force-wrap-aliases = true
+combine-as-imports = true
+
+[tool.ruff.format]
+quote-style = "single"
+docstring-code-format = true
+indent-style = "space"

--- a/src/plankapy/v2/__init__.py
+++ b/src/plankapy/v2/__init__.py
@@ -1,16 +1,18 @@
-__all__ = ('Planka', )
-
-from .interface import Planka as Planka
-from .interface import Client as Client
-from . models import *
-from .utils import *
 from . import (
-    api as api, 
+    api as api,
     models as models,
     utils as utils,
 )
+from .interface import (
+    Client as Client,
+    Planka as Planka,
+)
+from .models import *
 from .models._helpers import (
     POSITION_GAP as POSITION_GAP,
-    model_list as model_list,
     ModelList as ModelList,
+    model_list as model_list,
 )
+from .utils import *
+
+__all__ = ('Planka', )

--- a/src/plankapy/v2/api/__init__.py
+++ b/src/plankapy/v2/api/__init__.py
@@ -1,4 +1,4 @@
-"""PLANKA API (2.0.1) - Generated on Wed Mar 11 2026"""
+"""PLANKA API (2.0.1) - Generated on Mon Jul 13 2026"""
 
 from .async_paths import *
 from .errors import *

--- a/src/plankapy/v2/api/__init__.py
+++ b/src/plankapy/v2/api/__init__.py
@@ -1,8 +1,8 @@
 """PLANKA API (2.0.1) - Generated on Wed Mar 11 2026"""
 
-from .schemas import *
-from .paths import *
 from .async_paths import *
 from .errors import *
+from .paths import *
+from .schemas import *
 
 __version__ = "2.0.1"

--- a/src/plankapy/v2/api/async_paths.py
+++ b/src/plankapy/v2/api/async_paths.py
@@ -1,28 +1,29 @@
 from __future__ import annotations
-from typing import (
-    Literal,
-    Unpack,
-)
-from httpx import AsyncClient, Response, HTTPStatusError
-from .schemas import *
-from .typ import *
-from .errors import *
+
+from typing import Unpack
+
+from httpx import AsyncClient, HTTPStatusError, Response
+
+from . import typ
+from .errors import ERRORS, PlankaError
 
 __all__ = ("AsyncPlankaEndpoints",)
 
-async def raise_planka_err(resp: Response) -> None:
+
+def raise_planka_err(resp: Response) -> None:
     try:
         resp.raise_for_status()
     except HTTPStatusError as status_err:
         planka_code = status_err.response.json().get('code')
         planka_err = ERRORS.get(planka_code, PlankaError)
-        raise planka_err(status_err)
+        raise planka_err(status_err) from status_err
+
 
 class AsyncPlankaEndpoints:
     def __init__(self, client: AsyncClient) -> None:
         self.client = client
 
-    async def acceptTerms(self, **kwargs: Unpack[Request_acceptTerms]) -> Response_acceptTerms:
+    async def acceptTerms(self, **kwargs: Unpack[typ.Request_acceptTerms]) -> typ.Response_acceptTerms:
         """Accept terms during the authentication flow. Converts the pending token to an access token.
 
         Args:
@@ -31,20 +32,20 @@ class AsyncPlankaEndpoints:
             initialLanguage (Literal['ar-YE', 'bg-BG', 'ca-ES', 'cs-CZ', 'da-DK', 'de-DE', 'el-GR', 'en-GB', 'en-US', 'es-ES', 'et-EE', 'fa-IR', 'fi-FI', 'fr-FR', 'hu-HU', 'id-ID', 'it-IT', 'ja-JP', 'ko-KR', 'nl-NL', 'pl-PL', 'pt-BR', 'pt-PT', 'ro-RO', 'ru-RU', 'sk-SK', 'sr-Cyrl-RS', 'sr-Latn-RS', 'sv-SE', 'tr-TR', 'uk-UA', 'uz-UZ', 'vi-VN', 'zh-CN', 'zh-TW'] | None): Preferred language for user interface and notifications (used only if user language is not set)
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+            If a matching PlankaError exists, it will be raised (see `api.errors`)
             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
+            ValidationError: 400
             Error: 401 Invalid pending token
             Error: 403 Authentication restriction
         """
         resp = await self.client.post("api/access-tokens/accept-terms", json=kwargs)
-        await raise_planka_err(resp)
+        raise_planka_err(resp)
         return resp.json()
 
-    async def createAccessToken(self, **kwargs: Unpack[Request_createAccessToken]) -> Response_createAccessToken:
+    async def createAccessToken(self, **kwargs: Unpack[typ.Request_createAccessToken]) -> typ.Response_createAccessToken:
         """Authenticates a user using email/username and password. Returns an access token for API authentication.
 
         Args:
@@ -53,35 +54,35 @@ class AsyncPlankaEndpoints:
             withHttpOnlyToken (bool): Whether to include an HTTP-only authentication cookie
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+            If a matching PlankaError exists, it will be raised (see `api.errors`)
             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
+            ValidationError: 400
             Error: 401 Invalid credentials
             Error: 403 Authentication restriction
         """
         resp = await self.client.post("api/access-tokens", json=kwargs)
-        await raise_planka_err(resp)
+        raise_planka_err(resp)
         return resp.json()
 
-    async def deleteAccessToken(self) -> Response_deleteAccessToken:
+    async def deleteAccessToken(self) -> typ.Response_deleteAccessToken:
         """Logs out the current user by deleting the session and access token. Clears HTTP-only cookies if present.
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+            If a matching PlankaError exists, it will be raised (see `api.errors`)
             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            Unauthorized: 401 
+            Unauthorized: 401
         """
         resp = await self.client.delete("api/access-tokens/me")
-        await raise_planka_err(resp)
+        raise_planka_err(resp)
         return resp.json()
 
-    async def exchangeForAccessTokenWithOidc(self, **kwargs: Unpack[Request_exchangeForAccessTokenWithOidc]) -> Response_exchangeForAccessTokenWithOidc:
+    async def exchangeForAccessTokenWithOidc(self, **kwargs: Unpack[typ.Request_exchangeForAccessTokenWithOidc]) -> typ.Response_exchangeForAccessTokenWithOidc:
         """Exchanges an OIDC authorization code for an access token. Creates a user if they do not exist.
 
         Args:
@@ -90,12 +91,12 @@ class AsyncPlankaEndpoints:
             withHttpOnlyToken (bool): Whether to include HTTP-only authentication cookie
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+            If a matching PlankaError exists, it will be raised (see `api.errors`)
             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
+            ValidationError: 400
             Error: 401 OIDC authentication error
             Error: 403 Authentication restriction
             Error: 409 Conflict error
@@ -103,29 +104,29 @@ class AsyncPlankaEndpoints:
             Error: 500 OIDC configuration error
         """
         resp = await self.client.post("api/access-tokens/exchange-with-oidc", json=kwargs)
-        await raise_planka_err(resp)
+        raise_planka_err(resp)
         return resp.json()
 
-    async def revokePendingToken(self, **kwargs: Unpack[Request_revokePendingToken]) -> Response_revokePendingToken:
+    async def revokePendingToken(self, **kwargs: Unpack[typ.Request_revokePendingToken]) -> typ.Response_revokePendingToken:
         """Revokes a pending authentication token and cancels the authentication flow.
 
         Args:
             pendingToken (str): Pending token to revoke
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+            If a matching PlankaError exists, it will be raised (see `api.errors`)
             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            NotFound: 404 
+            ValidationError: 400
+            NotFound: 404
         """
         resp = await self.client.post("api/access-tokens/revoke-pending-token", json=kwargs)
-        await raise_planka_err(resp)
+        raise_planka_err(resp)
         return resp.json()
 
-    async def getBoardActions(self, boardId: str, **kwargs: Unpack[Request_getBoardActions]) -> Response_getBoardActions:
+    async def getBoardActions(self, boardId: str, **kwargs: Unpack[typ.Request_getBoardActions]) -> typ.Response_getBoardActions:
         """Retrieves a list of actions (activity history) for a specific board, with pagination support.
 
         Args:
@@ -133,22 +134,22 @@ class AsyncPlankaEndpoints:
             beforeId (str): ID to get actions before (for pagination)) (optional)
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+            If a matching PlankaError exists, it will be raised (see `api.errors`)
             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            NotFound: 404 
+            ValidationError: 400
+            Unauthorized: 401
+            NotFound: 404
         """
         valid_params = ('beforeId',)
         passed_params = {k: v for k, v in kwargs.items() if k in valid_params if isinstance(v, str | int | float)}
         resp = await self.client.get(f"api/boards/{boardId}/actions", params=passed_params)
-        await raise_planka_err(resp)
+        raise_planka_err(resp)
         return resp.json()
 
-    async def getCardActions(self, cardId: str, **kwargs: Unpack[Request_getCardActions]) -> Response_getCardActions:
+    async def getCardActions(self, cardId: str, **kwargs: Unpack[typ.Request_getCardActions]) -> typ.Response_getCardActions:
         """Retrieves a list of actions (activity history) for a specific card, with pagination support.
 
         Args:
@@ -156,22 +157,22 @@ class AsyncPlankaEndpoints:
             beforeId (str): ID to get actions before (for pagination)) (optional)
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+            If a matching PlankaError exists, it will be raised (see `api.errors`)
             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            NotFound: 404 
+            ValidationError: 400
+            Unauthorized: 401
+            NotFound: 404
         """
         valid_params = ('beforeId',)
         passed_params = {k: v for k, v in kwargs.items() if k in valid_params if isinstance(v, str | int | float)}
         resp = await self.client.get(f"api/cards/{cardId}/actions", params=passed_params)
-        await raise_planka_err(resp)
+        raise_planka_err(resp)
         return resp.json()
 
-    async def createAttachment(self, cardId: str, **kwargs: Unpack[Request_createAttachment]) -> Response_createAttachment:
+    async def createAttachment(self, cardId: str, **kwargs: Unpack[typ.Request_createAttachment]) -> typ.Response_createAttachment:
         """Creates an attachment on a card. Requires board editor permissions.
 
         Args:
@@ -183,43 +184,43 @@ class AsyncPlankaEndpoints:
             requestId (str): Request ID for tracking
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+            If a matching PlankaError exists, it will be raised (see `api.errors`)
             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            Forbidden: 403 
-            NotFound: 404 
+            ValidationError: 400
+            Unauthorized: 401
+            Forbidden: 403
+            NotFound: 404
             Error: 422 Upload or validation error
         """
         resp = await self.client.post(f"api/cards/{cardId}/attachments", json=kwargs)
-        await raise_planka_err(resp)
+        raise_planka_err(resp)
         return resp.json()
 
-    async def deleteAttachment(self, id: str) -> Response_deleteAttachment:
+    async def deleteAttachment(self, id: str) -> typ.Response_deleteAttachment:
         """Deletes an attachment. Requires board editor permissions.
 
         Args:
             id (str): ID of the attachment to delete)
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+            If a matching PlankaError exists, it will be raised (see `api.errors`)
             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            Forbidden: 403 
-            NotFound: 404 
+            ValidationError: 400
+            Unauthorized: 401
+            Forbidden: 403
+            NotFound: 404
         """
         resp = await self.client.delete(f"api/attachments/{id}")
-        await raise_planka_err(resp)
+        raise_planka_err(resp)
         return resp.json()
 
-    async def updateAttachment(self, id: str, **kwargs: Unpack[Request_updateAttachment]) -> Response_updateAttachment:
+    async def updateAttachment(self, id: str, **kwargs: Unpack[typ.Request_updateAttachment]) -> typ.Response_updateAttachment:
         """Updates an attachment. Requires board editor permissions.
 
         Args:
@@ -227,21 +228,21 @@ class AsyncPlankaEndpoints:
             name (str): Name/title of the attachment
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+            If a matching PlankaError exists, it will be raised (see `api.errors`)
             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            Forbidden: 403 
-            NotFound: 404 
+            ValidationError: 400
+            Unauthorized: 401
+            Forbidden: 403
+            NotFound: 404
         """
         resp = await self.client.patch(f"api/attachments/{id}", json=kwargs)
-        await raise_planka_err(resp)
+        raise_planka_err(resp)
         return resp.json()
 
-    async def createBackgroundImage(self, projectId: str, **kwargs: Unpack[Request_createBackgroundImage]) -> Response_createBackgroundImage:
+    async def createBackgroundImage(self, projectId: str, **kwargs: Unpack[typ.Request_createBackgroundImage]) -> typ.Response_createBackgroundImage:
         """Uploads a background image for a project. Requires project manager permissions.
 
         Args:
@@ -250,43 +251,43 @@ class AsyncPlankaEndpoints:
             requestId (str): Request ID for tracking
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+            If a matching PlankaError exists, it will be raised (see `api.errors`)
             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            Forbidden: 403 
-            NotFound: 404 
+            ValidationError: 400
+            Unauthorized: 401
+            Forbidden: 403
+            NotFound: 404
             Error: 422 File upload error
         """
         resp = await self.client.post(f"api/projects/{projectId}/background-images", json=kwargs)
-        await raise_planka_err(resp)
+        raise_planka_err(resp)
         return resp.json()
 
-    async def deleteBackgroundImage(self, id: str) -> Response_deleteBackgroundImage:
+    async def deleteBackgroundImage(self, id: str) -> typ.Response_deleteBackgroundImage:
         """Deletes a background image. Requires project manager permissions.
 
         Args:
             id (str): ID of the background image to delete)
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+            If a matching PlankaError exists, it will be raised (see `api.errors`)
             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            Forbidden: 403 
-            NotFound: 404 
+            ValidationError: 400
+            Unauthorized: 401
+            Forbidden: 403
+            NotFound: 404
         """
         resp = await self.client.delete(f"api/background-images/{id}")
-        await raise_planka_err(resp)
+        raise_planka_err(resp)
         return resp.json()
 
-    async def createBaseCustomFieldGroup(self, projectId: str, **kwargs: Unpack[Request_createBaseCustomFieldGroup]) -> Response_createBaseCustomFieldGroup:
+    async def createBaseCustomFieldGroup(self, projectId: str, **kwargs: Unpack[typ.Request_createBaseCustomFieldGroup]) -> typ.Response_createBaseCustomFieldGroup:
         """Creates a base custom field group within a project. Requires project manager permissions.
 
         Args:
@@ -294,42 +295,42 @@ class AsyncPlankaEndpoints:
             name (str): Name/title of the base custom field group
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+            If a matching PlankaError exists, it will be raised (see `api.errors`)
             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            Forbidden: 403 
-            NotFound: 404 
+            ValidationError: 400
+            Unauthorized: 401
+            Forbidden: 403
+            NotFound: 404
         """
         resp = await self.client.post(f"api/projects/{projectId}/base-custom-field-groups", json=kwargs)
-        await raise_planka_err(resp)
+        raise_planka_err(resp)
         return resp.json()
 
-    async def deleteBaseCustomFieldGroup(self, id: str) -> Response_deleteBaseCustomFieldGroup:
+    async def deleteBaseCustomFieldGroup(self, id: str) -> typ.Response_deleteBaseCustomFieldGroup:
         """Deletes a base custom field group. Requires project manager permissions.
 
         Args:
             id (str): ID of the base custom field group to delete)
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+            If a matching PlankaError exists, it will be raised (see `api.errors`)
             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            Forbidden: 403 
-            NotFound: 404 
+            ValidationError: 400
+            Unauthorized: 401
+            Forbidden: 403
+            NotFound: 404
         """
         resp = await self.client.delete(f"api/base-custom-field-groups/{id}")
-        await raise_planka_err(resp)
+        raise_planka_err(resp)
         return resp.json()
 
-    async def updateBaseCustomFieldGroup(self, id: str, **kwargs: Unpack[Request_updateBaseCustomFieldGroup]) -> Response_updateBaseCustomFieldGroup:
+    async def updateBaseCustomFieldGroup(self, id: str, **kwargs: Unpack[typ.Request_updateBaseCustomFieldGroup]) -> typ.Response_updateBaseCustomFieldGroup:
         """Updates a base custom field group. Requires project manager permissions.
 
         Args:
@@ -337,21 +338,21 @@ class AsyncPlankaEndpoints:
             name (str): Name/title of the base custom field group
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+            If a matching PlankaError exists, it will be raised (see `api.errors`)
             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            Forbidden: 403 
-            NotFound: 404 
+            ValidationError: 400
+            Unauthorized: 401
+            Forbidden: 403
+            NotFound: 404
         """
         resp = await self.client.patch(f"api/base-custom-field-groups/{id}", json=kwargs)
-        await raise_planka_err(resp)
+        raise_planka_err(resp)
         return resp.json()
 
-    async def createBoardMembership(self, boardId: str, **kwargs: Unpack[Request_createBoardMembership]) -> Response_createBoardMembership:
+    async def createBoardMembership(self, boardId: str, **kwargs: Unpack[typ.Request_createBoardMembership]) -> typ.Response_createBoardMembership:
         """Creates a board membership within a board. Requires project manager permissions.
 
         Args:
@@ -361,42 +362,42 @@ class AsyncPlankaEndpoints:
             canComment (bool | None): Whether the user can comment on cards (applies only to viewers)
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+            If a matching PlankaError exists, it will be raised (see `api.errors`)
             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            Forbidden: 403 
-            NotFound: 404 
-            Conflict: 409 
+            ValidationError: 400
+            Unauthorized: 401
+            Forbidden: 403
+            NotFound: 404
+            Conflict: 409
         """
         resp = await self.client.post(f"api/boards/{boardId}/board-memberships", json=kwargs)
-        await raise_planka_err(resp)
+        raise_planka_err(resp)
         return resp.json()
 
-    async def deleteBoardMembership(self, id: str) -> Response_deleteBoardMembership:
+    async def deleteBoardMembership(self, id: str) -> typ.Response_deleteBoardMembership:
         """Deletes a board membership. Users can remove their own membership, project managers can remove any membership.
 
         Args:
             id (str): ID of the board membership to delete)
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+            If a matching PlankaError exists, it will be raised (see `api.errors`)
             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            NotFound: 404 
+            ValidationError: 400
+            Unauthorized: 401
+            NotFound: 404
         """
         resp = await self.client.delete(f"api/board-memberships/{id}")
-        await raise_planka_err(resp)
+        raise_planka_err(resp)
         return resp.json()
 
-    async def updateBoardMembership(self, id: str, **kwargs: Unpack[Request_updateBoardMembership]) -> Response_updateBoardMembership:
+    async def updateBoardMembership(self, id: str, **kwargs: Unpack[typ.Request_updateBoardMembership]) -> typ.Response_updateBoardMembership:
         """Updates a board membership. Requires project manager permissions.
 
         Args:
@@ -405,20 +406,20 @@ class AsyncPlankaEndpoints:
             canComment (bool | None): Whether the user can comment on cards (applies only to viewers)
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+            If a matching PlankaError exists, it will be raised (see `api.errors`)
             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            NotFound: 404 
+            ValidationError: 400
+            Unauthorized: 401
+            NotFound: 404
         """
         resp = await self.client.patch(f"api/board-memberships/{id}", json=kwargs)
-        await raise_planka_err(resp)
+        raise_planka_err(resp)
         return resp.json()
 
-    async def createBoard(self, projectId: str, **kwargs: Unpack[Request_createBoard]) -> Response_createBoard:
+    async def createBoard(self, projectId: str, **kwargs: Unpack[typ.Request_createBoard]) -> typ.Response_createBoard:
         """Creates a board within a project. Supports importing from Trello. Requires project manager permissions.
 
         Args:
@@ -430,41 +431,41 @@ class AsyncPlankaEndpoints:
             requestId (str): Request ID for tracking
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+            If a matching PlankaError exists, it will be raised (see `api.errors`)
             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            NotFound: 404 
+            ValidationError: 400
+            Unauthorized: 401
+            NotFound: 404
             Error: 422 Import file upload error
         """
         resp = await self.client.post(f"api/projects/{projectId}/boards", json=kwargs)
-        await raise_planka_err(resp)
+        raise_planka_err(resp)
         return resp.json()
 
-    async def deleteBoard(self, id: str) -> Response_deleteBoard:
+    async def deleteBoard(self, id: str) -> typ.Response_deleteBoard:
         """Deletes a board and all its contents (lists, cards, etc.). Requires project manager permissions.
 
         Args:
             id (str): ID of the board to delete)
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+            If a matching PlankaError exists, it will be raised (see `api.errors`)
             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            NotFound: 404 
+            ValidationError: 400
+            Unauthorized: 401
+            NotFound: 404
         """
         resp = await self.client.delete(f"api/boards/{id}")
-        await raise_planka_err(resp)
+        raise_planka_err(resp)
         return resp.json()
 
-    async def getBoard(self, id: str, **kwargs: Unpack[Request_getBoard]) -> Response_getBoard:
+    async def getBoard(self, id: str, **kwargs: Unpack[typ.Request_getBoard]) -> typ.Response_getBoard:
         """Retrieves comprehensive board information, including lists, cards, and other related data.
 
         Args:
@@ -472,22 +473,22 @@ class AsyncPlankaEndpoints:
             subscribe (bool): Whether to subscribe to real-time updates for this board (only for socket connections)) (optional)
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+            If a matching PlankaError exists, it will be raised (see `api.errors`)
             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            NotFound: 404 
+            ValidationError: 400
+            Unauthorized: 401
+            NotFound: 404
         """
         valid_params = ('subscribe',)
         passed_params = {k: v for k, v in kwargs.items() if k in valid_params if isinstance(v, str | int | float)}
         resp = await self.client.get(f"api/boards/{id}", params=passed_params)
-        await raise_planka_err(resp)
+        raise_planka_err(resp)
         return resp.json()
 
-    async def updateBoard(self, id: str, **kwargs: Unpack[Request_updateBoard]) -> Response_updateBoard:
+    async def updateBoard(self, id: str, **kwargs: Unpack[typ.Request_updateBoard]) -> typ.Response_updateBoard:
         """Updates a board. Project managers can update all fields, board members can only subscribe/unsubscribe.
 
         Args:
@@ -502,27 +503,27 @@ class AsyncPlankaEndpoints:
             isSubscribed (bool): Whether the current user is subscribed to the board
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+            If a matching PlankaError exists, it will be raised (see `api.errors`)
             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            NotFound: 404 
+            ValidationError: 400
+            Unauthorized: 401
+            NotFound: 404
         """
         resp = await self.client.patch(f"api/boards/{id}", json=kwargs)
-        await raise_planka_err(resp)
+        raise_planka_err(resp)
         return resp.json()
 
-    async def getBootstrap(self) -> Response_getBootstrap:
+    async def getBootstrap(self) -> typ.Response_getBootstrap:
         """Retrieves the application bootstrap.
         """
         resp = await self.client.get("api/bootstrap")
-        await raise_planka_err(resp)
+        raise_planka_err(resp)
         return resp.json()
 
-    async def createCardLabel(self, cardId: str, **kwargs: Unpack[Request_createCardLabel]) -> Response_createCardLabel:
+    async def createCardLabel(self, cardId: str, **kwargs: Unpack[typ.Request_createCardLabel]) -> typ.Response_createCardLabel:
         """Adds a label to a card. Requires board editor permissions.
 
         Args:
@@ -530,22 +531,22 @@ class AsyncPlankaEndpoints:
             labelId (str): ID of the label to add to the card
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+            If a matching PlankaError exists, it will be raised (see `api.errors`)
             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            Forbidden: 403 
-            NotFound: 404 
-            Conflict: 409 
+            ValidationError: 400
+            Unauthorized: 401
+            Forbidden: 403
+            NotFound: 404
+            Conflict: 409
         """
         resp = await self.client.post(f"api/cards/{cardId}/card-labels", json=kwargs)
-        await raise_planka_err(resp)
+        raise_planka_err(resp)
         return resp.json()
 
-    async def deleteCardLabel(self, cardId: str, labelId: str) -> Response_deleteCardLabel:
+    async def deleteCardLabel(self, cardId: str, labelId: str) -> typ.Response_deleteCardLabel:
         """Removes a label from a card. Requires board editor permissions.
 
         Args:
@@ -553,21 +554,21 @@ class AsyncPlankaEndpoints:
             labelId (str): ID of the label to remove from the card)
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+            If a matching PlankaError exists, it will be raised (see `api.errors`)
             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            Forbidden: 403 
-            NotFound: 404 
+            ValidationError: 400
+            Unauthorized: 401
+            Forbidden: 403
+            NotFound: 404
         """
         resp = await self.client.delete(f"api/cards/{cardId}/card-labels/labelId:{labelId}")
-        await raise_planka_err(resp)
+        raise_planka_err(resp)
         return resp.json()
 
-    async def createCardMembership(self, cardId: str, **kwargs: Unpack[Request_createCardMembership]) -> Response_createCardMembership:
+    async def createCardMembership(self, cardId: str, **kwargs: Unpack[typ.Request_createCardMembership]) -> typ.Response_createCardMembership:
         """Adds a user to a card. Requires board editor permissions.
 
         Args:
@@ -575,22 +576,22 @@ class AsyncPlankaEndpoints:
             userId (str): ID of the card to add the user to
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+            If a matching PlankaError exists, it will be raised (see `api.errors`)
             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            Forbidden: 403 
-            NotFound: 404 
-            Conflict: 409 
+            ValidationError: 400
+            Unauthorized: 401
+            Forbidden: 403
+            NotFound: 404
+            Conflict: 409
         """
         resp = await self.client.post(f"api/cards/{cardId}/card-memberships", json=kwargs)
-        await raise_planka_err(resp)
+        raise_planka_err(resp)
         return resp.json()
 
-    async def deleteCardMembership(self, cardId: str, userId: str) -> Response_deleteCardMembership:
+    async def deleteCardMembership(self, cardId: str, userId: str) -> typ.Response_deleteCardMembership:
         """Removes a user from a card. Requires board editor permissions.
 
         Args:
@@ -598,21 +599,21 @@ class AsyncPlankaEndpoints:
             userId (str): ID of the user to remove from the card)
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+            If a matching PlankaError exists, it will be raised (see `api.errors`)
             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            Forbidden: 403 
-            NotFound: 404 
+            ValidationError: 400
+            Unauthorized: 401
+            Forbidden: 403
+            NotFound: 404
         """
         resp = await self.client.delete(f"api/cards/{cardId}/card-memberships/userId:{userId}")
-        await raise_planka_err(resp)
+        raise_planka_err(resp)
         return resp.json()
 
-    async def createCard(self, listId: str, **kwargs: Unpack[Request_createCard]) -> Response_createCard:
+    async def createCard(self, listId: str, **kwargs: Unpack[typ.Request_createCard]) -> typ.Response_createCard:
         """Creates a card within a list. Requires board editor permissions.
 
         Args:
@@ -626,22 +627,22 @@ class AsyncPlankaEndpoints:
             stopwatch (dict[str, Any] | None): Stopwatch data for time tracking
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+            If a matching PlankaError exists, it will be raised (see `api.errors`)
             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            Forbidden: 403 
-            NotFound: 404 
-            UnprocessableEntity: 422 
+            ValidationError: 400
+            Unauthorized: 401
+            Forbidden: 403
+            NotFound: 404
+            UnprocessableEntity: 422
         """
         resp = await self.client.post(f"api/lists/{listId}/cards", json=kwargs)
-        await raise_planka_err(resp)
+        raise_planka_err(resp)
         return resp.json()
 
-    async def getCards(self, listId: str, **kwargs: Unpack[Request_getCards]) -> Response_getCards:
+    async def getCards(self, listId: str, **kwargs: Unpack[typ.Request_getCards]) -> typ.Response_getCards:
         """Retrieves cards from an endless list with filtering, search, and pagination support.
 
         Args:
@@ -653,63 +654,63 @@ class AsyncPlankaEndpoints:
             labelIds (str): Comma-separated label IDs to filter by labels) (optional)
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+            If a matching PlankaError exists, it will be raised (see `api.errors`)
             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            NotFound: 404 
+            ValidationError: 400
+            Unauthorized: 401
+            NotFound: 404
         """
         valid_params = ('before[listChangedAt]', 'before[id]', 'search', 'userIds', 'labelIds')
         passed_params = {k: v for k, v in kwargs.items() if k in valid_params if isinstance(v, str | int | float)}
         resp = await self.client.get(f"api/lists/{listId}/cards", params=passed_params)
-        await raise_planka_err(resp)
+        raise_planka_err(resp)
         return resp.json()
 
-    async def deleteCard(self, id: str) -> Response_deleteCard:
+    async def deleteCard(self, id: str) -> typ.Response_deleteCard:
         """Deletes a card and all its contents (tasks, attachments, etc.). Requires board editor permissions.
 
         Args:
             id (str): ID of the card to delete)
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+            If a matching PlankaError exists, it will be raised (see `api.errors`)
             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            Forbidden: 403 
-            NotFound: 404 
+            ValidationError: 400
+            Unauthorized: 401
+            Forbidden: 403
+            NotFound: 404
         """
         resp = await self.client.delete(f"api/cards/{id}")
-        await raise_planka_err(resp)
+        raise_planka_err(resp)
         return resp.json()
 
-    async def getCard(self, id: str) -> Response_getCard:
+    async def getCard(self, id: str) -> typ.Response_getCard:
         """Retrieves comprehensive card information, including tasks, attachments, and other related data.
 
         Args:
             id (str): ID of the card to retrieve)
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+            If a matching PlankaError exists, it will be raised (see `api.errors`)
             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            NotFound: 404 
+            ValidationError: 400
+            Unauthorized: 401
+            NotFound: 404
         """
         resp = await self.client.get(f"api/cards/{id}")
-        await raise_planka_err(resp)
+        raise_planka_err(resp)
         return resp.json()
 
-    async def updateCard(self, id: str, **kwargs: Unpack[Request_updateCard]) -> Response_updateCard:
+    async def updateCard(self, id: str, **kwargs: Unpack[typ.Request_updateCard]) -> typ.Response_updateCard:
         """Updates a card. Board editors can update all fields, viewers can only subscribe/unsubscribe.
 
         Args:
@@ -727,22 +728,22 @@ class AsyncPlankaEndpoints:
             isSubscribed (bool): Whether the current user is subscribed to the card
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+            If a matching PlankaError exists, it will be raised (see `api.errors`)
             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            Forbidden: 403 
-            NotFound: 404 
-            UnprocessableEntity: 422 
+            ValidationError: 400
+            Unauthorized: 401
+            Forbidden: 403
+            NotFound: 404
+            UnprocessableEntity: 422
         """
         resp = await self.client.patch(f"api/cards/{id}", json=kwargs)
-        await raise_planka_err(resp)
+        raise_planka_err(resp)
         return resp.json()
 
-    async def duplicateCard(self, id: str, **kwargs: Unpack[Request_duplicateCard]) -> Response_duplicateCard:
+    async def duplicateCard(self, id: str, **kwargs: Unpack[typ.Request_duplicateCard]) -> typ.Response_duplicateCard:
         """Creates a duplicate of a card with all its contents (tasks, attachments, etc.). Requires board editor permissions.
 
         Args:
@@ -753,42 +754,42 @@ class AsyncPlankaEndpoints:
             name (str | None): Name/title for the duplicated card
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+            If a matching PlankaError exists, it will be raised (see `api.errors`)
             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            Forbidden: 403 
-            NotFound: 404 
-            UnprocessableEntity: 422 
+            ValidationError: 400
+            Unauthorized: 401
+            Forbidden: 403
+            NotFound: 404
+            UnprocessableEntity: 422
         """
         resp = await self.client.post(f"api/cards/{id}/duplicate", json=kwargs)
-        await raise_planka_err(resp)
+        raise_planka_err(resp)
         return resp.json()
 
-    async def readCardNotifications(self, id: str) -> Response_readCardNotifications:
+    async def readCardNotifications(self, id: str) -> typ.Response_readCardNotifications:
         """Marks all notifications for a specific card as read for the current user. Requires access to the card.
 
         Args:
             id (str): ID of the card to mark notifications as read for)
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+            If a matching PlankaError exists, it will be raised (see `api.errors`)
             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            NotFound: 404 
+            ValidationError: 400
+            Unauthorized: 401
+            NotFound: 404
         """
         resp = await self.client.post(f"api/cards/{id}/read-notifications")
-        await raise_planka_err(resp)
+        raise_planka_err(resp)
         return resp.json()
 
-    async def createComment(self, cardId: str, **kwargs: Unpack[Request_createComment]) -> Response_createComment:
+    async def createComment(self, cardId: str, **kwargs: Unpack[typ.Request_createComment]) -> typ.Response_createComment:
         """Creates a new comment on a card. Requires board editor permissions or comment permissions.
 
         Args:
@@ -796,21 +797,21 @@ class AsyncPlankaEndpoints:
             text (str): Content of the comment
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+            If a matching PlankaError exists, it will be raised (see `api.errors`)
             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            Forbidden: 403 
-            NotFound: 404 
+            ValidationError: 400
+            Unauthorized: 401
+            Forbidden: 403
+            NotFound: 404
         """
         resp = await self.client.post(f"api/cards/{cardId}/comments", json=kwargs)
-        await raise_planka_err(resp)
+        raise_planka_err(resp)
         return resp.json()
 
-    async def getComments(self, cardId: str, **kwargs: Unpack[Request_getComments]) -> Response_getComments:
+    async def getComments(self, cardId: str, **kwargs: Unpack[typ.Request_getComments]) -> typ.Response_getComments:
         """Retrieves comments for a card with pagination support. Requires access to the card.
 
         Args:
@@ -818,43 +819,43 @@ class AsyncPlankaEndpoints:
             beforeId (str): ID to get comments before (for pagination)) (optional)
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+            If a matching PlankaError exists, it will be raised (see `api.errors`)
             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            NotFound: 404 
+            ValidationError: 400
+            Unauthorized: 401
+            NotFound: 404
         """
         valid_params = ('beforeId',)
         passed_params = {k: v for k, v in kwargs.items() if k in valid_params if isinstance(v, str | int | float)}
         resp = await self.client.get(f"api/cards/{cardId}/comments", params=passed_params)
-        await raise_planka_err(resp)
+        raise_planka_err(resp)
         return resp.json()
 
-    async def deleteComment(self, id: str) -> Response_deleteComment:
+    async def deleteComment(self, id: str) -> typ.Response_deleteComment:
         """Deletes a comment. Can be deleted by the comment author (with comment permissions) or project manager.
 
         Args:
             id (str): ID of the comment to delete)
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+            If a matching PlankaError exists, it will be raised (see `api.errors`)
             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            Forbidden: 403 
-            NotFound: 404 
+            ValidationError: 400
+            Unauthorized: 401
+            Forbidden: 403
+            NotFound: 404
         """
         resp = await self.client.delete(f"api/comments/{id}")
-        await raise_planka_err(resp)
+        raise_planka_err(resp)
         return resp.json()
 
-    async def updateComments(self, id: str, **kwargs: Unpack[Request_updateComments]) -> Response_updateComments:
+    async def updateComments(self, id: str, **kwargs: Unpack[typ.Request_updateComments]) -> typ.Response_updateComments:
         """Updates a comment. Only the author of the comment can update it.
 
         Args:
@@ -862,28 +863,28 @@ class AsyncPlankaEndpoints:
             text (str): Content of the comment
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+            If a matching PlankaError exists, it will be raised (see `api.errors`)
             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            Forbidden: 403 
-            NotFound: 404 
+            ValidationError: 400
+            Unauthorized: 401
+            Forbidden: 403
+            NotFound: 404
         """
         resp = await self.client.patch(f"api/comments/{id}", json=kwargs)
-        await raise_planka_err(resp)
+        raise_planka_err(resp)
         return resp.json()
 
-    async def getConfig(self) -> Response_getConfig:
+    async def getConfig(self) -> typ.Response_getConfig:
         """Retrieves the application configuration. Requires admin privileges.
         """
         resp = await self.client.get("api/config")
-        await raise_planka_err(resp)
+        raise_planka_err(resp)
         return resp.json()
 
-    async def updateConfig(self, **kwargs: Unpack[Request_updateConfig]) -> Response_updateConfig:
+    async def updateConfig(self, **kwargs: Unpack[typ.Request_updateConfig]) -> typ.Response_updateConfig:
         """Updates the application configuration. Requires admin privileges.
 
         Args:
@@ -897,26 +898,26 @@ class AsyncPlankaEndpoints:
             smtpFrom (str | None): Default "from" used for outgoing SMTP emails
         """
         resp = await self.client.patch("api/config", json=kwargs)
-        await raise_planka_err(resp)
+        raise_planka_err(resp)
         return resp.json()
 
-    async def testSmtpConfig(self) -> Response_testSmtpConfig:
+    async def testSmtpConfig(self) -> typ.Response_testSmtpConfig:
         """Sends a test email to verify the SMTP is configured correctly. Only available when SMTP is configured via the UI.
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+            If a matching PlankaError exists, it will be raised (see `api.errors`)
             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            Unauthorized: 401 
-            Forbidden: 403 
+            Unauthorized: 401
+            Forbidden: 403
         """
         resp = await self.client.post("api/config/test-smtp")
-        await raise_planka_err(resp)
+        raise_planka_err(resp)
         return resp.json()
 
-    async def createBoardCustomFieldGroup(self, boardId: str, **kwargs: Unpack[Request_createBoardCustomFieldGroup]) -> Response_createBoardCustomFieldGroup:
+    async def createBoardCustomFieldGroup(self, boardId: str, **kwargs: Unpack[typ.Request_createBoardCustomFieldGroup]) -> typ.Response_createBoardCustomFieldGroup:
         """Creates a custom field group within a board. Either `baseCustomFieldGroupId` or `name` must be provided. Requires board editor permissions.
 
         Args:
@@ -926,22 +927,22 @@ class AsyncPlankaEndpoints:
             name (str | None): Name/title of the custom field group (required if `baseCustomFieldGroupId` is not provided)
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+            If a matching PlankaError exists, it will be raised (see `api.errors`)
             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            Forbidden: 403 
-            NotFound: 404 
-            UnprocessableEntity: 422 
+            ValidationError: 400
+            Unauthorized: 401
+            Forbidden: 403
+            NotFound: 404
+            UnprocessableEntity: 422
         """
         resp = await self.client.post(f"api/boards/{boardId}/custom-field-groups", json=kwargs)
-        await raise_planka_err(resp)
+        raise_planka_err(resp)
         return resp.json()
 
-    async def createCardCustomFieldGroup(self, cardId: str, **kwargs: Unpack[Request_createCardCustomFieldGroup]) -> Response_createCardCustomFieldGroup:
+    async def createCardCustomFieldGroup(self, cardId: str, **kwargs: Unpack[typ.Request_createCardCustomFieldGroup]) -> typ.Response_createCardCustomFieldGroup:
         """Creates a custom field group within a card. Either `baseCustomFieldGroupId` or `name` must be provided. Requires board editor permissions.
 
         Args:
@@ -951,63 +952,63 @@ class AsyncPlankaEndpoints:
             name (str | None): Name/title of the custom field group (required if `baseCustomFieldGroupId` is not provided)
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+            If a matching PlankaError exists, it will be raised (see `api.errors`)
             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            Forbidden: 403 
-            NotFound: 404 
-            UnprocessableEntity: 422 
+            ValidationError: 400
+            Unauthorized: 401
+            Forbidden: 403
+            NotFound: 404
+            UnprocessableEntity: 422
         """
         resp = await self.client.post(f"api/cards/{cardId}/custom-field-groups", json=kwargs)
-        await raise_planka_err(resp)
+        raise_planka_err(resp)
         return resp.json()
 
-    async def deleteCustomFieldGroup(self, id: str) -> Response_deleteCustomFieldGroup:
+    async def deleteCustomFieldGroup(self, id: str) -> typ.Response_deleteCustomFieldGroup:
         """Deletes a custom field group. Requires board editor permissions.
 
         Args:
             id (str): ID of the custom field group to delete)
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+            If a matching PlankaError exists, it will be raised (see `api.errors`)
             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            Forbidden: 403 
-            NotFound: 404 
+            ValidationError: 400
+            Unauthorized: 401
+            Forbidden: 403
+            NotFound: 404
         """
         resp = await self.client.delete(f"api/custom-field-groups/{id}")
-        await raise_planka_err(resp)
+        raise_planka_err(resp)
         return resp.json()
 
-    async def getCustomFieldGroup(self, id: str) -> Response_getCustomFieldGroup:
+    async def getCustomFieldGroup(self, id: str) -> typ.Response_getCustomFieldGroup:
         """Retrieves comprehensive custom field group information, including fields and values. Requires access to the board/card.
 
         Args:
             id (str): ID of the custom field group to retrieve)
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+            If a matching PlankaError exists, it will be raised (see `api.errors`)
             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            NotFound: 404 
+            ValidationError: 400
+            Unauthorized: 401
+            NotFound: 404
         """
         resp = await self.client.get(f"api/custom-field-groups/{id}")
-        await raise_planka_err(resp)
+        raise_planka_err(resp)
         return resp.json()
 
-    async def updateCustomFieldGroup(self, id: str, **kwargs: Unpack[Request_updateCustomFieldGroup]) -> Response_updateCustomFieldGroup:
+    async def updateCustomFieldGroup(self, id: str, **kwargs: Unpack[typ.Request_updateCustomFieldGroup]) -> typ.Response_updateCustomFieldGroup:
         """Updates a custom field group. Supports both board-wide and card-specific groups. Requires board editor permissions.
 
         Args:
@@ -1016,22 +1017,22 @@ class AsyncPlankaEndpoints:
             name (str | None): Name/title of the custom field group
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+            If a matching PlankaError exists, it will be raised (see `api.errors`)
             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            Forbidden: 403 
-            NotFound: 404 
-            UnprocessableEntity: 422 
+            ValidationError: 400
+            Unauthorized: 401
+            Forbidden: 403
+            NotFound: 404
+            UnprocessableEntity: 422
         """
         resp = await self.client.patch(f"api/custom-field-groups/{id}", json=kwargs)
-        await raise_planka_err(resp)
+        raise_planka_err(resp)
         return resp.json()
 
-    async def updateCustomFieldValue(self, cardId: str, customFieldGroupId: str, customFieldId: str, **kwargs: Unpack[Request_updateCustomFieldValue]) -> Response_updateCustomFieldValue:
+    async def updateCustomFieldValue(self, cardId: str, customFieldGroupId: str, customFieldId: str, **kwargs: Unpack[typ.Request_updateCustomFieldValue]) -> typ.Response_updateCustomFieldValue:
         """Creates or updates a custom field value for a card. Requires board editor permissions.
 
         Args:
@@ -1041,21 +1042,21 @@ class AsyncPlankaEndpoints:
             content (str): Content/value of the custom field
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+            If a matching PlankaError exists, it will be raised (see `api.errors`)
             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            Forbidden: 403 
-            NotFound: 404 
+            ValidationError: 400
+            Unauthorized: 401
+            Forbidden: 403
+            NotFound: 404
         """
         resp = await self.client.patch(f"api/cards/{cardId}/custom-field-values/customFieldGroupId:{customFieldGroupId}:customFieldId:{customFieldId}", json=kwargs)
-        await raise_planka_err(resp)
+        raise_planka_err(resp)
         return resp.json()
 
-    async def deleteCustomFieldValue(self, cardId: str, customFieldGroupId: str, customFieldId: str) -> Response_deleteCustomFieldValue:
+    async def deleteCustomFieldValue(self, cardId: str, customFieldGroupId: str, customFieldId: str) -> typ.Response_deleteCustomFieldValue:
         """Deletes a custom field value for a specific card. Requires board editor permissions.
 
         Args:
@@ -1064,21 +1065,21 @@ class AsyncPlankaEndpoints:
             customFieldId (str): ID of the custom field the value belongs to)
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+            If a matching PlankaError exists, it will be raised (see `api.errors`)
             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            Forbidden: 403 
-            NotFound: 404 
+            ValidationError: 400
+            Unauthorized: 401
+            Forbidden: 403
+            NotFound: 404
         """
         resp = await self.client.delete(f"api/cards/{cardId}/custom-field-value/customFieldGroupId:{customFieldGroupId}:customFieldId:{customFieldId}")
-        await raise_planka_err(resp)
+        raise_planka_err(resp)
         return resp.json()
 
-    async def createCustomFieldInBaseGroup(self, baseCustomFieldGroupId: str, **kwargs: Unpack[Request_createCustomFieldInBaseGroup]) -> Response_createCustomFieldInBaseGroup:
+    async def createCustomFieldInBaseGroup(self, baseCustomFieldGroupId: str, **kwargs: Unpack[typ.Request_createCustomFieldInBaseGroup]) -> typ.Response_createCustomFieldInBaseGroup:
         """Creates a custom field within a base custom field group. Requires project manager permissions.
 
         Args:
@@ -1088,20 +1089,20 @@ class AsyncPlankaEndpoints:
             showOnFrontOfCard (bool): Whether to show the field on the front of cards
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+            If a matching PlankaError exists, it will be raised (see `api.errors`)
             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            NotFound: 404 
+            ValidationError: 400
+            Unauthorized: 401
+            NotFound: 404
         """
         resp = await self.client.post(f"api/base-custom-field-groups/{baseCustomFieldGroupId}/custom-fields", json=kwargs)
-        await raise_planka_err(resp)
+        raise_planka_err(resp)
         return resp.json()
 
-    async def createCustomFieldInGroup(self, customFieldGroupId: str, **kwargs: Unpack[Request_createCustomFieldInGroup]) -> Response_createCustomFieldInGroup:
+    async def createCustomFieldInGroup(self, customFieldGroupId: str, **kwargs: Unpack[typ.Request_createCustomFieldInGroup]) -> typ.Response_createCustomFieldInGroup:
         """Creates a custom field within a custom field group. Requires board editor permissions.
 
         Args:
@@ -1111,42 +1112,42 @@ class AsyncPlankaEndpoints:
             showOnFrontOfCard (bool): Whether to show the field on the front of cards
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+            If a matching PlankaError exists, it will be raised (see `api.errors`)
             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            Forbidden: 403 
-            NotFound: 404 
+            ValidationError: 400
+            Unauthorized: 401
+            Forbidden: 403
+            NotFound: 404
         """
         resp = await self.client.post(f"api/custom-field-groups/{customFieldGroupId}/custom-fields", json=kwargs)
-        await raise_planka_err(resp)
+        raise_planka_err(resp)
         return resp.json()
 
-    async def deleteCustomField(self, id: str) -> Response_deleteCustomField:
+    async def deleteCustomField(self, id: str) -> typ.Response_deleteCustomField:
         """Deletes a custom field. Can delete the in base custom field group (requires project manager permissions) or the custom field group (requires board editor permissions).
 
         Args:
             id (str): ID of the custom field to delete)
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+            If a matching PlankaError exists, it will be raised (see `api.errors`)
             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            Forbidden: 403 
-            NotFound: 404 
+            ValidationError: 400
+            Unauthorized: 401
+            Forbidden: 403
+            NotFound: 404
         """
         resp = await self.client.delete(f"api/custom-fields/{id}")
-        await raise_planka_err(resp)
+        raise_planka_err(resp)
         return resp.json()
 
-    async def updateCustomField(self, id: str, **kwargs: Unpack[Request_updateCustomField]) -> Response_updateCustomField:
+    async def updateCustomField(self, id: str, **kwargs: Unpack[typ.Request_updateCustomField]) -> typ.Response_updateCustomField:
         """Updates a custom field. Can update in the base custom field group (requires project manager permissions) or the custom field group (requires board editor permissions).
 
         Args:
@@ -1156,21 +1157,21 @@ class AsyncPlankaEndpoints:
             showOnFrontOfCard (bool): Whether to show the field on the front of cards
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+            If a matching PlankaError exists, it will be raised (see `api.errors`)
             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            Forbidden: 403 
-            NotFound: 404 
+            ValidationError: 400
+            Unauthorized: 401
+            Forbidden: 403
+            NotFound: 404
         """
         resp = await self.client.patch(f"api/custom-fields/{id}", json=kwargs)
-        await raise_planka_err(resp)
+        raise_planka_err(resp)
         return resp.json()
 
-    async def createLabel(self, boardId: str, **kwargs: Unpack[Request_createLabel]) -> Response_createLabel:
+    async def createLabel(self, boardId: str, **kwargs: Unpack[typ.Request_createLabel]) -> typ.Response_createLabel:
         """Creates a label within a board. Requires board editor permissions.
 
         Args:
@@ -1180,42 +1181,42 @@ class AsyncPlankaEndpoints:
             color (Literal['muddy-grey', 'autumn-leafs', 'morning-sky', 'antique-blue', 'egg-yellow', 'desert-sand', 'dark-granite', 'fresh-salad', 'lagoon-blue', 'midnight-blue', 'light-orange', 'pumpkin-orange', 'light-concrete', 'sunny-grass', 'navy-blue', 'lilac-eyes', 'apricot-red', 'orange-peel', 'silver-glint', 'bright-moss', 'deep-ocean', 'summer-sky', 'berry-red', 'light-cocoa', 'grey-stone', 'tank-green', 'coral-green', 'sugar-plum', 'pink-tulip', 'shady-rust', 'wet-rock', 'wet-moss', 'turquoise-sea', 'lavender-fields', 'piggy-red', 'light-mud', 'gun-metal', 'modern-green', 'french-coast', 'sweet-lilac', 'red-burgundy', 'pirate-gold']): Color of the label
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+            If a matching PlankaError exists, it will be raised (see `api.errors`)
             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            Forbidden: 403 
-            NotFound: 404 
+            ValidationError: 400
+            Unauthorized: 401
+            Forbidden: 403
+            NotFound: 404
         """
         resp = await self.client.post(f"api/boards/{boardId}/labels", json=kwargs)
-        await raise_planka_err(resp)
+        raise_planka_err(resp)
         return resp.json()
 
-    async def deleteLabel(self, id: str) -> Response_deleteLabel:
+    async def deleteLabel(self, id: str) -> typ.Response_deleteLabel:
         """Deletes a label. Requires board editor permissions.
 
         Args:
             id (str): ID of the label to delete)
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+            If a matching PlankaError exists, it will be raised (see `api.errors`)
             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            Forbidden: 403 
-            NotFound: 404 
+            ValidationError: 400
+            Unauthorized: 401
+            Forbidden: 403
+            NotFound: 404
         """
         resp = await self.client.delete(f"api/labels/{id}")
-        await raise_planka_err(resp)
+        raise_planka_err(resp)
         return resp.json()
 
-    async def updateLabel(self, id: str, **kwargs: Unpack[Request_updateLabel]) -> Response_updateLabel:
+    async def updateLabel(self, id: str, **kwargs: Unpack[typ.Request_updateLabel]) -> typ.Response_updateLabel:
         """Updates a label. Requires board editor permissions.
 
         Args:
@@ -1225,42 +1226,42 @@ class AsyncPlankaEndpoints:
             color (Literal['muddy-grey', 'autumn-leafs', 'morning-sky', 'antique-blue', 'egg-yellow', 'desert-sand', 'dark-granite', 'fresh-salad', 'lagoon-blue', 'midnight-blue', 'light-orange', 'pumpkin-orange', 'light-concrete', 'sunny-grass', 'navy-blue', 'lilac-eyes', 'apricot-red', 'orange-peel', 'silver-glint', 'bright-moss', 'deep-ocean', 'summer-sky', 'berry-red', 'light-cocoa', 'grey-stone', 'tank-green', 'coral-green', 'sugar-plum', 'pink-tulip', 'shady-rust', 'wet-rock', 'wet-moss', 'turquoise-sea', 'lavender-fields', 'piggy-red', 'light-mud', 'gun-metal', 'modern-green', 'french-coast', 'sweet-lilac', 'red-burgundy', 'pirate-gold']): Color of the label
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+            If a matching PlankaError exists, it will be raised (see `api.errors`)
             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            Forbidden: 403 
-            NotFound: 404 
+            ValidationError: 400
+            Unauthorized: 401
+            Forbidden: 403
+            NotFound: 404
         """
         resp = await self.client.patch(f"api/labels/{id}", json=kwargs)
-        await raise_planka_err(resp)
+        raise_planka_err(resp)
         return resp.json()
 
-    async def clearList(self, id: str) -> Response_clearList:
+    async def clearList(self, id: str) -> typ.Response_clearList:
         """Deletes all cards from a list. Only works with trash-type lists. Requires project manager or board editor permissions.
 
         Args:
             id (str): ID of the list to clear (must be a trash-type list))
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+            If a matching PlankaError exists, it will be raised (see `api.errors`)
             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            Forbidden: 403 
-            NotFound: 404 
+            ValidationError: 400
+            Unauthorized: 401
+            Forbidden: 403
+            NotFound: 404
         """
         resp = await self.client.post(f"api/lists/{id}/clear")
-        await raise_planka_err(resp)
+        raise_planka_err(resp)
         return resp.json()
 
-    async def createList(self, boardId: str, **kwargs: Unpack[Request_createList]) -> Response_createList:
+    async def createList(self, boardId: str, **kwargs: Unpack[typ.Request_createList]) -> typ.Response_createList:
         """Creates a list within a board. Requires board editor permissions.
 
         Args:
@@ -1270,62 +1271,62 @@ class AsyncPlankaEndpoints:
             name (str): Name/title of the list
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+            If a matching PlankaError exists, it will be raised (see `api.errors`)
             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            Forbidden: 403 
-            NotFound: 404 
+            ValidationError: 400
+            Unauthorized: 401
+            Forbidden: 403
+            NotFound: 404
         """
         resp = await self.client.post(f"api/boards/{boardId}/lists", json=kwargs)
-        await raise_planka_err(resp)
+        raise_planka_err(resp)
         return resp.json()
 
-    async def deleteList(self, id: str) -> Response_deleteList:
+    async def deleteList(self, id: str) -> typ.Response_deleteList:
         """Deletes a list and moves its cards to a trash list. Can only delete finite lists. Requires board editor permissions.
 
         Args:
             id (str): ID of the list to delete)
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+            If a matching PlankaError exists, it will be raised (see `api.errors`)
             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            Forbidden: 403 
-            NotFound: 404 
+            ValidationError: 400
+            Unauthorized: 401
+            Forbidden: 403
+            NotFound: 404
         """
         resp = await self.client.delete(f"api/lists/{id}")
-        await raise_planka_err(resp)
+        raise_planka_err(resp)
         return resp.json()
 
-    async def getList(self, id: str) -> Response_getList:
+    async def getList(self, id: str) -> typ.Response_getList:
         """Retrieves comprehensive list information, including cards, attachments, and other related data. Requires access to the board.
 
         Args:
             id (str): ID of the list to retrieve)
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+            If a matching PlankaError exists, it will be raised (see `api.errors`)
             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            NotFound: 404 
+            ValidationError: 400
+            Unauthorized: 401
+            NotFound: 404
         """
         resp = await self.client.get(f"api/lists/{id}")
-        await raise_planka_err(resp)
+        raise_planka_err(resp)
         return resp.json()
 
-    async def updateList(self, id: str, **kwargs: Unpack[Request_updateList]) -> Response_updateList:
+    async def updateList(self, id: str, **kwargs: Unpack[typ.Request_updateList]) -> typ.Response_updateList:
         """Updates a list. Can move lists between boards. Requires board editor permissions.
 
         Args:
@@ -1337,21 +1338,21 @@ class AsyncPlankaEndpoints:
             color (Literal['berry-red', 'pumpkin-orange', 'lagoon-blue', 'pink-tulip', 'light-mud', 'orange-peel', 'bright-moss', 'antique-blue', 'dark-granite', 'turquoise-sea'] | None): Color for the list
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+            If a matching PlankaError exists, it will be raised (see `api.errors`)
             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            Forbidden: 403 
-            NotFound: 404 
+            ValidationError: 400
+            Unauthorized: 401
+            Forbidden: 403
+            NotFound: 404
         """
         resp = await self.client.patch(f"api/lists/{id}", json=kwargs)
-        await raise_planka_err(resp)
+        raise_planka_err(resp)
         return resp.json()
 
-    async def moveListCards(self, id: str, **kwargs: Unpack[Request_moveListCards]) -> Response_moveListCards:
+    async def moveListCards(self, id: str, **kwargs: Unpack[typ.Request_moveListCards]) -> typ.Response_moveListCards:
         """Moves all cards from a closed list to an archive list. Requires board editor permissions.
 
         Args:
@@ -1359,21 +1360,21 @@ class AsyncPlankaEndpoints:
             listId (str): ID of the target list (must be an archive-type list)
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+            If a matching PlankaError exists, it will be raised (see `api.errors`)
             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            Forbidden: 403 
-            NotFound: 404 
+            ValidationError: 400
+            Unauthorized: 401
+            Forbidden: 403
+            NotFound: 404
         """
         resp = await self.client.post(f"api/lists/{id}/move-cards", json=kwargs)
-        await raise_planka_err(resp)
+        raise_planka_err(resp)
         return resp.json()
 
-    async def sortList(self, id: str, **kwargs: Unpack[Request_sortList]) -> Response_sortList:
+    async def sortList(self, id: str, **kwargs: Unpack[typ.Request_sortList]) -> typ.Response_sortList:
         """Sorts all cards within a list. Requires board editor permissions.
 
         Args:
@@ -1382,22 +1383,22 @@ class AsyncPlankaEndpoints:
             order (Literal['asc', 'desc']): Sorting order
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+            If a matching PlankaError exists, it will be raised (see `api.errors`)
             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            Forbidden: 403 
-            NotFound: 404 
-            UnprocessableEntity: 422 
+            ValidationError: 400
+            Unauthorized: 401
+            Forbidden: 403
+            NotFound: 404
+            UnprocessableEntity: 422
         """
         resp = await self.client.post(f"api/lists/{id}/sort", json=kwargs)
-        await raise_planka_err(resp)
+        raise_planka_err(resp)
         return resp.json()
 
-    async def createBoardNotificationService(self, boardId: str, **kwargs: Unpack[Request_createBoardNotificationService]) -> Response_createBoardNotificationService:
+    async def createBoardNotificationService(self, boardId: str, **kwargs: Unpack[typ.Request_createBoardNotificationService]) -> typ.Response_createBoardNotificationService:
         """Creates a new notification service for a board. Requires project manager permissions.
 
         Args:
@@ -1406,21 +1407,21 @@ class AsyncPlankaEndpoints:
             format (Literal['text', 'markdown', 'html']): Format for notification messages
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+            If a matching PlankaError exists, it will be raised (see `api.errors`)
             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            NotFound: 404 
-            Conflict: 409 
+            ValidationError: 400
+            Unauthorized: 401
+            NotFound: 404
+            Conflict: 409
         """
         resp = await self.client.post(f"api/boards/{boardId}/notification-services", json=kwargs)
-        await raise_planka_err(resp)
+        raise_planka_err(resp)
         return resp.json()
 
-    async def createUserNotificationService(self, userId: str, **kwargs: Unpack[Request_createUserNotificationService]) -> Response_createUserNotificationService:
+    async def createUserNotificationService(self, userId: str, **kwargs: Unpack[typ.Request_createUserNotificationService]) -> typ.Response_createUserNotificationService:
         """Creates a new notification service for a user. Users can only create services for themselves.
 
         Args:
@@ -1429,41 +1430,41 @@ class AsyncPlankaEndpoints:
             format (Literal['text', 'markdown', 'html']): Format for notification messages
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+            If a matching PlankaError exists, it will be raised (see `api.errors`)
             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            NotFound: 404 
-            Conflict: 409 
+            ValidationError: 400
+            Unauthorized: 401
+            NotFound: 404
+            Conflict: 409
         """
         resp = await self.client.post(f"api/users/{userId}/notification-services", json=kwargs)
-        await raise_planka_err(resp)
+        raise_planka_err(resp)
         return resp.json()
 
-    async def deleteNotificationService(self, id: str) -> Response_deleteNotificationService:
+    async def deleteNotificationService(self, id: str) -> typ.Response_deleteNotificationService:
         """Deletes a notification service. Users can delete their own services, project managers can delete board services.
 
         Args:
             id (str): ID of the notification service to delete)
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+            If a matching PlankaError exists, it will be raised (see `api.errors`)
             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            NotFound: 404 
+            ValidationError: 400
+            Unauthorized: 401
+            NotFound: 404
         """
         resp = await self.client.delete(f"api/notification-services/{id}")
-        await raise_planka_err(resp)
+        raise_planka_err(resp)
         return resp.json()
 
-    async def updateNotificationService(self, id: str, **kwargs: Unpack[Request_updateNotificationService]) -> Response_updateNotificationService:
+    async def updateNotificationService(self, id: str, **kwargs: Unpack[typ.Request_updateNotificationService]) -> typ.Response_updateNotificationService:
         """Updates a notification service. Users can update their own services, project managers can update board services.
 
         Args:
@@ -1472,92 +1473,92 @@ class AsyncPlankaEndpoints:
             format (Literal['text', 'markdown', 'html']): Format for notification messages
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+            If a matching PlankaError exists, it will be raised (see `api.errors`)
             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            NotFound: 404 
+            ValidationError: 400
+            Unauthorized: 401
+            NotFound: 404
         """
         resp = await self.client.patch(f"api/notification-services/{id}", json=kwargs)
-        await raise_planka_err(resp)
+        raise_planka_err(resp)
         return resp.json()
 
-    async def testNotificationService(self, id: str) -> Response_testNotificationService:
+    async def testNotificationService(self, id: str) -> typ.Response_testNotificationService:
         """Sends a test notification to verify the notification service is working. Users can test their own services, project managers can test board services.
 
         Args:
             id (str): ID of the notification service to test)
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+            If a matching PlankaError exists, it will be raised (see `api.errors`)
             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            NotFound: 404 
+            ValidationError: 400
+            Unauthorized: 401
+            NotFound: 404
         """
         resp = await self.client.post(f"api/notification-services/{id}/test")
-        await raise_planka_err(resp)
+        raise_planka_err(resp)
         return resp.json()
 
-    async def getNotifications(self) -> Response_getNotifications:
+    async def getNotifications(self) -> typ.Response_getNotifications:
         """Retrieves all unread notifications for the current user, including creator users.
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+            If a matching PlankaError exists, it will be raised (see `api.errors`)
             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
+            ValidationError: 400
+            Unauthorized: 401
         """
         resp = await self.client.get("api/notifications")
-        await raise_planka_err(resp)
+        raise_planka_err(resp)
         return resp.json()
 
-    async def readAllNotifications(self) -> Response_readAllNotifications:
+    async def readAllNotifications(self) -> typ.Response_readAllNotifications:
         """Marks all notifications for the current user as read.
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+            If a matching PlankaError exists, it will be raised (see `api.errors`)
             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
+            ValidationError: 400
+            Unauthorized: 401
         """
         resp = await self.client.post("api/notifications/read-all")
-        await raise_planka_err(resp)
+        raise_planka_err(resp)
         return resp.json()
 
-    async def getNotification(self, id: str) -> Response_getNotification:
+    async def getNotification(self, id: str) -> typ.Response_getNotification:
         """Retrieves notification, including creator users. Users can only access their own notifications.
 
         Args:
             id (str): ID of the notification to retrieve)
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+            If a matching PlankaError exists, it will be raised (see `api.errors`)
             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            NotFound: 404 
+            ValidationError: 400
+            Unauthorized: 401
+            NotFound: 404
         """
         resp = await self.client.get(f"api/notifications/{id}")
-        await raise_planka_err(resp)
+        raise_planka_err(resp)
         return resp.json()
 
-    async def updateNotification(self, id: str, **kwargs: Unpack[Request_updateNotification]) -> Response_updateNotification:
+    async def updateNotification(self, id: str, **kwargs: Unpack[typ.Request_updateNotification]) -> typ.Response_updateNotification:
         """Updates a notification. Users can only update their own notifications.
 
         Args:
@@ -1565,20 +1566,20 @@ class AsyncPlankaEndpoints:
             isRead (bool): Whether the notification has been read
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+            If a matching PlankaError exists, it will be raised (see `api.errors`)
             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            NotFound: 404 
+            ValidationError: 400
+            Unauthorized: 401
+            NotFound: 404
         """
         resp = await self.client.patch(f"api/notifications/{id}", json=kwargs)
-        await raise_planka_err(resp)
+        raise_planka_err(resp)
         return resp.json()
 
-    async def createProjectManager(self, projectId: str, **kwargs: Unpack[Request_createProjectManager]) -> Response_createProjectManager:
+    async def createProjectManager(self, projectId: str, **kwargs: Unpack[typ.Request_createProjectManager]) -> typ.Response_createProjectManager:
         """Creates a project manager within a project. Requires admin privileges for shared projects or existing project manager permissions. The user must be an admin or project owner.
 
         Args:
@@ -1586,45 +1587,45 @@ class AsyncPlankaEndpoints:
             userId (str): ID of the user who is assigned as project manager
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+            If a matching PlankaError exists, it will be raised (see `api.errors`)
             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            Forbidden: 403 
-            NotFound: 404 
-            Conflict: 409 
-            UnprocessableEntity: 422 
+            ValidationError: 400
+            Unauthorized: 401
+            Forbidden: 403
+            NotFound: 404
+            Conflict: 409
+            UnprocessableEntity: 422
         """
         resp = await self.client.post(f"api/projects/{projectId}/project-managers", json=kwargs)
-        await raise_planka_err(resp)
+        raise_planka_err(resp)
         return resp.json()
 
-    async def deleteProjectManager(self, id: str) -> Response_deleteProjectManager:
+    async def deleteProjectManager(self, id: str) -> typ.Response_deleteProjectManager:
         """Deletes a project manager. Requires admin privileges for shared projects or existing project manager permissions. Cannot remove the last project manager.
 
         Args:
             id (str): ID of the project manager to delete)
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+            If a matching PlankaError exists, it will be raised (see `api.errors`)
             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            Forbidden: 403 
-            NotFound: 404 
-            UnprocessableEntity: 422 
+            ValidationError: 400
+            Unauthorized: 401
+            Forbidden: 403
+            NotFound: 404
+            UnprocessableEntity: 422
         """
         resp = await self.client.delete(f"api/project-managers/{id}")
-        await raise_planka_err(resp)
+        raise_planka_err(resp)
         return resp.json()
 
-    async def createProject(self, **kwargs: Unpack[Request_createProject]) -> Response_createProject:
+    async def createProject(self, **kwargs: Unpack[typ.Request_createProject]) -> typ.Response_createProject:
         """Creates a project. The current user automatically becomes a project manager.
 
         Args:
@@ -1633,76 +1634,76 @@ class AsyncPlankaEndpoints:
             description (str | None): Detailed description of the project
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+            If a matching PlankaError exists, it will be raised (see `api.errors`)
             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
+            ValidationError: 400
+            Unauthorized: 401
         """
         resp = await self.client.post("api/projects", json=kwargs)
-        await raise_planka_err(resp)
+        raise_planka_err(resp)
         return resp.json()
 
-    async def getProjects(self) -> Response_getProjects:
+    async def getProjects(self) -> typ.Response_getProjects:
         """Retrieves all projects the current user has access to, including managed projects, membership projects, and shared projects (for admins).
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+            If a matching PlankaError exists, it will be raised (see `api.errors`)
             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
+            ValidationError: 400
+            Unauthorized: 401
         """
         resp = await self.client.get("api/projects")
-        await raise_planka_err(resp)
+        raise_planka_err(resp)
         return resp.json()
 
-    async def deleteProject(self, id: str) -> Response_deleteProject:
+    async def deleteProject(self, id: str) -> typ.Response_deleteProject:
         """Deletes a project. The project must not have any boards. Requires project manager permissions.
 
         Args:
             id (str): ID of the project to delete)
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+            If a matching PlankaError exists, it will be raised (see `api.errors`)
             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            NotFound: 404 
-            UnprocessableEntity: 422 
+            ValidationError: 400
+            Unauthorized: 401
+            NotFound: 404
+            UnprocessableEntity: 422
         """
         resp = await self.client.delete(f"api/projects/{id}")
-        await raise_planka_err(resp)
+        raise_planka_err(resp)
         return resp.json()
 
-    async def getProject(self, id: str) -> Response_getProject:
+    async def getProject(self, id: str) -> typ.Response_getProject:
         """Retrieves comprehensive project information, including boards, board memberships, and other related data.
 
         Args:
             id (str): ID of the project to retrieve)
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+            If a matching PlankaError exists, it will be raised (see `api.errors`)
             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            NotFound: 404 
+            ValidationError: 400
+            Unauthorized: 401
+            NotFound: 404
         """
         resp = await self.client.get(f"api/projects/{id}")
-        await raise_planka_err(resp)
+        raise_planka_err(resp)
         return resp.json()
 
-    async def updateProject(self, id: str, **kwargs: Unpack[Request_updateProject]) -> Response_updateProject:
+    async def updateProject(self, id: str, **kwargs: Unpack[typ.Request_updateProject]) -> typ.Response_updateProject:
         """Updates a project. Accessible fields depend on user permissions.
 
         Args:
@@ -1717,23 +1718,23 @@ class AsyncPlankaEndpoints:
             isFavorite (bool): Whether the project is marked as favorite by the current user
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+            If a matching PlankaError exists, it will be raised (see `api.errors`)
             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            Forbidden: 403 
-            NotFound: 404 
-            Conflict: 409 
-            UnprocessableEntity: 422 
+            ValidationError: 400
+            Unauthorized: 401
+            Forbidden: 403
+            NotFound: 404
+            Conflict: 409
+            UnprocessableEntity: 422
         """
         resp = await self.client.patch(f"api/projects/{id}", json=kwargs)
-        await raise_planka_err(resp)
+        raise_planka_err(resp)
         return resp.json()
 
-    async def createTaskList(self, cardId: str, **kwargs: Unpack[Request_createTaskList]) -> Response_createTaskList:
+    async def createTaskList(self, cardId: str, **kwargs: Unpack[typ.Request_createTaskList]) -> typ.Response_createTaskList:
         """Creates a task list within a card. Requires board editor permissions.
 
         Args:
@@ -1744,62 +1745,62 @@ class AsyncPlankaEndpoints:
             hideCompletedTasks (bool): Whether to hide completed tasks
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+            If a matching PlankaError exists, it will be raised (see `api.errors`)
             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            Forbidden: 403 
-            NotFound: 404 
+            ValidationError: 400
+            Unauthorized: 401
+            Forbidden: 403
+            NotFound: 404
         """
         resp = await self.client.post(f"api/cards/{cardId}/task-lists", json=kwargs)
-        await raise_planka_err(resp)
+        raise_planka_err(resp)
         return resp.json()
 
-    async def deleteTaskList(self, id: str) -> Response_deleteTaskList:
+    async def deleteTaskList(self, id: str) -> typ.Response_deleteTaskList:
         """Deletes a task list and all its tasks. Requires board editor permissions.
 
         Args:
             id (str): ID of the task list to delete)
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+            If a matching PlankaError exists, it will be raised (see `api.errors`)
             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            Forbidden: 403 
-            NotFound: 404 
+            ValidationError: 400
+            Unauthorized: 401
+            Forbidden: 403
+            NotFound: 404
         """
         resp = await self.client.delete(f"api/task-lists/{id}")
-        await raise_planka_err(resp)
+        raise_planka_err(resp)
         return resp.json()
 
-    async def getTaskList(self, id: str) -> Response_getTaskList:
+    async def getTaskList(self, id: str) -> typ.Response_getTaskList:
         """Retrieves task list information, including tasks. Requires access to the card.
 
         Args:
             id (str): ID of the task list to retrieve)
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+            If a matching PlankaError exists, it will be raised (see `api.errors`)
             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            NotFound: 404 
+            ValidationError: 400
+            Unauthorized: 401
+            NotFound: 404
         """
         resp = await self.client.get(f"api/task-lists/{id}")
-        await raise_planka_err(resp)
+        raise_planka_err(resp)
         return resp.json()
 
-    async def updateTaskList(self, id: str, **kwargs: Unpack[Request_updateTaskList]) -> Response_updateTaskList:
+    async def updateTaskList(self, id: str, **kwargs: Unpack[typ.Request_updateTaskList]) -> typ.Response_updateTaskList:
         """Updates a task list. Requires board editor permissions.
 
         Args:
@@ -1810,21 +1811,21 @@ class AsyncPlankaEndpoints:
             hideCompletedTasks (bool): Whether to hide completed tasks
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+            If a matching PlankaError exists, it will be raised (see `api.errors`)
             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            Forbidden: 403 
-            NotFound: 404 
+            ValidationError: 400
+            Unauthorized: 401
+            Forbidden: 403
+            NotFound: 404
         """
         resp = await self.client.patch(f"api/task-lists/{id}", json=kwargs)
-        await raise_planka_err(resp)
+        raise_planka_err(resp)
         return resp.json()
 
-    async def createTask(self, taskListId: str, **kwargs: Unpack[Request_createTask]) -> Response_createTask:
+    async def createTask(self, taskListId: str, **kwargs: Unpack[typ.Request_createTask]) -> typ.Response_createTask:
         """Creates a task within a task list. Either `linkedCardId` or `name` must be provided. Requires board editor permissions.
 
         Args:
@@ -1835,43 +1836,43 @@ class AsyncPlankaEndpoints:
             isCompleted (bool): Whether the task is completed
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+            If a matching PlankaError exists, it will be raised (see `api.errors`)
             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            Forbidden: 403 
-            NotFound: 404 
-            UnprocessableEntity: 422 
+            ValidationError: 400
+            Unauthorized: 401
+            Forbidden: 403
+            NotFound: 404
+            UnprocessableEntity: 422
         """
         resp = await self.client.post(f"api/task-lists/{taskListId}/tasks", json=kwargs)
-        await raise_planka_err(resp)
+        raise_planka_err(resp)
         return resp.json()
 
-    async def deleteTask(self, id: str) -> Response_deleteTask:
+    async def deleteTask(self, id: str) -> typ.Response_deleteTask:
         """Deletes a task. Requires board editor permissions.
 
         Args:
             id (str): ID of the task to delete)
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+            If a matching PlankaError exists, it will be raised (see `api.errors`)
             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            Forbidden: 403 
-            NotFound: 404 
+            ValidationError: 400
+            Unauthorized: 401
+            Forbidden: 403
+            NotFound: 404
         """
         resp = await self.client.delete(f"api/tasks/{id}")
-        await raise_planka_err(resp)
+        raise_planka_err(resp)
         return resp.json()
 
-    async def updateTask(self, id: str, **kwargs: Unpack[Request_updateTask]) -> Response_updateTask:
+    async def updateTask(self, id: str, **kwargs: Unpack[typ.Request_updateTask]) -> typ.Response_updateTask:
         """Updates a task. Linked card tasks have limited update options. Requires board editor permissions.
 
         Args:
@@ -1883,63 +1884,63 @@ class AsyncPlankaEndpoints:
             isCompleted (bool): Whether the task is completed
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+            If a matching PlankaError exists, it will be raised (see `api.errors`)
             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            Forbidden: 403 
-            NotFound: 404 
+            ValidationError: 400
+            Unauthorized: 401
+            Forbidden: 403
+            NotFound: 404
         """
         resp = await self.client.patch(f"api/tasks/{id}", json=kwargs)
-        await raise_planka_err(resp)
+        raise_planka_err(resp)
         return resp.json()
 
-    async def getTerms(self, **kwargs: Unpack[Request_getTerms]) -> Response_getTerms:
+    async def getTerms(self, **kwargs: Unpack[typ.Request_getTerms]) -> typ.Response_getTerms:
         """Retrieves terms and conditions in the specified language.
 
         Args:
             language (str): Language code for terms localization) (optional)
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+            If a matching PlankaError exists, it will be raised (see `api.errors`)
             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            NotFound: 404 
+            ValidationError: 400
+            Unauthorized: 401
+            NotFound: 404
         """
         valid_params = ('language',)
         passed_params = {k: v for k, v in kwargs.items() if k in valid_params if isinstance(v, str | int | float)}
         resp = await self.client.get("api/terms", params=passed_params)
-        await raise_planka_err(resp)
+        raise_planka_err(resp)
         return resp.json()
 
-    async def createUserApiKey(self, id: str) -> Response_createUserApiKey:
+    async def createUserApiKey(self, id: str) -> typ.Response_createUserApiKey:
         """Generates a user's API key. The full API key is returned only once and cannot be retrieved again.
 
         Args:
             id (str): ID of the user to create API key for)
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+            If a matching PlankaError exists, it will be raised (see `api.errors`)
             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            NotFound: 404 
+            ValidationError: 400
+            Unauthorized: 401
+            NotFound: 404
         """
         resp = await self.client.post(f"api/users/{id}/api-key")
-        await raise_planka_err(resp)
+        raise_planka_err(resp)
         return resp.json()
 
-    async def createUser(self, **kwargs: Unpack[Request_createUser]) -> Response_createUser:
+    async def createUser(self, **kwargs: Unpack[typ.Request_createUser]) -> typ.Response_createUser:
         """Creates a user account. Requires admin privileges.
 
         Args:
@@ -1956,59 +1957,59 @@ class AsyncPlankaEndpoints:
             turnOffRecentCardHighlighting (bool): Whether recent card highlighting is disabled
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+            If a matching PlankaError exists, it will be raised (see `api.errors`)
             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            Forbidden: 403 
-            Conflict: 409 
+            ValidationError: 400
+            Unauthorized: 401
+            Forbidden: 403
+            Conflict: 409
         """
         resp = await self.client.post("api/users", json=kwargs)
-        await raise_planka_err(resp)
+        raise_planka_err(resp)
         return resp.json()
 
-    async def getUsers(self) -> Response_getUsers:
+    async def getUsers(self) -> typ.Response_getUsers:
         """Retrieves a list of all users. Requires admin or project owner privileges.
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+            If a matching PlankaError exists, it will be raised (see `api.errors`)
             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            Forbidden: 403 
+            ValidationError: 400
+            Unauthorized: 401
+            Forbidden: 403
         """
         resp = await self.client.get("api/users")
-        await raise_planka_err(resp)
+        raise_planka_err(resp)
         return resp.json()
 
-    async def deleteUser(self, id: str) -> Response_deleteUser:
+    async def deleteUser(self, id: str) -> typ.Response_deleteUser:
         """Deletes a user account. Cannot delete the default admin user. Requires admin privileges.
 
         Args:
             id (str): ID of the user to delete)
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+            If a matching PlankaError exists, it will be raised (see `api.errors`)
             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            Forbidden: 403 
-            NotFound: 404 
+            ValidationError: 400
+            Unauthorized: 401
+            Forbidden: 403
+            NotFound: 404
         """
         resp = await self.client.delete(f"api/users/{id}")
-        await raise_planka_err(resp)
+        raise_planka_err(resp)
         return resp.json()
 
-    async def getUser(self, id: str, **kwargs: Unpack[Request_getUser]) -> Response_getUser:
+    async def getUser(self, id: str, **kwargs: Unpack[typ.Request_getUser]) -> typ.Response_getUser:
         """Retrieves a user. Use 'me' as ID to get the current user.
 
         Args:
@@ -2016,22 +2017,22 @@ class AsyncPlankaEndpoints:
             subscribe (bool): Whether to subscribe to real-time updates for this user (only for socket connections)) (optional)
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+            If a matching PlankaError exists, it will be raised (see `api.errors`)
             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            NotFound: 404 
+            ValidationError: 400
+            Unauthorized: 401
+            NotFound: 404
         """
         valid_params = ('subscribe',)
         passed_params = {k: v for k, v in kwargs.items() if k in valid_params if isinstance(v, str | int | float)}
         resp = await self.client.get(f"api/users/{id}", params=passed_params)
-        await raise_planka_err(resp)
+        raise_planka_err(resp)
         return resp.json()
 
-    async def updateUser(self, id: str, **kwargs: Unpack[Request_updateUser]) -> Response_updateUser:
+    async def updateUser(self, id: str, **kwargs: Unpack[typ.Request_updateUser]) -> typ.Response_updateUser:
         """Updates a user. Users can update their own profile, admins can update any user.
 
         Args:
@@ -2054,22 +2055,22 @@ class AsyncPlankaEndpoints:
             isDeactivated (bool): Whether the user account is deactivated and cannot log in (for admins)
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+            If a matching PlankaError exists, it will be raised (see `api.errors`)
             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            Forbidden: 403 
-            NotFound: 404 
-            Conflict: 409 
+            ValidationError: 400
+            Unauthorized: 401
+            Forbidden: 403
+            NotFound: 404
+            Conflict: 409
         """
         resp = await self.client.patch(f"api/users/{id}", json=kwargs)
-        await raise_planka_err(resp)
+        raise_planka_err(resp)
         return resp.json()
 
-    async def updateUserAvatar(self, id: str, **kwargs: Unpack[Request_updateUserAvatar]) -> Response_updateUserAvatar:
+    async def updateUserAvatar(self, id: str, **kwargs: Unpack[typ.Request_updateUserAvatar]) -> typ.Response_updateUserAvatar:
         """Updates a user's avatar image. Users can update their own avatar, admins can update any user's avatar.
 
         Args:
@@ -2077,21 +2078,21 @@ class AsyncPlankaEndpoints:
             file (str): Avatar image file (must be an image format)
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+            If a matching PlankaError exists, it will be raised (see `api.errors`)
             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            NotFound: 404 
-            UnprocessableEntity: 422 
+            ValidationError: 400
+            Unauthorized: 401
+            NotFound: 404
+            UnprocessableEntity: 422
         """
         resp = await self.client.post(f"api/users/{id}/avatar", json=kwargs)
-        await raise_planka_err(resp)
+        raise_planka_err(resp)
         return resp.json()
 
-    async def updateUserEmail(self, id: str, **kwargs: Unpack[Request_updateUserEmail]) -> Response_updateUserEmail:
+    async def updateUserEmail(self, id: str, **kwargs: Unpack[typ.Request_updateUserEmail]) -> typ.Response_updateUserEmail:
         """Updates a user's email address. Users must provide current password when updating their own email. Admins can update any user's email without a password.
 
         Args:
@@ -2100,22 +2101,22 @@ class AsyncPlankaEndpoints:
             currentPassword (str): Current password (required when updating own email)
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+            If a matching PlankaError exists, it will be raised (see `api.errors`)
             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            Forbidden: 403 
-            NotFound: 404 
-            Conflict: 409 
+            ValidationError: 400
+            Unauthorized: 401
+            Forbidden: 403
+            NotFound: 404
+            Conflict: 409
         """
         resp = await self.client.patch(f"api/users/{id}/email", json=kwargs)
-        await raise_planka_err(resp)
+        raise_planka_err(resp)
         return resp.json()
 
-    async def updateUserPassword(self, id: str, **kwargs: Unpack[Request_updateUserPassword]) -> Response_updateUserPassword:
+    async def updateUserPassword(self, id: str, **kwargs: Unpack[typ.Request_updateUserPassword]) -> typ.Response_updateUserPassword:
         """Updates a user's password. Users must provide a current password when updating their own password. Admins can update any user's password without the current password. Returns a new access token when updating own password.
 
         Args:
@@ -2124,21 +2125,21 @@ class AsyncPlankaEndpoints:
             currentPassword (str): Current password (required when updating own password)
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+            If a matching PlankaError exists, it will be raised (see `api.errors`)
             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            Forbidden: 403 
-            NotFound: 404 
+            ValidationError: 400
+            Unauthorized: 401
+            Forbidden: 403
+            NotFound: 404
         """
         resp = await self.client.patch(f"api/users/{id}/password", json=kwargs)
-        await raise_planka_err(resp)
+        raise_planka_err(resp)
         return resp.json()
 
-    async def updateUserUsername(self, id: str, **kwargs: Unpack[Request_updateUserUsername]) -> Response_updateUserUsername:
+    async def updateUserUsername(self, id: str, **kwargs: Unpack[typ.Request_updateUserUsername]) -> typ.Response_updateUserUsername:
         """Updates a user's username. Users must provide a current password when updating their own username (unless they are SSO users with `oidcIgnoreUsername` enabled). Admins can update any user's username without the current password.
 
         Args:
@@ -2147,22 +2148,22 @@ class AsyncPlankaEndpoints:
             currentPassword (str): Current password (required when updating own username)
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+            If a matching PlankaError exists, it will be raised (see `api.errors`)
             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            Forbidden: 403 
-            NotFound: 404 
-            Conflict: 409 
+            ValidationError: 400
+            Unauthorized: 401
+            Forbidden: 403
+            NotFound: 404
+            Conflict: 409
         """
         resp = await self.client.patch(f"api/users/{id}/username", json=kwargs)
-        await raise_planka_err(resp)
+        raise_planka_err(resp)
         return resp.json()
 
-    async def createWebhook(self, **kwargs: Unpack[Request_createWebhook]) -> Response_createWebhook:
+    async def createWebhook(self, **kwargs: Unpack[typ.Request_createWebhook]) -> typ.Response_createWebhook:
         """Creates a webhook. Requires admin privileges.
 
         Args:
@@ -2173,56 +2174,56 @@ class AsyncPlankaEndpoints:
             excludedEvents (str | None): Comma-separated list of events excluded from the webhook
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+            If a matching PlankaError exists, it will be raised (see `api.errors`)
             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            Conflict: 409 
+            ValidationError: 400
+            Unauthorized: 401
+            Conflict: 409
         """
         resp = await self.client.post("api/webhooks", json=kwargs)
-        await raise_planka_err(resp)
+        raise_planka_err(resp)
         return resp.json()
 
-    async def getWebhooks(self) -> Response_getWebhooks:
+    async def getWebhooks(self) -> typ.Response_getWebhooks:
         """Retrieves a list of all configured webhooks. Requires admin privileges.
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+            If a matching PlankaError exists, it will be raised (see `api.errors`)
             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
+            ValidationError: 400
+            Unauthorized: 401
         """
         resp = await self.client.get("api/webhooks")
-        await raise_planka_err(resp)
+        raise_planka_err(resp)
         return resp.json()
 
-    async def deleteWebhook(self, id: str) -> Response_deleteWebhook:
+    async def deleteWebhook(self, id: str) -> typ.Response_deleteWebhook:
         """Deletes a webhook. Requires admin privileges.
 
         Args:
             id (str): ID of the webhook to delete)
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+            If a matching PlankaError exists, it will be raised (see `api.errors`)
             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            NotFound: 404 
+            ValidationError: 400
+            Unauthorized: 401
+            NotFound: 404
         """
         resp = await self.client.delete(f"api/webhooks/{id}")
-        await raise_planka_err(resp)
+        raise_planka_err(resp)
         return resp.json()
 
-    async def updateWebhook(self, id: str, **kwargs: Unpack[Request_updateWebhook]) -> Response_updateWebhook:
+    async def updateWebhook(self, id: str, **kwargs: Unpack[typ.Request_updateWebhook]) -> typ.Response_updateWebhook:
         """Updates a webhook. Requires admin privileges.
 
         Args:
@@ -2234,15 +2235,15 @@ class AsyncPlankaEndpoints:
             excludedEvents (str | None): Comma-separated list of events excluded from the webhook
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+            If a matching PlankaError exists, it will be raised (see `api.errors`)
             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            NotFound: 404 
+            ValidationError: 400
+            Unauthorized: 401
+            NotFound: 404
         """
         resp = await self.client.patch(f"api/webhooks/{id}", json=kwargs)
-        await raise_planka_err(resp)
+        raise_planka_err(resp)
         return resp.json()

--- a/src/plankapy/v2/api/async_paths.py
+++ b/src/plankapy/v2/api/async_paths.py
@@ -33,8 +33,8 @@ class AsyncPlankaEndpoints:
 
         Note:
             All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
-            If a matching PlankaError exists, it will be raised (see `api.errors`)
-            Planka internal status codes and names are included here for disambiguation
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
             ValidationError: 400
@@ -55,8 +55,8 @@ class AsyncPlankaEndpoints:
 
         Note:
             All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
-            If a matching PlankaError exists, it will be raised (see `api.errors`)
-            Planka internal status codes and names are included here for disambiguation
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
             ValidationError: 400
@@ -72,8 +72,8 @@ class AsyncPlankaEndpoints:
 
         Note:
             All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
-            If a matching PlankaError exists, it will be raised (see `api.errors`)
-            Planka internal status codes and names are included here for disambiguation
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
             Unauthorized: 401
@@ -92,8 +92,8 @@ class AsyncPlankaEndpoints:
 
         Note:
             All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
-            If a matching PlankaError exists, it will be raised (see `api.errors`)
-            Planka internal status codes and names are included here for disambiguation
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
             ValidationError: 400
@@ -115,8 +115,8 @@ class AsyncPlankaEndpoints:
 
         Note:
             All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
-            If a matching PlankaError exists, it will be raised (see `api.errors`)
-            Planka internal status codes and names are included here for disambiguation
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
             ValidationError: 400
@@ -135,8 +135,8 @@ class AsyncPlankaEndpoints:
 
         Note:
             All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
-            If a matching PlankaError exists, it will be raised (see `api.errors`)
-            Planka internal status codes and names are included here for disambiguation
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
             ValidationError: 400
@@ -158,8 +158,8 @@ class AsyncPlankaEndpoints:
 
         Note:
             All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
-            If a matching PlankaError exists, it will be raised (see `api.errors`)
-            Planka internal status codes and names are included here for disambiguation
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
             ValidationError: 400
@@ -185,8 +185,8 @@ class AsyncPlankaEndpoints:
 
         Note:
             All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
-            If a matching PlankaError exists, it will be raised (see `api.errors`)
-            Planka internal status codes and names are included here for disambiguation
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
             ValidationError: 400
@@ -207,8 +207,8 @@ class AsyncPlankaEndpoints:
 
         Note:
             All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
-            If a matching PlankaError exists, it will be raised (see `api.errors`)
-            Planka internal status codes and names are included here for disambiguation
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
             ValidationError: 400
@@ -229,8 +229,8 @@ class AsyncPlankaEndpoints:
 
         Note:
             All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
-            If a matching PlankaError exists, it will be raised (see `api.errors`)
-            Planka internal status codes and names are included here for disambiguation
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
             ValidationError: 400
@@ -252,8 +252,8 @@ class AsyncPlankaEndpoints:
 
         Note:
             All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
-            If a matching PlankaError exists, it will be raised (see `api.errors`)
-            Planka internal status codes and names are included here for disambiguation
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
             ValidationError: 400
@@ -274,8 +274,8 @@ class AsyncPlankaEndpoints:
 
         Note:
             All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
-            If a matching PlankaError exists, it will be raised (see `api.errors`)
-            Planka internal status codes and names are included here for disambiguation
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
             ValidationError: 400
@@ -296,8 +296,8 @@ class AsyncPlankaEndpoints:
 
         Note:
             All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
-            If a matching PlankaError exists, it will be raised (see `api.errors`)
-            Planka internal status codes and names are included here for disambiguation
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
             ValidationError: 400
@@ -317,8 +317,8 @@ class AsyncPlankaEndpoints:
 
         Note:
             All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
-            If a matching PlankaError exists, it will be raised (see `api.errors`)
-            Planka internal status codes and names are included here for disambiguation
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
             ValidationError: 400
@@ -339,8 +339,8 @@ class AsyncPlankaEndpoints:
 
         Note:
             All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
-            If a matching PlankaError exists, it will be raised (see `api.errors`)
-            Planka internal status codes and names are included here for disambiguation
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
             ValidationError: 400
@@ -363,8 +363,8 @@ class AsyncPlankaEndpoints:
 
         Note:
             All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
-            If a matching PlankaError exists, it will be raised (see `api.errors`)
-            Planka internal status codes and names are included here for disambiguation
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
             ValidationError: 400
@@ -385,8 +385,8 @@ class AsyncPlankaEndpoints:
 
         Note:
             All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
-            If a matching PlankaError exists, it will be raised (see `api.errors`)
-            Planka internal status codes and names are included here for disambiguation
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
             ValidationError: 400
@@ -407,8 +407,8 @@ class AsyncPlankaEndpoints:
 
         Note:
             All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
-            If a matching PlankaError exists, it will be raised (see `api.errors`)
-            Planka internal status codes and names are included here for disambiguation
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
             ValidationError: 400
@@ -432,8 +432,8 @@ class AsyncPlankaEndpoints:
 
         Note:
             All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
-            If a matching PlankaError exists, it will be raised (see `api.errors`)
-            Planka internal status codes and names are included here for disambiguation
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
             ValidationError: 400
@@ -453,8 +453,8 @@ class AsyncPlankaEndpoints:
 
         Note:
             All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
-            If a matching PlankaError exists, it will be raised (see `api.errors`)
-            Planka internal status codes and names are included here for disambiguation
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
             ValidationError: 400
@@ -474,8 +474,8 @@ class AsyncPlankaEndpoints:
 
         Note:
             All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
-            If a matching PlankaError exists, it will be raised (see `api.errors`)
-            Planka internal status codes and names are included here for disambiguation
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
             ValidationError: 400
@@ -504,8 +504,8 @@ class AsyncPlankaEndpoints:
 
         Note:
             All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
-            If a matching PlankaError exists, it will be raised (see `api.errors`)
-            Planka internal status codes and names are included here for disambiguation
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
             ValidationError: 400
@@ -532,8 +532,8 @@ class AsyncPlankaEndpoints:
 
         Note:
             All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
-            If a matching PlankaError exists, it will be raised (see `api.errors`)
-            Planka internal status codes and names are included here for disambiguation
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
             ValidationError: 400
@@ -555,8 +555,8 @@ class AsyncPlankaEndpoints:
 
         Note:
             All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
-            If a matching PlankaError exists, it will be raised (see `api.errors`)
-            Planka internal status codes and names are included here for disambiguation
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
             ValidationError: 400
@@ -577,8 +577,8 @@ class AsyncPlankaEndpoints:
 
         Note:
             All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
-            If a matching PlankaError exists, it will be raised (see `api.errors`)
-            Planka internal status codes and names are included here for disambiguation
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
             ValidationError: 400
@@ -600,8 +600,8 @@ class AsyncPlankaEndpoints:
 
         Note:
             All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
-            If a matching PlankaError exists, it will be raised (see `api.errors`)
-            Planka internal status codes and names are included here for disambiguation
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
             ValidationError: 400
@@ -628,8 +628,8 @@ class AsyncPlankaEndpoints:
 
         Note:
             All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
-            If a matching PlankaError exists, it will be raised (see `api.errors`)
-            Planka internal status codes and names are included here for disambiguation
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
             ValidationError: 400
@@ -655,8 +655,8 @@ class AsyncPlankaEndpoints:
 
         Note:
             All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
-            If a matching PlankaError exists, it will be raised (see `api.errors`)
-            Planka internal status codes and names are included here for disambiguation
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
             ValidationError: 400
@@ -677,8 +677,8 @@ class AsyncPlankaEndpoints:
 
         Note:
             All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
-            If a matching PlankaError exists, it will be raised (see `api.errors`)
-            Planka internal status codes and names are included here for disambiguation
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
             ValidationError: 400
@@ -698,8 +698,8 @@ class AsyncPlankaEndpoints:
 
         Note:
             All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
-            If a matching PlankaError exists, it will be raised (see `api.errors`)
-            Planka internal status codes and names are included here for disambiguation
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
             ValidationError: 400
@@ -729,8 +729,8 @@ class AsyncPlankaEndpoints:
 
         Note:
             All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
-            If a matching PlankaError exists, it will be raised (see `api.errors`)
-            Planka internal status codes and names are included here for disambiguation
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
             ValidationError: 400
@@ -755,8 +755,8 @@ class AsyncPlankaEndpoints:
 
         Note:
             All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
-            If a matching PlankaError exists, it will be raised (see `api.errors`)
-            Planka internal status codes and names are included here for disambiguation
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
             ValidationError: 400
@@ -777,8 +777,8 @@ class AsyncPlankaEndpoints:
 
         Note:
             All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
-            If a matching PlankaError exists, it will be raised (see `api.errors`)
-            Planka internal status codes and names are included here for disambiguation
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
             ValidationError: 400
@@ -798,8 +798,8 @@ class AsyncPlankaEndpoints:
 
         Note:
             All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
-            If a matching PlankaError exists, it will be raised (see `api.errors`)
-            Planka internal status codes and names are included here for disambiguation
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
             ValidationError: 400
@@ -820,8 +820,8 @@ class AsyncPlankaEndpoints:
 
         Note:
             All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
-            If a matching PlankaError exists, it will be raised (see `api.errors`)
-            Planka internal status codes and names are included here for disambiguation
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
             ValidationError: 400
@@ -842,8 +842,8 @@ class AsyncPlankaEndpoints:
 
         Note:
             All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
-            If a matching PlankaError exists, it will be raised (see `api.errors`)
-            Planka internal status codes and names are included here for disambiguation
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
             ValidationError: 400
@@ -864,8 +864,8 @@ class AsyncPlankaEndpoints:
 
         Note:
             All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
-            If a matching PlankaError exists, it will be raised (see `api.errors`)
-            Planka internal status codes and names are included here for disambiguation
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
             ValidationError: 400
@@ -906,8 +906,8 @@ class AsyncPlankaEndpoints:
 
         Note:
             All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
-            If a matching PlankaError exists, it will be raised (see `api.errors`)
-            Planka internal status codes and names are included here for disambiguation
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
             Unauthorized: 401
@@ -928,8 +928,8 @@ class AsyncPlankaEndpoints:
 
         Note:
             All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
-            If a matching PlankaError exists, it will be raised (see `api.errors`)
-            Planka internal status codes and names are included here for disambiguation
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
             ValidationError: 400
@@ -953,8 +953,8 @@ class AsyncPlankaEndpoints:
 
         Note:
             All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
-            If a matching PlankaError exists, it will be raised (see `api.errors`)
-            Planka internal status codes and names are included here for disambiguation
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
             ValidationError: 400
@@ -975,8 +975,8 @@ class AsyncPlankaEndpoints:
 
         Note:
             All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
-            If a matching PlankaError exists, it will be raised (see `api.errors`)
-            Planka internal status codes and names are included here for disambiguation
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
             ValidationError: 400
@@ -996,8 +996,8 @@ class AsyncPlankaEndpoints:
 
         Note:
             All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
-            If a matching PlankaError exists, it will be raised (see `api.errors`)
-            Planka internal status codes and names are included here for disambiguation
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
             ValidationError: 400
@@ -1018,8 +1018,8 @@ class AsyncPlankaEndpoints:
 
         Note:
             All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
-            If a matching PlankaError exists, it will be raised (see `api.errors`)
-            Planka internal status codes and names are included here for disambiguation
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
             ValidationError: 400
@@ -1043,8 +1043,8 @@ class AsyncPlankaEndpoints:
 
         Note:
             All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
-            If a matching PlankaError exists, it will be raised (see `api.errors`)
-            Planka internal status codes and names are included here for disambiguation
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
             ValidationError: 400
@@ -1066,8 +1066,8 @@ class AsyncPlankaEndpoints:
 
         Note:
             All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
-            If a matching PlankaError exists, it will be raised (see `api.errors`)
-            Planka internal status codes and names are included here for disambiguation
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
             ValidationError: 400
@@ -1090,8 +1090,8 @@ class AsyncPlankaEndpoints:
 
         Note:
             All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
-            If a matching PlankaError exists, it will be raised (see `api.errors`)
-            Planka internal status codes and names are included here for disambiguation
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
             ValidationError: 400
@@ -1113,8 +1113,8 @@ class AsyncPlankaEndpoints:
 
         Note:
             All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
-            If a matching PlankaError exists, it will be raised (see `api.errors`)
-            Planka internal status codes and names are included here for disambiguation
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
             ValidationError: 400
@@ -1134,8 +1134,8 @@ class AsyncPlankaEndpoints:
 
         Note:
             All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
-            If a matching PlankaError exists, it will be raised (see `api.errors`)
-            Planka internal status codes and names are included here for disambiguation
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
             ValidationError: 400
@@ -1158,8 +1158,8 @@ class AsyncPlankaEndpoints:
 
         Note:
             All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
-            If a matching PlankaError exists, it will be raised (see `api.errors`)
-            Planka internal status codes and names are included here for disambiguation
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
             ValidationError: 400
@@ -1182,8 +1182,8 @@ class AsyncPlankaEndpoints:
 
         Note:
             All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
-            If a matching PlankaError exists, it will be raised (see `api.errors`)
-            Planka internal status codes and names are included here for disambiguation
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
             ValidationError: 400
@@ -1203,8 +1203,8 @@ class AsyncPlankaEndpoints:
 
         Note:
             All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
-            If a matching PlankaError exists, it will be raised (see `api.errors`)
-            Planka internal status codes and names are included here for disambiguation
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
             ValidationError: 400
@@ -1227,8 +1227,8 @@ class AsyncPlankaEndpoints:
 
         Note:
             All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
-            If a matching PlankaError exists, it will be raised (see `api.errors`)
-            Planka internal status codes and names are included here for disambiguation
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
             ValidationError: 400
@@ -1248,8 +1248,8 @@ class AsyncPlankaEndpoints:
 
         Note:
             All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
-            If a matching PlankaError exists, it will be raised (see `api.errors`)
-            Planka internal status codes and names are included here for disambiguation
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
             ValidationError: 400
@@ -1272,8 +1272,8 @@ class AsyncPlankaEndpoints:
 
         Note:
             All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
-            If a matching PlankaError exists, it will be raised (see `api.errors`)
-            Planka internal status codes and names are included here for disambiguation
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
             ValidationError: 400
@@ -1293,8 +1293,8 @@ class AsyncPlankaEndpoints:
 
         Note:
             All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
-            If a matching PlankaError exists, it will be raised (see `api.errors`)
-            Planka internal status codes and names are included here for disambiguation
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
             ValidationError: 400
@@ -1314,8 +1314,8 @@ class AsyncPlankaEndpoints:
 
         Note:
             All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
-            If a matching PlankaError exists, it will be raised (see `api.errors`)
-            Planka internal status codes and names are included here for disambiguation
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
             ValidationError: 400
@@ -1339,8 +1339,8 @@ class AsyncPlankaEndpoints:
 
         Note:
             All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
-            If a matching PlankaError exists, it will be raised (see `api.errors`)
-            Planka internal status codes and names are included here for disambiguation
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
             ValidationError: 400
@@ -1361,8 +1361,8 @@ class AsyncPlankaEndpoints:
 
         Note:
             All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
-            If a matching PlankaError exists, it will be raised (see `api.errors`)
-            Planka internal status codes and names are included here for disambiguation
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
             ValidationError: 400
@@ -1384,8 +1384,8 @@ class AsyncPlankaEndpoints:
 
         Note:
             All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
-            If a matching PlankaError exists, it will be raised (see `api.errors`)
-            Planka internal status codes and names are included here for disambiguation
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
             ValidationError: 400
@@ -1408,8 +1408,8 @@ class AsyncPlankaEndpoints:
 
         Note:
             All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
-            If a matching PlankaError exists, it will be raised (see `api.errors`)
-            Planka internal status codes and names are included here for disambiguation
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
             ValidationError: 400
@@ -1431,8 +1431,8 @@ class AsyncPlankaEndpoints:
 
         Note:
             All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
-            If a matching PlankaError exists, it will be raised (see `api.errors`)
-            Planka internal status codes and names are included here for disambiguation
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
             ValidationError: 400
@@ -1452,8 +1452,8 @@ class AsyncPlankaEndpoints:
 
         Note:
             All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
-            If a matching PlankaError exists, it will be raised (see `api.errors`)
-            Planka internal status codes and names are included here for disambiguation
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
             ValidationError: 400
@@ -1474,8 +1474,8 @@ class AsyncPlankaEndpoints:
 
         Note:
             All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
-            If a matching PlankaError exists, it will be raised (see `api.errors`)
-            Planka internal status codes and names are included here for disambiguation
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
             ValidationError: 400
@@ -1494,8 +1494,8 @@ class AsyncPlankaEndpoints:
 
         Note:
             All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
-            If a matching PlankaError exists, it will be raised (see `api.errors`)
-            Planka internal status codes and names are included here for disambiguation
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
             ValidationError: 400
@@ -1511,8 +1511,8 @@ class AsyncPlankaEndpoints:
 
         Note:
             All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
-            If a matching PlankaError exists, it will be raised (see `api.errors`)
-            Planka internal status codes and names are included here for disambiguation
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
             ValidationError: 400
@@ -1527,8 +1527,8 @@ class AsyncPlankaEndpoints:
 
         Note:
             All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
-            If a matching PlankaError exists, it will be raised (see `api.errors`)
-            Planka internal status codes and names are included here for disambiguation
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
             ValidationError: 400
@@ -1546,8 +1546,8 @@ class AsyncPlankaEndpoints:
 
         Note:
             All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
-            If a matching PlankaError exists, it will be raised (see `api.errors`)
-            Planka internal status codes and names are included here for disambiguation
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
             ValidationError: 400
@@ -1567,8 +1567,8 @@ class AsyncPlankaEndpoints:
 
         Note:
             All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
-            If a matching PlankaError exists, it will be raised (see `api.errors`)
-            Planka internal status codes and names are included here for disambiguation
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
             ValidationError: 400
@@ -1588,8 +1588,8 @@ class AsyncPlankaEndpoints:
 
         Note:
             All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
-            If a matching PlankaError exists, it will be raised (see `api.errors`)
-            Planka internal status codes and names are included here for disambiguation
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
             ValidationError: 400
@@ -1611,8 +1611,8 @@ class AsyncPlankaEndpoints:
 
         Note:
             All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
-            If a matching PlankaError exists, it will be raised (see `api.errors`)
-            Planka internal status codes and names are included here for disambiguation
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
             ValidationError: 400
@@ -1635,8 +1635,8 @@ class AsyncPlankaEndpoints:
 
         Note:
             All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
-            If a matching PlankaError exists, it will be raised (see `api.errors`)
-            Planka internal status codes and names are included here for disambiguation
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
             ValidationError: 400
@@ -1651,8 +1651,8 @@ class AsyncPlankaEndpoints:
 
         Note:
             All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
-            If a matching PlankaError exists, it will be raised (see `api.errors`)
-            Planka internal status codes and names are included here for disambiguation
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
             ValidationError: 400
@@ -1670,8 +1670,8 @@ class AsyncPlankaEndpoints:
 
         Note:
             All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
-            If a matching PlankaError exists, it will be raised (see `api.errors`)
-            Planka internal status codes and names are included here for disambiguation
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
             ValidationError: 400
@@ -1691,8 +1691,8 @@ class AsyncPlankaEndpoints:
 
         Note:
             All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
-            If a matching PlankaError exists, it will be raised (see `api.errors`)
-            Planka internal status codes and names are included here for disambiguation
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
             ValidationError: 400
@@ -1719,8 +1719,8 @@ class AsyncPlankaEndpoints:
 
         Note:
             All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
-            If a matching PlankaError exists, it will be raised (see `api.errors`)
-            Planka internal status codes and names are included here for disambiguation
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
             ValidationError: 400
@@ -1746,8 +1746,8 @@ class AsyncPlankaEndpoints:
 
         Note:
             All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
-            If a matching PlankaError exists, it will be raised (see `api.errors`)
-            Planka internal status codes and names are included here for disambiguation
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
             ValidationError: 400
@@ -1767,8 +1767,8 @@ class AsyncPlankaEndpoints:
 
         Note:
             All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
-            If a matching PlankaError exists, it will be raised (see `api.errors`)
-            Planka internal status codes and names are included here for disambiguation
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
             ValidationError: 400
@@ -1788,8 +1788,8 @@ class AsyncPlankaEndpoints:
 
         Note:
             All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
-            If a matching PlankaError exists, it will be raised (see `api.errors`)
-            Planka internal status codes and names are included here for disambiguation
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
             ValidationError: 400
@@ -1812,8 +1812,8 @@ class AsyncPlankaEndpoints:
 
         Note:
             All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
-            If a matching PlankaError exists, it will be raised (see `api.errors`)
-            Planka internal status codes and names are included here for disambiguation
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
             ValidationError: 400
@@ -1837,8 +1837,8 @@ class AsyncPlankaEndpoints:
 
         Note:
             All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
-            If a matching PlankaError exists, it will be raised (see `api.errors`)
-            Planka internal status codes and names are included here for disambiguation
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
             ValidationError: 400
@@ -1859,8 +1859,8 @@ class AsyncPlankaEndpoints:
 
         Note:
             All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
-            If a matching PlankaError exists, it will be raised (see `api.errors`)
-            Planka internal status codes and names are included here for disambiguation
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
             ValidationError: 400
@@ -1885,8 +1885,8 @@ class AsyncPlankaEndpoints:
 
         Note:
             All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
-            If a matching PlankaError exists, it will be raised (see `api.errors`)
-            Planka internal status codes and names are included here for disambiguation
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
             ValidationError: 400
@@ -1906,8 +1906,8 @@ class AsyncPlankaEndpoints:
 
         Note:
             All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
-            If a matching PlankaError exists, it will be raised (see `api.errors`)
-            Planka internal status codes and names are included here for disambiguation
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
             ValidationError: 400
@@ -1928,8 +1928,8 @@ class AsyncPlankaEndpoints:
 
         Note:
             All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
-            If a matching PlankaError exists, it will be raised (see `api.errors`)
-            Planka internal status codes and names are included here for disambiguation
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
             ValidationError: 400
@@ -1958,8 +1958,8 @@ class AsyncPlankaEndpoints:
 
         Note:
             All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
-            If a matching PlankaError exists, it will be raised (see `api.errors`)
-            Planka internal status codes and names are included here for disambiguation
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
             ValidationError: 400
@@ -1976,8 +1976,8 @@ class AsyncPlankaEndpoints:
 
         Note:
             All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
-            If a matching PlankaError exists, it will be raised (see `api.errors`)
-            Planka internal status codes and names are included here for disambiguation
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
             ValidationError: 400
@@ -1996,8 +1996,8 @@ class AsyncPlankaEndpoints:
 
         Note:
             All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
-            If a matching PlankaError exists, it will be raised (see `api.errors`)
-            Planka internal status codes and names are included here for disambiguation
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
             ValidationError: 400
@@ -2018,8 +2018,8 @@ class AsyncPlankaEndpoints:
 
         Note:
             All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
-            If a matching PlankaError exists, it will be raised (see `api.errors`)
-            Planka internal status codes and names are included here for disambiguation
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
             ValidationError: 400
@@ -2056,8 +2056,8 @@ class AsyncPlankaEndpoints:
 
         Note:
             All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
-            If a matching PlankaError exists, it will be raised (see `api.errors`)
-            Planka internal status codes and names are included here for disambiguation
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
             ValidationError: 400
@@ -2079,8 +2079,8 @@ class AsyncPlankaEndpoints:
 
         Note:
             All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
-            If a matching PlankaError exists, it will be raised (see `api.errors`)
-            Planka internal status codes and names are included here for disambiguation
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
             ValidationError: 400
@@ -2102,8 +2102,8 @@ class AsyncPlankaEndpoints:
 
         Note:
             All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
-            If a matching PlankaError exists, it will be raised (see `api.errors`)
-            Planka internal status codes and names are included here for disambiguation
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
             ValidationError: 400
@@ -2126,8 +2126,8 @@ class AsyncPlankaEndpoints:
 
         Note:
             All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
-            If a matching PlankaError exists, it will be raised (see `api.errors`)
-            Planka internal status codes and names are included here for disambiguation
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
             ValidationError: 400
@@ -2149,8 +2149,8 @@ class AsyncPlankaEndpoints:
 
         Note:
             All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
-            If a matching PlankaError exists, it will be raised (see `api.errors`)
-            Planka internal status codes and names are included here for disambiguation
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
             ValidationError: 400
@@ -2175,8 +2175,8 @@ class AsyncPlankaEndpoints:
 
         Note:
             All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
-            If a matching PlankaError exists, it will be raised (see `api.errors`)
-            Planka internal status codes and names are included here for disambiguation
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
             ValidationError: 400
@@ -2192,8 +2192,8 @@ class AsyncPlankaEndpoints:
 
         Note:
             All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
-            If a matching PlankaError exists, it will be raised (see `api.errors`)
-            Planka internal status codes and names are included here for disambiguation
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
             ValidationError: 400
@@ -2211,8 +2211,8 @@ class AsyncPlankaEndpoints:
 
         Note:
             All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
-            If a matching PlankaError exists, it will be raised (see `api.errors`)
-            Planka internal status codes and names are included here for disambiguation
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
             ValidationError: 400
@@ -2236,8 +2236,8 @@ class AsyncPlankaEndpoints:
 
         Note:
             All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
-            If a matching PlankaError exists, it will be raised (see `api.errors`)
-            Planka internal status codes and names are included here for disambiguation
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
             ValidationError: 400

--- a/src/plankapy/v2/api/errors.py
+++ b/src/plankapy/v2/api/errors.py
@@ -1,17 +1,20 @@
 from __future__ import annotations
+
 from typing import Any
+
 from httpx import HTTPStatusError
 
 __all__ = (
-    "PlankaError",
     "ERRORS",
     "Conflict",
     "Forbidden",
     "NotFound",
+    "PlankaError",
     "Unauthorized",
     "UnprocessableEntity",
     "ValidationError",
 )
+
 
 class PlankaError(HTTPStatusError):
     def __init__(self, parent: HTTPStatusError, *args: Any, **kwargs: Any) -> None:
@@ -22,23 +25,29 @@ class PlankaError(HTTPStatusError):
             self.add_note(problem)
 
 
-class Conflict(PlankaError): ...
-"""Request conflicts with current state of the resource"""
+class Conflict(PlankaError):
+    """Request conflicts with current state of the resource"""
 
-class Forbidden(PlankaError): ...
-"""Access forbidden - insufficient permissions"""
 
-class NotFound(PlankaError): ...
-"""Resource not found"""
+class Forbidden(PlankaError):
+    """Access forbidden - insufficient permissions"""
 
-class Unauthorized(PlankaError): ...
-"""Authentication required or invalid credentials"""
 
-class UnprocessableEntity(PlankaError): ...
-"""Request contains semantic errors or validation failures"""
+class NotFound(PlankaError):
+    """Resource not found"""
 
-class ValidationError(PlankaError): ...
-"""Request validation failed due to missing or invalid parameters"""
+
+class Unauthorized(PlankaError):
+    """Authentication required or invalid credentials"""
+
+
+class UnprocessableEntity(PlankaError):
+    """Request contains semantic errors or validation failures"""
+
+
+class ValidationError(PlankaError):
+    """Request validation failed due to missing or invalid parameters"""
+
 
 ERRORS: dict[str, type[PlankaError]] = {
     'E_CONFLICT': Conflict,

--- a/src/plankapy/v2/api/events.py
+++ b/src/plankapy/v2/api/events.py
@@ -3,80 +3,80 @@ from typing import Literal, get_args
 ActionEvent = Literal['actionCreate']
 ActionEvents: tuple[ActionEvent, ...] = get_args(ActionEvent)
 
-AttachmentEvent = Literal['attachmentCreate', 'attachmentUpdate', 'attachmentDelete'] 
+AttachmentEvent = Literal['attachmentCreate', 'attachmentUpdate', 'attachmentDelete']
 AttachmentEvents: tuple[AttachmentEvent, ...] = get_args(AttachmentEvent)
 
-BackgroundImageEvent = Literal['backgroundImageCreate', 'backgroundImageDelete'] 
+BackgroundImageEvent = Literal['backgroundImageCreate', 'backgroundImageDelete']
 BackgroundImageEvents: tuple[BackgroundImageEvent, ...] = get_args(BackgroundImageEvent)
 
-BaseCustomFieldGroupEvent = Literal['baseCustomFieldGroupCreate', 'baseCustomFieldGroupUpdate', 'baseCustomFieldGroupDelete'] 
+BaseCustomFieldGroupEvent = Literal['baseCustomFieldGroupCreate', 'baseCustomFieldGroupUpdate', 'baseCustomFieldGroupDelete']
 BaseCustomFieldGroupEvents: tuple[BaseCustomFieldGroupEvent, ...] = get_args(BaseCustomFieldGroupEvent)
 
 BoardEvent = Literal['boardCreate', 'boardUpdate', 'boardDelete']
 BoardEvents: tuple[BoardEvent, ...] = get_args(BoardEvent)
 
-BoardMembershipEvent = Literal['boardMembershipCreate', 'boardMembershipUpdate', 'boardMembershipDelete'] 
+BoardMembershipEvent = Literal['boardMembershipCreate', 'boardMembershipUpdate', 'boardMembershipDelete']
 BoardMembershipEvents: tuple[BoardMembershipEvent, ...] = get_args(BoardMembershipEvent)
 
-CardEvent = Literal['cardCreate', 'cardUpdate', 'cardDelete'] 
+CardEvent = Literal['cardCreate', 'cardUpdate', 'cardDelete']
 CardEvents: tuple[CardEvent, ...] = get_args(CardEvent)
 
 CardLabelEvent = Literal['cardLabelCreate', 'cardLabelDelete']
 CardLabelEvents: tuple[CardLabelEvent, ...] = get_args(CardLabelEvent)
 
-CardMembershipEvent = Literal['cardMembershipCreate', 'cardMembershipDelete'] 
+CardMembershipEvent = Literal['cardMembershipCreate', 'cardMembershipDelete']
 CardMembershipEvents: tuple[CardMembershipEvent, ...] = get_args(CardMembershipEvent)
 
-CommentEvent = Literal['commentCreate', 'commentUpdate', 'commentDelete'] 
+CommentEvent = Literal['commentCreate', 'commentUpdate', 'commentDelete']
 CommentEvents: tuple[CommentEvent, ...] = get_args(CommentEvent)
 
 ConfigEvent = Literal['configUpdate']
 ConfigEvents: tuple[ConfigEvent, ...] = get_args(ConfigEvent)
 
-CustomFieldEvent = Literal['customFieldCreate', 'customFieldUpdate', 'customFieldDelete'] 
+CustomFieldEvent = Literal['customFieldCreate', 'customFieldUpdate', 'customFieldDelete']
 CustomFieldEvents: tuple[CustomFieldEvent, ...] = get_args(CustomFieldEvent)
 
-CustomFieldGroupEvent = Literal['customFieldGroupCreate', 'customFieldGroupUpdate', 'customFieldGroupDelete'] 
-CustomFieldGroupEvents: tuple[CustomFieldGroupEvent, ...] = get_args(CustomFieldGroupEvent) 
+CustomFieldGroupEvent = Literal['customFieldGroupCreate', 'customFieldGroupUpdate', 'customFieldGroupDelete']
+CustomFieldGroupEvents: tuple[CustomFieldGroupEvent, ...] = get_args(CustomFieldGroupEvent)
 
 CustomFieldValueEvent = Literal['customFieldValueUpdate', 'customFieldValueDelete']
 CustomFieldValueEvents: tuple[CustomFieldValueEvent, ...] = get_args(CustomFieldValueEvent)
 
-LabelEvent = Literal['labelCreate', 'labelUpdate', 'labelDelete'] 
+LabelEvent = Literal['labelCreate', 'labelUpdate', 'labelDelete']
 LabelEvents: tuple[LabelEvent, ...] = get_args(LabelEvent)
 
-ListEvent = Literal['listCreate', 'listUpdate', 'listClear', 'listDelete'] 
+ListEvent = Literal['listCreate', 'listUpdate', 'listClear', 'listDelete']
 ListEvents: tuple[ListEvent, ...] = get_args(ListEvent)
 
-NotificationEvent = Literal['notificationCreate', 'notificationUpdate'] 
+NotificationEvent = Literal['notificationCreate', 'notificationUpdate']
 NotificationEvents: tuple[NotificationEvent, ...] = get_args(NotificationEvent)
 
-NotificationServiceEvent = Literal['notificationServiceCreate', 'notificationServiceUpdate', 'notificationServiceDelete'] 
+NotificationServiceEvent = Literal['notificationServiceCreate', 'notificationServiceUpdate', 'notificationServiceDelete']
 NotificationServiceEvents: tuple[NotificationServiceEvent, ...] = get_args(NotificationServiceEvent)
 
 ProjectEvent = Literal['projectCreate', 'projectUpdate', 'projectDelete']
 ProjectEvents: tuple[ProjectEvent, ...] = get_args(ProjectEvent)
 
-ProjectManagerEvent =  Literal['projectManagerCreate', 'projectManagerDelete'] 
+ProjectManagerEvent = Literal['projectManagerCreate', 'projectManagerDelete']
 ProjectManagerEvents: tuple[ProjectManagerEvent, ...] = get_args(ProjectManagerEvent)
 
-TaskEvent = Literal['taskCreate', 'taskUpdate', 'taskDelete'] 
+TaskEvent = Literal['taskCreate', 'taskUpdate', 'taskDelete']
 TaskEvents: tuple[TaskEvent, ...] = get_args(TaskEvent)
 
-TaskListEvent = Literal['taskListCreate', 'taskListUpdate', 'taskListDelete'] 
+TaskListEvent = Literal['taskListCreate', 'taskListUpdate', 'taskListDelete']
 TaskListEvents: tuple[TaskListEvent, ...] = get_args(TaskListEvent)
 
-UserEvent = Literal['userCreate', 'userUpdate', 'userDelete'] 
+UserEvent = Literal['userCreate', 'userUpdate', 'userDelete']
 UserEvents: tuple[UserEvent, ...] = get_args(UserEvent)
 
-WebhookEvent =  Literal['webhookCreate', 'webhookUpdate', 'webhookDelete']
+WebhookEvent = Literal['webhookCreate', 'webhookUpdate', 'webhookDelete']
 WebhookEvents: tuple[WebhookEvent, ...] = get_args(WebhookEvent)
 
 PlankaEvent = (
     ActionEvent | AttachmentEvent | BackgroundImageEvent | BaseCustomFieldGroupEvent |
     BoardEvent | BoardMembershipEvent | CardEvent | CardLabelEvent | CardMembershipEvent |
-    CommentEvent | ConfigEvent | CustomFieldEvent | CustomFieldGroupEvent | 
-    CustomFieldValueEvent | LabelEvent | ListEvent | NotificationEvent | NotificationServiceEvent | 
+    CommentEvent | ConfigEvent | CustomFieldEvent | CustomFieldGroupEvent |
+    CustomFieldValueEvent | LabelEvent | ListEvent | NotificationEvent | NotificationServiceEvent |
     ProjectEvent | ProjectManagerEvent | TaskEvent | TaskListEvent | UserEvent | WebhookEvent
 )
 

--- a/src/plankapy/v2/api/paths.py
+++ b/src/plankapy/v2/api/paths.py
@@ -38,7 +38,7 @@ class PlankaEndpoints:
 
         Raises:
             ValidationError: 400
-             Error: 401 Invalid pending token
+            Error: 401 Invalid pending token
             Error: 403 Authentication restriction
         """
         resp = self.client.post("api/access-tokens/accept-terms", json=kwargs)
@@ -60,7 +60,7 @@ class PlankaEndpoints:
 
         Raises:
             ValidationError: 400
-             Error: 401 Invalid credentials
+            Error: 401 Invalid credentials
             Error: 403 Authentication restriction
         """
         resp = self.client.post("api/access-tokens", json=kwargs)
@@ -77,7 +77,7 @@ class PlankaEndpoints:
 
         Raises:
             Unauthorized: 401
-         """
+        """
         resp = self.client.delete("api/access-tokens/me")
         raise_planka_err(resp)
         return resp.json()
@@ -121,7 +121,7 @@ class PlankaEndpoints:
         Raises:
             ValidationError: 400
             NotFound: 404
-         """
+        """
         resp = self.client.post("api/access-tokens/revoke-pending-token", json=kwargs)
         raise_planka_err(resp)
         return resp.json()
@@ -142,7 +142,7 @@ class PlankaEndpoints:
             ValidationError: 400
             Unauthorized: 401
             NotFound: 404
-         """
+        """
         valid_params = ('beforeId',)
         passed_params = {k: v for k, v in kwargs.items() if k in valid_params if isinstance(v, str | int | float)}
         resp = self.client.get(f"api/boards/{boardId}/actions", params=passed_params)
@@ -165,7 +165,7 @@ class PlankaEndpoints:
             ValidationError: 400
             Unauthorized: 401
             NotFound: 404
-         """
+        """
         valid_params = ('beforeId',)
         passed_params = {k: v for k, v in kwargs.items() if k in valid_params if isinstance(v, str | int | float)}
         resp = self.client.get(f"api/cards/{cardId}/actions", params=passed_params)
@@ -229,7 +229,7 @@ class PlankaEndpoints:
             Unauthorized: 401
             Forbidden: 403
             NotFound: 404
-         """
+        """
         resp = self.client.delete(f"api/attachments/{id}")
         raise_planka_err(resp)
         return resp.json()
@@ -251,7 +251,7 @@ class PlankaEndpoints:
             Unauthorized: 401
             Forbidden: 403
             NotFound: 404
-         """
+        """
         resp = self.client.patch(f"api/attachments/{id}", json=kwargs)
         raise_planka_err(resp)
         return resp.json()
@@ -299,7 +299,7 @@ class PlankaEndpoints:
             Unauthorized: 401
             Forbidden: 403
             NotFound: 404
-         """
+        """
         resp = self.client.delete(f"api/background-images/{id}")
         raise_planka_err(resp)
         return resp.json()
@@ -321,7 +321,7 @@ class PlankaEndpoints:
             Unauthorized: 401
             Forbidden: 403
             NotFound: 404
-         """
+        """
         resp = self.client.post(f"api/projects/{projectId}/base-custom-field-groups", json=kwargs)
         raise_planka_err(resp)
         return resp.json()
@@ -342,7 +342,7 @@ class PlankaEndpoints:
             Unauthorized: 401
             Forbidden: 403
             NotFound: 404
-         """
+        """
         resp = self.client.delete(f"api/base-custom-field-groups/{id}")
         raise_planka_err(resp)
         return resp.json()
@@ -364,7 +364,7 @@ class PlankaEndpoints:
             Unauthorized: 401
             Forbidden: 403
             NotFound: 404
-         """
+        """
         resp = self.client.patch(f"api/base-custom-field-groups/{id}", json=kwargs)
         raise_planka_err(resp)
         return resp.json()
@@ -389,7 +389,7 @@ class PlankaEndpoints:
             Forbidden: 403
             NotFound: 404
             Conflict: 409
-         """
+        """
         resp = self.client.post(f"api/boards/{boardId}/board-memberships", json=kwargs)
         raise_planka_err(resp)
         return resp.json()
@@ -409,7 +409,7 @@ class PlankaEndpoints:
             ValidationError: 400
             Unauthorized: 401
             NotFound: 404
-         """
+        """
         resp = self.client.delete(f"api/board-memberships/{id}")
         raise_planka_err(resp)
         return resp.json()
@@ -431,7 +431,7 @@ class PlankaEndpoints:
             ValidationError: 400
             Unauthorized: 401
             NotFound: 404
-         """
+        """
         resp = self.client.patch(f"api/board-memberships/{id}", json=kwargs)
         raise_planka_err(resp)
         return resp.json()
@@ -456,7 +456,7 @@ class PlankaEndpoints:
             ValidationError: 400
             Unauthorized: 401
             NotFound: 404
-             Error: 422 Import file upload error
+            Error: 422 Import file upload error
         """
         if imp_file := kwargs.pop('importFile', None):
             resp = self.client.post(
@@ -483,7 +483,7 @@ class PlankaEndpoints:
             ValidationError: 400
             Unauthorized: 401
             NotFound: 404
-         """
+        """
         resp = self.client.delete(f"api/boards/{id}")
         raise_planka_err(resp)
         return resp.json()
@@ -504,7 +504,7 @@ class PlankaEndpoints:
             ValidationError: 400
             Unauthorized: 401
             NotFound: 404
-         """
+        """
         valid_params = ('subscribe',)
         passed_params = {k: v for k, v in kwargs.items() if k in valid_params if isinstance(v, str | int | float)}
         resp = self.client.get(f"api/boards/{id}", params=passed_params)
@@ -534,7 +534,7 @@ class PlankaEndpoints:
             ValidationError: 400
             Unauthorized: 401
             NotFound: 404
-         """
+        """
         resp = self.client.patch(f"api/boards/{id}", json=kwargs)
         raise_planka_err(resp)
         return resp.json()
@@ -564,7 +564,7 @@ class PlankaEndpoints:
             Forbidden: 403
             NotFound: 404
             Conflict: 409
-         """
+        """
         resp = self.client.post(f"api/cards/{cardId}/card-labels", json=kwargs)
         raise_planka_err(resp)
         return resp.json()
@@ -586,7 +586,7 @@ class PlankaEndpoints:
             Unauthorized: 401
             Forbidden: 403
             NotFound: 404
-         """
+        """
         resp = self.client.delete(f"api/cards/{cardId}/card-labels/labelId:{labelId}")
         raise_planka_err(resp)
         return resp.json()
@@ -609,7 +609,7 @@ class PlankaEndpoints:
             Forbidden: 403
             NotFound: 404
             Conflict: 409
-         """
+        """
         resp = self.client.post(f"api/cards/{cardId}/card-memberships", json=kwargs)
         raise_planka_err(resp)
         return resp.json()
@@ -631,7 +631,7 @@ class PlankaEndpoints:
             Unauthorized: 401
             Forbidden: 403
             NotFound: 404
-         """
+        """
         resp = self.client.delete(f"api/cards/{cardId}/card-memberships/userId:{userId}")
         raise_planka_err(resp)
         return resp.json()
@@ -660,7 +660,7 @@ class PlankaEndpoints:
             Forbidden: 403
             NotFound: 404
             UnprocessableEntity: 422
-         """
+        """
         resp = self.client.post(f"api/lists/{listId}/cards", json=kwargs)
         raise_planka_err(resp)
         return resp.json()
@@ -685,7 +685,7 @@ class PlankaEndpoints:
             ValidationError: 400
             Unauthorized: 401
             NotFound: 404
-         """
+        """
         # Monkey patch since brackets cannot be used in varaible names
         if 'before_listChangedAt' in kwargs:
             kwargs['before[listChangedAt]'] = kwargs.pop('before_listChangedAt')  # type: ignore
@@ -714,7 +714,7 @@ class PlankaEndpoints:
             Unauthorized: 401
             Forbidden: 403
             NotFound: 404
-         """
+        """
         resp = self.client.delete(f"api/cards/{id}")
         raise_planka_err(resp)
         return resp.json()
@@ -734,7 +734,7 @@ class PlankaEndpoints:
             ValidationError: 400
             Unauthorized: 401
             NotFound: 404
-         """
+        """
         resp = self.client.get(f"api/cards/{id}")
         raise_planka_err(resp)
         return resp.json()
@@ -767,7 +767,7 @@ class PlankaEndpoints:
             Forbidden: 403
             NotFound: 404
             UnprocessableEntity: 422
-         """
+        """
         resp = self.client.patch(f"api/cards/{id}", json=kwargs)
         raise_planka_err(resp)
         return resp.json()
@@ -793,7 +793,7 @@ class PlankaEndpoints:
             Forbidden: 403
             NotFound: 404
             UnprocessableEntity: 422
-         """
+        """
         resp = self.client.post(f"api/cards/{id}/duplicate", json=kwargs)
         raise_planka_err(resp)
         return resp.json()
@@ -813,7 +813,7 @@ class PlankaEndpoints:
             ValidationError: 400
             Unauthorized: 401
             NotFound: 404
-         """
+        """
         resp = self.client.post(f"api/cards/{id}/read-notifications")
         raise_planka_err(resp)
         return resp.json()
@@ -835,7 +835,7 @@ class PlankaEndpoints:
             Unauthorized: 401
             Forbidden: 403
             NotFound: 404
-         """
+        """
         resp = self.client.post(f"api/cards/{cardId}/comments", json=kwargs)
         raise_planka_err(resp)
         return resp.json()
@@ -856,7 +856,7 @@ class PlankaEndpoints:
             ValidationError: 400
             Unauthorized: 401
             NotFound: 404
-         """
+        """
         valid_params = ('beforeId',)
         passed_params = {k: v for k, v in kwargs.items() if k in valid_params if isinstance(v, str | int | float)}
         resp = self.client.get(f"api/cards/{cardId}/comments", params=passed_params)
@@ -879,7 +879,7 @@ class PlankaEndpoints:
             Unauthorized: 401
             Forbidden: 403
             NotFound: 404
-         """
+        """
         resp = self.client.delete(f"api/comments/{id}")
         raise_planka_err(resp)
         return resp.json()
@@ -901,7 +901,7 @@ class PlankaEndpoints:
             Unauthorized: 401
             Forbidden: 403
             NotFound: 404
-         """
+        """
         resp = self.client.patch(f"api/comments/{id}", json=kwargs)
         raise_planka_err(resp)
         return resp.json()
@@ -940,8 +940,8 @@ class PlankaEndpoints:
 
         Raises:
             Unauthorized: 401
-             Forbidden: 403
-         """
+            Forbidden: 403
+        """
         resp = self.client.post("api/config/test-smtp")
         raise_planka_err(resp)
         return resp.json()
@@ -966,7 +966,7 @@ class PlankaEndpoints:
             Forbidden: 403
             NotFound: 404
             UnprocessableEntity: 422
-         """
+        """
         resp = self.client.post(f"api/boards/{boardId}/custom-field-groups", json=kwargs)
         raise_planka_err(resp)
         return resp.json()
@@ -991,7 +991,7 @@ class PlankaEndpoints:
             Forbidden: 403
             NotFound: 404
             UnprocessableEntity: 422
-         """
+        """
         resp = self.client.post(f"api/cards/{cardId}/custom-field-groups", json=kwargs)
         raise_planka_err(resp)
         return resp.json()
@@ -1012,7 +1012,7 @@ class PlankaEndpoints:
             Unauthorized: 401
             Forbidden: 403
             NotFound: 404
-         """
+        """
         resp = self.client.delete(f"api/custom-field-groups/{id}")
         raise_planka_err(resp)
         return resp.json()
@@ -1032,7 +1032,7 @@ class PlankaEndpoints:
             ValidationError: 400
             Unauthorized: 401
             NotFound: 404
-         """
+        """
         resp = self.client.get(f"api/custom-field-groups/{id}")
         raise_planka_err(resp)
         return resp.json()
@@ -1056,7 +1056,7 @@ class PlankaEndpoints:
             Forbidden: 403
             NotFound: 404
             UnprocessableEntity: 422
-         """
+        """
         resp = self.client.patch(f"api/custom-field-groups/{id}", json=kwargs)
         raise_planka_err(resp)
         return resp.json()
@@ -1126,7 +1126,7 @@ class PlankaEndpoints:
             ValidationError: 400
             Unauthorized: 401
             NotFound: 404
-         """
+        """
         resp = self.client.post(f"api/base-custom-field-groups/{baseCustomFieldGroupId}/custom-fields", json=kwargs)
         raise_planka_err(resp)
         return resp.json()
@@ -1150,7 +1150,7 @@ class PlankaEndpoints:
             Unauthorized: 401
             Forbidden: 403
             NotFound: 404
-         """
+        """
         resp = self.client.post(f"api/custom-field-groups/{customFieldGroupId}/custom-fields", json=kwargs)
         raise_planka_err(resp)
         return resp.json()
@@ -1171,7 +1171,7 @@ class PlankaEndpoints:
             Unauthorized: 401
             Forbidden: 403
             NotFound: 404
-         """
+        """
         resp = self.client.delete(f"api/custom-fields/{id}")
         raise_planka_err(resp)
         return resp.json()
@@ -1195,7 +1195,7 @@ class PlankaEndpoints:
             Unauthorized: 401
             Forbidden: 403
             NotFound: 404
-         """
+        """
         resp = self.client.patch(f"api/custom-fields/{id}", json=kwargs)
         raise_planka_err(resp)
         return resp.json()
@@ -1219,7 +1219,7 @@ class PlankaEndpoints:
             Unauthorized: 401
             Forbidden: 403
             NotFound: 404
-         """
+        """
         resp = self.client.post(f"api/boards/{boardId}/labels", json=kwargs)
         raise_planka_err(resp)
         return resp.json()
@@ -1240,7 +1240,7 @@ class PlankaEndpoints:
             Unauthorized: 401
             Forbidden: 403
             NotFound: 404
-         """
+        """
         resp = self.client.delete(f"api/labels/{id}")
         raise_planka_err(resp)
         return resp.json()
@@ -1264,7 +1264,7 @@ class PlankaEndpoints:
             Unauthorized: 401
             Forbidden: 403
             NotFound: 404
-         """
+        """
         resp = self.client.patch(f"api/labels/{id}", json=kwargs)
         raise_planka_err(resp)
         return resp.json()
@@ -1285,7 +1285,7 @@ class PlankaEndpoints:
             Unauthorized: 401
             Forbidden: 403
             NotFound: 404
-         """
+        """
         resp = self.client.post(f"api/lists/{id}/clear")
         raise_planka_err(resp)
         return resp.json()
@@ -1309,7 +1309,7 @@ class PlankaEndpoints:
             Unauthorized: 401
             Forbidden: 403
             NotFound: 404
-         """
+        """
         resp = self.client.post(f"api/boards/{boardId}/lists", json=kwargs)
         raise_planka_err(resp)
         return resp.json()
@@ -1330,7 +1330,7 @@ class PlankaEndpoints:
             Unauthorized: 401
             Forbidden: 403
             NotFound: 404
-         """
+        """
         resp = self.client.delete(f"api/lists/{id}")
         raise_planka_err(resp)
         return resp.json()
@@ -1350,7 +1350,7 @@ class PlankaEndpoints:
             ValidationError: 400
             Unauthorized: 401
             NotFound: 404
-         """
+        """
         resp = self.client.get(f"api/lists/{id}")
         raise_planka_err(resp)
         return resp.json()
@@ -1376,7 +1376,7 @@ class PlankaEndpoints:
             Unauthorized: 401
             Forbidden: 403
             NotFound: 404
-         """
+        """
         resp = self.client.patch(f"api/lists/{id}", json=kwargs)
         raise_planka_err(resp)
         return resp.json()
@@ -1398,7 +1398,7 @@ class PlankaEndpoints:
             Unauthorized: 401
             Forbidden: 403
             NotFound: 404
-         """
+        """
         resp = self.client.post(f"api/lists/{id}/move-cards", json=kwargs)
         raise_planka_err(resp)
         return resp.json()
@@ -1422,7 +1422,7 @@ class PlankaEndpoints:
             Forbidden: 403
             NotFound: 404
             UnprocessableEntity: 422
-         """
+        """
         resp = self.client.post(f"api/lists/{id}/sort", json=kwargs)
         raise_planka_err(resp)
         return resp.json()
@@ -1445,7 +1445,7 @@ class PlankaEndpoints:
             Unauthorized: 401
             NotFound: 404
             Conflict: 409
-         """
+        """
         resp = self.client.post(f"api/boards/{boardId}/notification-services", json=kwargs)
         raise_planka_err(resp)
         return resp.json()
@@ -1468,7 +1468,7 @@ class PlankaEndpoints:
             Unauthorized: 401
             NotFound: 404
             Conflict: 409
-         """
+        """
         resp = self.client.post(f"api/users/{userId}/notification-services", json=kwargs)
         raise_planka_err(resp)
         return resp.json()
@@ -1488,7 +1488,7 @@ class PlankaEndpoints:
             ValidationError: 400
             Unauthorized: 401
             NotFound: 404
-         """
+        """
         resp = self.client.delete(f"api/notification-services/{id}")
         raise_planka_err(resp)
         return resp.json()
@@ -1510,7 +1510,7 @@ class PlankaEndpoints:
             ValidationError: 400
             Unauthorized: 401
             NotFound: 404
-         """
+        """
         resp = self.client.patch(f"api/notification-services/{id}", json=kwargs)
         raise_planka_err(resp)
         return resp.json()
@@ -1530,7 +1530,7 @@ class PlankaEndpoints:
             ValidationError: 400
             Unauthorized: 401
             NotFound: 404
-         """
+        """
         resp = self.client.post(f"api/notification-services/{id}/test")
         raise_planka_err(resp)
         return resp.json()
@@ -1545,8 +1545,8 @@ class PlankaEndpoints:
 
         Raises:
             ValidationError: 400
-             Unauthorized: 401
-         """
+            Unauthorized: 401
+        """
         resp = self.client.get("api/notifications")
         raise_planka_err(resp)
         return resp.json()
@@ -1561,8 +1561,8 @@ class PlankaEndpoints:
 
         Raises:
             ValidationError: 400
-             Unauthorized: 401
-         """
+            Unauthorized: 401
+        """
         resp = self.client.post("api/notifications/read-all")
         raise_planka_err(resp)
         return resp.json()
@@ -1582,7 +1582,7 @@ class PlankaEndpoints:
             ValidationError: 400
             Unauthorized: 401
             NotFound: 404
-         """
+        """
         resp = self.client.get(f"api/notifications/{id}")
         raise_planka_err(resp)
         return resp.json()
@@ -1603,7 +1603,7 @@ class PlankaEndpoints:
             ValidationError: 400
             Unauthorized: 401
             NotFound: 404
-         """
+        """
         resp = self.client.patch(f"api/notifications/{id}", json=kwargs)
         raise_planka_err(resp)
         return resp.json()
@@ -1627,7 +1627,7 @@ class PlankaEndpoints:
             NotFound: 404
             Conflict: 409
             UnprocessableEntity: 422
-         """
+        """
         resp = self.client.post(f"api/projects/{projectId}/project-managers", json=kwargs)
         raise_planka_err(resp)
         return resp.json()
@@ -1649,7 +1649,7 @@ class PlankaEndpoints:
             Forbidden: 403
             NotFound: 404
             UnprocessableEntity: 422
-         """
+        """
         resp = self.client.delete(f"api/project-managers/{id}")
         raise_planka_err(resp)
         return resp.json()
@@ -1669,8 +1669,8 @@ class PlankaEndpoints:
 
         Raises:
             ValidationError: 400
-             Unauthorized: 401
-         """
+            Unauthorized: 401
+        """
         resp = self.client.post("api/projects", json=kwargs)
         raise_planka_err(resp)
         return resp.json()
@@ -1685,8 +1685,8 @@ class PlankaEndpoints:
 
         Raises:
             ValidationError: 400
-             Unauthorized: 401
-         """
+            Unauthorized: 401
+        """
         resp = self.client.get("api/projects")
         raise_planka_err(resp)
         return resp.json()
@@ -1707,7 +1707,7 @@ class PlankaEndpoints:
             Unauthorized: 401
             NotFound: 404
             UnprocessableEntity: 422
-         """
+        """
         resp = self.client.delete(f"api/projects/{id}")
         raise_planka_err(resp)
         return resp.json()
@@ -1727,7 +1727,7 @@ class PlankaEndpoints:
             ValidationError: 400
             Unauthorized: 401
             NotFound: 404
-         """
+        """
         resp = self.client.get(f"api/projects/{id}")
         raise_planka_err(resp)
         return resp.json()
@@ -1758,7 +1758,7 @@ class PlankaEndpoints:
             NotFound: 404
             Conflict: 409
             UnprocessableEntity: 422
-         """
+        """
         resp = self.client.patch(f"api/projects/{id}", json=kwargs)
         raise_planka_err(resp)
         return resp.json()
@@ -1783,7 +1783,7 @@ class PlankaEndpoints:
             Unauthorized: 401
             Forbidden: 403
             NotFound: 404
-         """
+        """
         resp = self.client.post(f"api/cards/{cardId}/task-lists", json=kwargs)
         raise_planka_err(resp)
         return resp.json()
@@ -1804,7 +1804,7 @@ class PlankaEndpoints:
             Unauthorized: 401
             Forbidden: 403
             NotFound: 404
-         """
+        """
         resp = self.client.delete(f"api/task-lists/{id}")
         raise_planka_err(resp)
         return resp.json()
@@ -1824,7 +1824,7 @@ class PlankaEndpoints:
             ValidationError: 400
             Unauthorized: 401
             NotFound: 404
-         """
+        """
         resp = self.client.get(f"api/task-lists/{id}")
         raise_planka_err(resp)
         return resp.json()
@@ -1849,7 +1849,7 @@ class PlankaEndpoints:
             Unauthorized: 401
             Forbidden: 403
             NotFound: 404
-         """
+        """
         resp = self.client.patch(f"api/task-lists/{id}", json=kwargs)
         raise_planka_err(resp)
         return resp.json()
@@ -1875,7 +1875,7 @@ class PlankaEndpoints:
             Forbidden: 403
             NotFound: 404
             UnprocessableEntity: 422
-         """
+        """
         resp = self.client.post(f"api/task-lists/{taskListId}/tasks", json=kwargs)
         raise_planka_err(resp)
         return resp.json()
@@ -1896,7 +1896,7 @@ class PlankaEndpoints:
             Unauthorized: 401
             Forbidden: 403
             NotFound: 404
-         """
+        """
         resp = self.client.delete(f"api/tasks/{id}")
         raise_planka_err(resp)
         return resp.json()
@@ -1922,7 +1922,7 @@ class PlankaEndpoints:
             Unauthorized: 401
             Forbidden: 403
             NotFound: 404
-         """
+        """
         resp = self.client.patch(f"api/tasks/{id}", json=kwargs)
         raise_planka_err(resp)
         return resp.json()
@@ -1942,7 +1942,7 @@ class PlankaEndpoints:
             ValidationError: 400
             Unauthorized: 401
             NotFound: 404
-         """
+        """
         valid_params = ('language',)
         passed_params = {k: v for k, v in kwargs.items() if k in valid_params if isinstance(v, str | int | float)}
         resp = self.client.get("api/terms", params=passed_params)
@@ -1964,7 +1964,7 @@ class PlankaEndpoints:
             ValidationError: 400
             Unauthorized: 401
             NotFound: 404
-         """
+        """
         resp = self.client.post(f"api/users/{id}/api-key")
         raise_planka_err(resp)
         return resp.json()
@@ -1992,10 +1992,10 @@ class PlankaEndpoints:
 
         Raises:
             ValidationError: 400
-             Unauthorized: 401
-             Forbidden: 403
+            Unauthorized: 401
+            Forbidden: 403
             Conflict: 409
-         """
+        """
         resp = self.client.post("api/users", json=kwargs)
         raise_planka_err(resp)
         return resp.json()
@@ -2010,9 +2010,9 @@ class PlankaEndpoints:
 
         Raises:
             ValidationError: 400
-             Unauthorized: 401
-             Forbidden: 403
-         """
+            Unauthorized: 401
+            Forbidden: 403
+        """
         resp = self.client.get("api/users")
         raise_planka_err(resp)
         return resp.json()
@@ -2033,7 +2033,7 @@ class PlankaEndpoints:
             Unauthorized: 401
             Forbidden: 403
             NotFound: 404
-         """
+        """
         resp = self.client.delete(f"api/users/{id}")
         raise_planka_err(resp)
         return resp.json()
@@ -2054,7 +2054,7 @@ class PlankaEndpoints:
             ValidationError: 400
             Unauthorized: 401
             NotFound: 404
-         """
+        """
         valid_params = ('subscribe',)
         passed_params = {k: v for k, v in kwargs.items() if k in valid_params if isinstance(v, str | int | float)}
         resp = self.client.get(f"api/users/{id}", params=passed_params)
@@ -2094,7 +2094,7 @@ class PlankaEndpoints:
             Forbidden: 403
             NotFound: 404
             Conflict: 409
-         """
+        """
         resp = self.client.patch(f"api/users/{id}", json=kwargs)
         raise_planka_err(resp)
         return resp.json()
@@ -2143,7 +2143,7 @@ class PlankaEndpoints:
             Forbidden: 403
             NotFound: 404
             Conflict: 409
-         """
+        """
         resp = self.client.patch(f"api/users/{id}/email", json=kwargs)
         raise_planka_err(resp)
         return resp.json()
@@ -2166,7 +2166,7 @@ class PlankaEndpoints:
             Unauthorized: 401
             Forbidden: 403
             NotFound: 404
-         """
+        """
         resp = self.client.patch(f"api/users/{id}/password", json=kwargs)
         raise_planka_err(resp)
         return resp.json()
@@ -2190,7 +2190,7 @@ class PlankaEndpoints:
             Forbidden: 403
             NotFound: 404
             Conflict: 409
-         """
+        """
         resp = self.client.patch(f"api/users/{id}/username", json=kwargs)
         raise_planka_err(resp)
         return resp.json()
@@ -2212,9 +2212,9 @@ class PlankaEndpoints:
 
         Raises:
             ValidationError: 400
-             Unauthorized: 401
+            Unauthorized: 401
             Conflict: 409
-         """
+        """
         resp = self.client.post("api/webhooks", json=kwargs)
         raise_planka_err(resp)
         return resp.json()
@@ -2229,8 +2229,8 @@ class PlankaEndpoints:
 
         Raises:
             ValidationError: 400
-             Unauthorized: 401
-         """
+            Unauthorized: 401
+        """
         resp = self.client.get("api/webhooks")
         raise_planka_err(resp)
         return resp.json()
@@ -2250,7 +2250,7 @@ class PlankaEndpoints:
             ValidationError: 400
             Unauthorized: 401
             NotFound: 404
-         """
+        """
         resp = self.client.delete(f"api/webhooks/{id}")
         raise_planka_err(resp)
         return resp.json()
@@ -2275,7 +2275,7 @@ class PlankaEndpoints:
             ValidationError: 400
             Unauthorized: 401
             NotFound: 404
-         """
+        """
         resp = self.client.patch(f"api/webhooks/{id}", json=kwargs)
         raise_planka_err(resp)
         return resp.json()

--- a/src/plankapy/v2/api/paths.py
+++ b/src/plankapy/v2/api/paths.py
@@ -1,13 +1,14 @@
 from __future__ import annotations
-from typing import (
-    Unpack,
-)
-from httpx import Client, Response, HTTPStatusError
-from .schemas import *
-from .typ import *
-from .errors import *
+
+from typing import Unpack
+
+from httpx import Client, HTTPStatusError, Response
+
+from . import typ
+from .errors import ERRORS, PlankaError
 
 __all__ = ("PlankaEndpoints",)
+
 
 def raise_planka_err(resp: Response) -> None:
     try:
@@ -20,11 +21,12 @@ def raise_planka_err(resp: Response) -> None:
         except Exception as e:
             raise status_err from e
 
+
 class PlankaEndpoints:
     def __init__(self, client: Client) -> None:
         self.client = client
 
-    def acceptTerms(self, **kwargs: Unpack[Request_acceptTerms]) -> Response_acceptTerms:
+    def acceptTerms(self, **kwargs: Unpack[typ.Request_acceptTerms]) -> typ.Response_acceptTerms:
         """Accept terms during the authentication flow. Converts the pending token to an access token.
 
         Args:
@@ -33,20 +35,20 @@ class PlankaEndpoints:
             initialLanguage (Literal['ar-YE', 'bg-BG', 'ca-ES', 'cs-CZ', 'da-DK', 'de-DE', 'el-GR', 'en-GB', 'en-US', 'es-ES', 'et-EE', 'fa-IR', 'fi-FI', 'fr-FR', 'hu-HU', 'id-ID', 'it-IT', 'ja-JP', 'ko-KR', 'nl-NL', 'pl-PL', 'pt-BR', 'pt-PT', 'ro-RO', 'ru-RU', 'sk-SK', 'sr-Cyrl-RS', 'sr-Latn-RS', 'sv-SE', 'tr-TR', 'uk-UA', 'uz-UZ', 'vi-VN', 'zh-CN', 'zh-TW'] | None): Preferred language for user interface and notifications (used only if user language is not set)
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
-            Planka internal status codes and names are included here for disambiguation
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Error: 401 Invalid pending token
+            ValidationError: 400
+             Error: 401 Invalid pending token
             Error: 403 Authentication restriction
         """
         resp = self.client.post("api/access-tokens/accept-terms", json=kwargs)
         raise_planka_err(resp)
         return resp.json()
 
-    def createAccessToken(self, **kwargs: Unpack[Request_createAccessToken]) -> Response_createAccessToken:
+    def createAccessToken(self, **kwargs: Unpack[typ.Request_createAccessToken]) -> typ.Response_createAccessToken:
         """Authenticates a user using email/username and password. Returns an access token for API authentication.
 
         Args:
@@ -55,35 +57,35 @@ class PlankaEndpoints:
             withHttpOnlyToken (bool): Whether to include an HTTP-only authentication cookie
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
-            Planka internal status codes and names are included here for disambiguation
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Error: 401 Invalid credentials
+            ValidationError: 400
+             Error: 401 Invalid credentials
             Error: 403 Authentication restriction
         """
         resp = self.client.post("api/access-tokens", json=kwargs)
         raise_planka_err(resp)
         return resp.json()
 
-    def deleteAccessToken(self) -> Response_deleteAccessToken:
+    def deleteAccessToken(self) -> typ.Response_deleteAccessToken:
         """Logs out the current user by deleting the session and access token. Clears HTTP-only cookies if present.
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
-            Planka internal status codes and names are included here for disambiguation
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            Unauthorized: 401 
-        """
+            Unauthorized: 401
+         """
         resp = self.client.delete("api/access-tokens/me")
         raise_planka_err(resp)
         return resp.json()
 
-    def exchangeForAccessTokenWithOidc(self, **kwargs: Unpack[Request_exchangeForAccessTokenWithOidc]) -> Response_exchangeForAccessTokenWithOidc:
+    def exchangeForAccessTokenWithOidc(self, **kwargs: Unpack[typ.Request_exchangeForAccessTokenWithOidc]) -> typ.Response_exchangeForAccessTokenWithOidc:
         """Exchanges an OIDC authorization code for an access token. Creates a user if they do not exist.
 
         Args:
@@ -92,12 +94,12 @@ class PlankaEndpoints:
             withHttpOnlyToken (bool): Whether to include HTTP-only authentication cookie
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
-            Planka internal status codes and names are included here for disambiguation
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
+            ValidationError: 400
             Error: 401 OIDC authentication error
             Error: 403 Authentication restriction
             Error: 409 Conflict error
@@ -108,26 +110,26 @@ class PlankaEndpoints:
         raise_planka_err(resp)
         return resp.json()
 
-    def revokePendingToken(self, **kwargs: Unpack[Request_revokePendingToken]) -> Response_revokePendingToken:
+    def revokePendingToken(self, **kwargs: Unpack[typ.Request_revokePendingToken]) -> typ.Response_revokePendingToken:
         """Revokes a pending authentication token and cancels the authentication flow.
 
         Args:
             pendingToken (str): Pending token to revoke
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
-            Planka internal status codes and names are included here for disambiguation
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            NotFound: 404 
-        """
+            ValidationError: 400
+            NotFound: 404
+         """
         resp = self.client.post("api/access-tokens/revoke-pending-token", json=kwargs)
         raise_planka_err(resp)
         return resp.json()
 
-    def getBoardActions(self, boardId: str, **kwargs: Unpack[Request_getBoardActions]) -> Response_getBoardActions:
+    def getBoardActions(self, boardId: str, **kwargs: Unpack[typ.Request_getBoardActions]) -> typ.Response_getBoardActions:
         """Retrieves a list of actions (activity history) for a specific board, with pagination support.
 
         Args:
@@ -135,22 +137,22 @@ class PlankaEndpoints:
             beforeId (str): ID to get actions before (for pagination)) (optional)
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
-            Planka internal status codes and names are included here for disambiguation
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            NotFound: 404 
-        """
+            ValidationError: 400
+            Unauthorized: 401
+            NotFound: 404
+         """
         valid_params = ('beforeId',)
         passed_params = {k: v for k, v in kwargs.items() if k in valid_params if isinstance(v, str | int | float)}
         resp = self.client.get(f"api/boards/{boardId}/actions", params=passed_params)
         raise_planka_err(resp)
         return resp.json()
 
-    def getCardActions(self, cardId: str, **kwargs: Unpack[Request_getCardActions]) -> Response_getCardActions:
+    def getCardActions(self, cardId: str, **kwargs: Unpack[typ.Request_getCardActions]) -> typ.Response_getCardActions:
         """Retrieves a list of actions (activity history) for a specific card, with pagination support.
 
         Args:
@@ -158,22 +160,22 @@ class PlankaEndpoints:
             beforeId (str): ID to get actions before (for pagination)) (optional)
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
-            Planka internal status codes and names are included here for disambiguation
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            NotFound: 404 
-        """
+            ValidationError: 400
+            Unauthorized: 401
+            NotFound: 404
+         """
         valid_params = ('beforeId',)
         passed_params = {k: v for k, v in kwargs.items() if k in valid_params if isinstance(v, str | int | float)}
         resp = self.client.get(f"api/cards/{cardId}/actions", params=passed_params)
         raise_planka_err(resp)
         return resp.json()
 
-    def createAttachment(self, cardId: str, mime_type: str|None=None, **kwargs: Unpack[Request_createAttachment]) -> Response_createAttachment:
+    def createAttachment(self, cardId: str, mime_type: str | None = None, **kwargs: Unpack[typ.Request_createAttachment]) -> typ.Response_createAttachment:
         """Creates an attachment on a card. Requires board editor permissions.
 
         Args:
@@ -186,56 +188,56 @@ class PlankaEndpoints:
             requestId (str): Request ID for tracking
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
-            Planka internal status codes and names are included here for disambiguation
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            Forbidden: 403 
-            NotFound: 404 
+            ValidationError: 400
+            Unauthorized: 401
+            Forbidden: 403
+            NotFound: 404
             Error: 422 Upload or validation error
         """
         # Handle file attachment
         if kwargs.get('type') == 'file':
             file_data = kwargs.pop('file')
             name = kwargs['name']
-            resp = self.client.post(f"api/cards/{cardId}/attachments", 
-                data=kwargs, 
-                files={'file': (name, file_data, mime_type)}, 
+            resp = self.client.post(f"api/cards/{cardId}/attachments",
+                data=kwargs,
+                files={'file': (name, file_data, mime_type)},
             )
             raise_planka_err(resp)
 
-        # Handle link attachment 
+        # Handle link attachment
         else:
             resp = self.client.post(f"api/cards/{cardId}/attachments", json=kwargs)
             raise_planka_err(resp)
-        
+
         return resp.json()
 
-    def deleteAttachment(self, id: str) -> Response_deleteAttachment:
+    def deleteAttachment(self, id: str) -> typ.Response_deleteAttachment:
         """Deletes an attachment. Requires board editor permissions.
 
         Args:
             id (str): ID of the attachment to delete)
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
-            Planka internal status codes and names are included here for disambiguation
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            Forbidden: 403 
-            NotFound: 404 
-        """
+            ValidationError: 400
+            Unauthorized: 401
+            Forbidden: 403
+            NotFound: 404
+         """
         resp = self.client.delete(f"api/attachments/{id}")
         raise_planka_err(resp)
         return resp.json()
 
-    def updateAttachment(self, id: str, **kwargs: Unpack[Request_updateAttachment]) -> Response_updateAttachment:
+    def updateAttachment(self, id: str, **kwargs: Unpack[typ.Request_updateAttachment]) -> typ.Response_updateAttachment:
         """Updates an attachment. Requires board editor permissions.
 
         Args:
@@ -243,21 +245,21 @@ class PlankaEndpoints:
             name (str): Name/title of the attachment
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
-            Planka internal status codes and names are included here for disambiguation
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            Forbidden: 403 
-            NotFound: 404 
-        """
+            ValidationError: 400
+            Unauthorized: 401
+            Forbidden: 403
+            NotFound: 404
+         """
         resp = self.client.patch(f"api/attachments/{id}", json=kwargs)
         raise_planka_err(resp)
         return resp.json()
 
-    def createBackgroundImage(self, projectId: str, mime_type: str | None=None, **kwargs: Unpack[Request_createBackgroundImage]) -> Response_createBackgroundImage:
+    def createBackgroundImage(self, projectId: str, mime_type: str | None = None, **kwargs: Unpack[typ.Request_createBackgroundImage]) -> typ.Response_createBackgroundImage:
         """Uploads a background image for a project. Requires project manager permissions.
 
         Args:
@@ -267,45 +269,45 @@ class PlankaEndpoints:
             requestId (str): Request ID for tracking
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
-            Planka internal status codes and names are included here for disambiguation
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            Forbidden: 403 
-            NotFound: 404 
+            ValidationError: 400
+            Unauthorized: 401
+            Forbidden: 403
+            NotFound: 404
             Error: 422 File upload error
         """
-        resp = self.client.post(f"api/projects/{projectId}/background-images", 
-            files={'file': ('background', kwargs['file'], mime_type)}, 
+        resp = self.client.post(f"api/projects/{projectId}/background-images",
+            files={'file': ('background', kwargs['file'], mime_type)},
         )
         raise_planka_err(resp)
         return resp.json()
 
-    def deleteBackgroundImage(self, id: str) -> Response_deleteBackgroundImage:
+    def deleteBackgroundImage(self, id: str) -> typ.Response_deleteBackgroundImage:
         """Deletes a background image. Requires project manager permissions.
 
         Args:
             id (str): ID of the background image to delete)
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
-            Planka internal status codes and names are included here for disambiguation
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            Forbidden: 403 
-            NotFound: 404 
-        """
+            ValidationError: 400
+            Unauthorized: 401
+            Forbidden: 403
+            NotFound: 404
+         """
         resp = self.client.delete(f"api/background-images/{id}")
         raise_planka_err(resp)
         return resp.json()
 
-    def createBaseCustomFieldGroup(self, projectId: str, **kwargs: Unpack[Request_createBaseCustomFieldGroup]) -> Response_createBaseCustomFieldGroup:
+    def createBaseCustomFieldGroup(self, projectId: str, **kwargs: Unpack[typ.Request_createBaseCustomFieldGroup]) -> typ.Response_createBaseCustomFieldGroup:
         """Creates a base custom field group within a project. Requires project manager permissions.
 
         Args:
@@ -313,42 +315,42 @@ class PlankaEndpoints:
             name (str): Name/title of the base custom field group
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
-            Planka internal status codes and names are included here for disambiguation
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            Forbidden: 403 
-            NotFound: 404 
-        """
+            ValidationError: 400
+            Unauthorized: 401
+            Forbidden: 403
+            NotFound: 404
+         """
         resp = self.client.post(f"api/projects/{projectId}/base-custom-field-groups", json=kwargs)
         raise_planka_err(resp)
         return resp.json()
 
-    def deleteBaseCustomFieldGroup(self, id: str) -> Response_deleteBaseCustomFieldGroup:
+    def deleteBaseCustomFieldGroup(self, id: str) -> typ.Response_deleteBaseCustomFieldGroup:
         """Deletes a base custom field group. Requires project manager permissions.
 
         Args:
             id (str): ID of the base custom field group to delete)
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
-            Planka internal status codes and names are included here for disambiguation
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            Forbidden: 403 
-            NotFound: 404 
-        """
+            ValidationError: 400
+            Unauthorized: 401
+            Forbidden: 403
+            NotFound: 404
+         """
         resp = self.client.delete(f"api/base-custom-field-groups/{id}")
         raise_planka_err(resp)
         return resp.json()
 
-    def updateBaseCustomFieldGroup(self, id: str, **kwargs: Unpack[Request_updateBaseCustomFieldGroup]) -> Response_updateBaseCustomFieldGroup:
+    def updateBaseCustomFieldGroup(self, id: str, **kwargs: Unpack[typ.Request_updateBaseCustomFieldGroup]) -> typ.Response_updateBaseCustomFieldGroup:
         """Updates a base custom field group. Requires project manager permissions.
 
         Args:
@@ -356,21 +358,21 @@ class PlankaEndpoints:
             name (str): Name/title of the base custom field group
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
-            Planka internal status codes and names are included here for disambiguation
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            Forbidden: 403 
-            NotFound: 404 
-        """
+            ValidationError: 400
+            Unauthorized: 401
+            Forbidden: 403
+            NotFound: 404
+         """
         resp = self.client.patch(f"api/base-custom-field-groups/{id}", json=kwargs)
         raise_planka_err(resp)
         return resp.json()
 
-    def createBoardMembership(self, boardId: str, **kwargs: Unpack[Request_createBoardMembership]) -> Response_createBoardMembership:
+    def createBoardMembership(self, boardId: str, **kwargs: Unpack[typ.Request_createBoardMembership]) -> typ.Response_createBoardMembership:
         """Creates a board membership within a board. Requires project manager permissions.
 
         Args:
@@ -380,42 +382,42 @@ class PlankaEndpoints:
             canComment (bool | None): Whether the user can comment on cards (applies only to viewers)
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
-            Planka internal status codes and names are included here for disambiguation
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            Forbidden: 403 
-            NotFound: 404 
-            Conflict: 409 
-        """
+            ValidationError: 400
+            Unauthorized: 401
+            Forbidden: 403
+            NotFound: 404
+            Conflict: 409
+         """
         resp = self.client.post(f"api/boards/{boardId}/board-memberships", json=kwargs)
         raise_planka_err(resp)
         return resp.json()
 
-    def deleteBoardMembership(self, id: str) -> Response_deleteBoardMembership:
+    def deleteBoardMembership(self, id: str) -> typ.Response_deleteBoardMembership:
         """Deletes a board membership. Users can remove their own membership, project managers can remove any membership.
 
         Args:
             id (str): ID of the board membership to delete)
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
-            Planka internal status codes and names are included here for disambiguation
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            NotFound: 404 
-        """
+            ValidationError: 400
+            Unauthorized: 401
+            NotFound: 404
+         """
         resp = self.client.delete(f"api/board-memberships/{id}")
         raise_planka_err(resp)
         return resp.json()
 
-    def updateBoardMembership(self, id: str, **kwargs: Unpack[Request_updateBoardMembership]) -> Response_updateBoardMembership:
+    def updateBoardMembership(self, id: str, **kwargs: Unpack[typ.Request_updateBoardMembership]) -> typ.Response_updateBoardMembership:
         """Updates a board membership. Requires project manager permissions.
 
         Args:
@@ -424,20 +426,20 @@ class PlankaEndpoints:
             canComment (bool | None): Whether the user can comment on cards (applies only to viewers)
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
-            Planka internal status codes and names are included here for disambiguation
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            NotFound: 404 
-        """
+            ValidationError: 400
+            Unauthorized: 401
+            NotFound: 404
+         """
         resp = self.client.patch(f"api/board-memberships/{id}", json=kwargs)
         raise_planka_err(resp)
         return resp.json()
 
-    def createBoard(self, projectId: str, **kwargs: Unpack[Request_createBoard]) -> Response_createBoard:
+    def createBoard(self, projectId: str, **kwargs: Unpack[typ.Request_createBoard]) -> typ.Response_createBoard:
         """Creates a board within a project. Supports importing from Trello. Requires project manager permissions.
 
         Args:
@@ -449,47 +451,47 @@ class PlankaEndpoints:
             requestId (str): Request ID for tracking
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
-            Planka internal status codes and names are included here for disambiguation
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            NotFound: 404 
-            Error: 422 Import file upload error
+            ValidationError: 400
+            Unauthorized: 401
+            NotFound: 404
+             Error: 422 Import file upload error
         """
         if imp_file := kwargs.pop('importFile', None):
             resp = self.client.post(
-                f"api/projects/{projectId}/boards", 
-                files={'file': (f'import', imp_file, None)}, 
+                f"api/projects/{projectId}/boards",
+                files={'file': ('import', imp_file, None)},
                 data=kwargs)
         else:
             resp = self.client.post(f"api/projects/{projectId}/boards", json=kwargs)
         raise_planka_err(resp)
         return resp.json()
 
-    def deleteBoard(self, id: str) -> Response_deleteBoard:
+    def deleteBoard(self, id: str) -> typ.Response_deleteBoard:
         """Deletes a board and all its contents (lists, cards, etc.). Requires project manager permissions.
 
         Args:
             id (str): ID of the board to delete)
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
-            Planka internal status codes and names are included here for disambiguation
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            NotFound: 404 
-        """
+            ValidationError: 400
+            Unauthorized: 401
+            NotFound: 404
+         """
         resp = self.client.delete(f"api/boards/{id}")
         raise_planka_err(resp)
         return resp.json()
 
-    def getBoard(self, id: str, **kwargs: Unpack[Request_getBoard]) -> Response_getBoard:
+    def getBoard(self, id: str, **kwargs: Unpack[typ.Request_getBoard]) -> typ.Response_getBoard:
         """Retrieves comprehensive board information, including lists, cards, and other related data.
 
         Args:
@@ -497,22 +499,22 @@ class PlankaEndpoints:
             subscribe (bool): Whether to subscribe to real-time updates for this board (only for socket connections)) (optional)
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
-            Planka internal status codes and names are included here for disambiguation
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            NotFound: 404 
-        """
+            ValidationError: 400
+            Unauthorized: 401
+            NotFound: 404
+         """
         valid_params = ('subscribe',)
         passed_params = {k: v for k, v in kwargs.items() if k in valid_params if isinstance(v, str | int | float)}
         resp = self.client.get(f"api/boards/{id}", params=passed_params)
         raise_planka_err(resp)
         return resp.json()
 
-    def updateBoard(self, id: str, **kwargs: Unpack[Request_updateBoard]) -> Response_updateBoard:
+    def updateBoard(self, id: str, **kwargs: Unpack[typ.Request_updateBoard]) -> typ.Response_updateBoard:
         """Updates a board. Project managers can update all fields, board members can only subscribe/unsubscribe.
 
         Args:
@@ -527,27 +529,27 @@ class PlankaEndpoints:
             isSubscribed (bool): Whether the current user is subscribed to the board
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
-            Planka internal status codes and names are included here for disambiguation
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            NotFound: 404 
-        """
+            ValidationError: 400
+            Unauthorized: 401
+            NotFound: 404
+         """
         resp = self.client.patch(f"api/boards/{id}", json=kwargs)
         raise_planka_err(resp)
         return resp.json()
 
-    def getBootstrap(self) -> Response_getBootstrap:
+    def getBootstrap(self) -> typ.Response_getBootstrap:
         """Retrieves the application bootstrap.
         """
         resp = self.client.get("api/bootstrap")
         raise_planka_err(resp)
         return resp.json()
 
-    def createCardLabel(self, cardId: str, **kwargs: Unpack[Request_createCardLabel]) -> Response_createCardLabel:
+    def createCardLabel(self, cardId: str, **kwargs: Unpack[typ.Request_createCardLabel]) -> typ.Response_createCardLabel:
         """Adds a label to a card. Requires board editor permissions.
 
         Args:
@@ -555,22 +557,22 @@ class PlankaEndpoints:
             labelId (str): ID of the label to add to the card
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
-            Planka internal status codes and names are included here for disambiguation
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            Forbidden: 403 
-            NotFound: 404 
-            Conflict: 409 
-        """
+            ValidationError: 400
+            Unauthorized: 401
+            Forbidden: 403
+            NotFound: 404
+            Conflict: 409
+         """
         resp = self.client.post(f"api/cards/{cardId}/card-labels", json=kwargs)
         raise_planka_err(resp)
         return resp.json()
 
-    def deleteCardLabel(self, cardId: str, labelId: str) -> Response_deleteCardLabel:
+    def deleteCardLabel(self, cardId: str, labelId: str) -> typ.Response_deleteCardLabel:
         """Removes a label from a card. Requires board editor permissions.
 
         Args:
@@ -578,21 +580,21 @@ class PlankaEndpoints:
             labelId (str): ID of the label to remove from the card)
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
-            Planka internal status codes and names are included here for disambiguation
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            Forbidden: 403 
-            NotFound: 404 
-        """
+            ValidationError: 400
+            Unauthorized: 401
+            Forbidden: 403
+            NotFound: 404
+         """
         resp = self.client.delete(f"api/cards/{cardId}/card-labels/labelId:{labelId}")
         raise_planka_err(resp)
         return resp.json()
 
-    def createCardMembership(self, cardId: str, **kwargs: Unpack[Request_createCardMembership]) -> Response_createCardMembership:
+    def createCardMembership(self, cardId: str, **kwargs: Unpack[typ.Request_createCardMembership]) -> typ.Response_createCardMembership:
         """Adds a user to a card. Requires board editor permissions.
 
         Args:
@@ -600,22 +602,22 @@ class PlankaEndpoints:
             userId (str): ID of the card to add the user to
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
-            Planka internal status codes and names are included here for disambiguation
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            Forbidden: 403 
-            NotFound: 404 
-            Conflict: 409 
-        """
+            ValidationError: 400
+            Unauthorized: 401
+            Forbidden: 403
+            NotFound: 404
+            Conflict: 409
+         """
         resp = self.client.post(f"api/cards/{cardId}/card-memberships", json=kwargs)
         raise_planka_err(resp)
         return resp.json()
 
-    def deleteCardMembership(self, cardId: str, userId: str) -> Response_deleteCardMembership:
+    def deleteCardMembership(self, cardId: str, userId: str) -> typ.Response_deleteCardMembership:
         """Removes a user from a card. Requires board editor permissions.
 
         Args:
@@ -623,21 +625,21 @@ class PlankaEndpoints:
             userId (str): ID of the user to remove from the card)
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
-            Planka internal status codes and names are included here for disambiguation
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            Forbidden: 403 
-            NotFound: 404 
-        """
+            ValidationError: 400
+            Unauthorized: 401
+            Forbidden: 403
+            NotFound: 404
+         """
         resp = self.client.delete(f"api/cards/{cardId}/card-memberships/userId:{userId}")
         raise_planka_err(resp)
         return resp.json()
 
-    def createCard(self, listId: str, **kwargs: Unpack[Request_createCard]) -> Response_createCard:
+    def createCard(self, listId: str, **kwargs: Unpack[typ.Request_createCard]) -> typ.Response_createCard:
         """Creates a card within a list. Requires board editor permissions.
 
         Args:
@@ -651,22 +653,22 @@ class PlankaEndpoints:
             stopwatch (dict[str, Any] | None): Stopwatch data for time tracking
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
-            Planka internal status codes and names are included here for disambiguation
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            Forbidden: 403 
-            NotFound: 404 
-            UnprocessableEntity: 422 
-        """
+            ValidationError: 400
+            Unauthorized: 401
+            Forbidden: 403
+            NotFound: 404
+            UnprocessableEntity: 422
+         """
         resp = self.client.post(f"api/lists/{listId}/cards", json=kwargs)
         raise_planka_err(resp)
         return resp.json()
 
-    def getCards(self, listId: str, **kwargs: Unpack[Request_getCards]) -> Response_getCards:
+    def getCards(self, listId: str, **kwargs: Unpack[typ.Request_getCards]) -> typ.Response_getCards:
         """Retrieves cards from an endless list with filtering, search, and pagination support.
 
         Args:
@@ -678,69 +680,69 @@ class PlankaEndpoints:
             labelIds (str): Comma-separated label IDs to filter by labels) (optional)
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
-            Planka internal status codes and names are included here for disambiguation
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            NotFound: 404 
-        """
+            ValidationError: 400
+            Unauthorized: 401
+            NotFound: 404
+         """
         # Monkey patch since brackets cannot be used in varaible names
         if 'before_listChangedAt' in kwargs:
-            kwargs['before[listChangedAt]'] = kwargs.pop('before_listChangedAt') # type: ignore
+            kwargs['before[listChangedAt]'] = kwargs.pop('before_listChangedAt')  # type: ignore
         if 'before_id' in kwargs:
-            kwargs['before[id]'] = kwargs.pop('before_id') # type: ignore
-            
+            kwargs['before[id]'] = kwargs.pop('before_id')  # type: ignore
+
         valid_params = ('before[listChangedAt]', 'before[id]', 'search', 'userIds', 'labelIds')
         passed_params = {k: v for k, v in kwargs.items() if k in valid_params if isinstance(v, str | int | float)}
         resp = self.client.get(f"api/lists/{listId}/cards", params=passed_params)
         raise_planka_err(resp)
         return resp.json()
 
-    def deleteCard(self, id: str) -> Response_deleteCard:
+    def deleteCard(self, id: str) -> typ.Response_deleteCard:
         """Deletes a card and all its contents (tasks, attachments, etc.). Requires board editor permissions.
 
         Args:
             id (str): ID of the card to delete)
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
-            Planka internal status codes and names are included here for disambiguation
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            Forbidden: 403 
-            NotFound: 404 
-        """
+            ValidationError: 400
+            Unauthorized: 401
+            Forbidden: 403
+            NotFound: 404
+         """
         resp = self.client.delete(f"api/cards/{id}")
         raise_planka_err(resp)
         return resp.json()
 
-    def getCard(self, id: str) -> Response_getCard:
+    def getCard(self, id: str) -> typ.Response_getCard:
         """Retrieves comprehensive card information, including tasks, attachments, and other related data.
 
         Args:
             id (str): ID of the card to retrieve)
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
-            Planka internal status codes and names are included here for disambiguation
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            NotFound: 404 
-        """
+            ValidationError: 400
+            Unauthorized: 401
+            NotFound: 404
+         """
         resp = self.client.get(f"api/cards/{id}")
         raise_planka_err(resp)
         return resp.json()
 
-    def updateCard(self, id: str, **kwargs: Unpack[Request_updateCard]) -> Response_updateCard:
+    def updateCard(self, id: str, **kwargs: Unpack[typ.Request_updateCard]) -> typ.Response_updateCard:
         """Updates a card. Board editors can update all fields, viewers can only subscribe/unsubscribe.
 
         Args:
@@ -758,22 +760,22 @@ class PlankaEndpoints:
             isSubscribed (bool): Whether the current user is subscribed to the card
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
-            Planka internal status codes and names are included here for disambiguation
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            Forbidden: 403 
-            NotFound: 404 
-            UnprocessableEntity: 422 
-        """
+            ValidationError: 400
+            Unauthorized: 401
+            Forbidden: 403
+            NotFound: 404
+            UnprocessableEntity: 422
+         """
         resp = self.client.patch(f"api/cards/{id}", json=kwargs)
         raise_planka_err(resp)
         return resp.json()
 
-    def duplicateCard(self, id: str, **kwargs: Unpack[Request_duplicateCard]) -> Response_duplicateCard:
+    def duplicateCard(self, id: str, **kwargs: Unpack[typ.Request_duplicateCard]) -> typ.Response_duplicateCard:
         """Creates a duplicate of a card with all its contents (tasks, attachments, etc.). Requires board editor permissions.
 
         Args:
@@ -784,42 +786,42 @@ class PlankaEndpoints:
             name (str | None): Name/title for the duplicated card
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
-            Planka internal status codes and names are included here for disambiguation
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            Forbidden: 403 
-            NotFound: 404 
-            UnprocessableEntity: 422 
-        """
+            ValidationError: 400
+            Unauthorized: 401
+            Forbidden: 403
+            NotFound: 404
+            UnprocessableEntity: 422
+         """
         resp = self.client.post(f"api/cards/{id}/duplicate", json=kwargs)
         raise_planka_err(resp)
         return resp.json()
 
-    def readCardNotifications(self, id: str) -> Response_readCardNotifications:
+    def readCardNotifications(self, id: str) -> typ.Response_readCardNotifications:
         """Marks all notifications for a specific card as read for the current user. Requires access to the card.
 
         Args:
             id (str): ID of the card to mark notifications as read for)
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
-            Planka internal status codes and names are included here for disambiguation
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            NotFound: 404 
-        """
+            ValidationError: 400
+            Unauthorized: 401
+            NotFound: 404
+         """
         resp = self.client.post(f"api/cards/{id}/read-notifications")
         raise_planka_err(resp)
         return resp.json()
 
-    def createComment(self, cardId: str, **kwargs: Unpack[Request_createComment]) -> Response_createComment:
+    def createComment(self, cardId: str, **kwargs: Unpack[typ.Request_createComment]) -> typ.Response_createComment:
         """Creates a new comment on a card. Requires board editor permissions or comment permissions.
 
         Args:
@@ -827,21 +829,21 @@ class PlankaEndpoints:
             text (str): Content of the comment
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
-            Planka internal status codes and names are included here for disambiguation
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            Forbidden: 403 
-            NotFound: 404 
-        """
+            ValidationError: 400
+            Unauthorized: 401
+            Forbidden: 403
+            NotFound: 404
+         """
         resp = self.client.post(f"api/cards/{cardId}/comments", json=kwargs)
         raise_planka_err(resp)
         return resp.json()
 
-    def getComments(self, cardId: str, **kwargs: Unpack[Request_getComments]) -> Response_getComments:
+    def getComments(self, cardId: str, **kwargs: Unpack[typ.Request_getComments]) -> typ.Response_getComments:
         """Retrieves comments for a card with pagination support. Requires access to the card.
 
         Args:
@@ -849,43 +851,43 @@ class PlankaEndpoints:
             beforeId (str): ID to get comments before (for pagination)) (optional)
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
-            Planka internal status codes and names are included here for disambiguation
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            NotFound: 404 
-        """
+            ValidationError: 400
+            Unauthorized: 401
+            NotFound: 404
+         """
         valid_params = ('beforeId',)
         passed_params = {k: v for k, v in kwargs.items() if k in valid_params if isinstance(v, str | int | float)}
         resp = self.client.get(f"api/cards/{cardId}/comments", params=passed_params)
         raise_planka_err(resp)
         return resp.json()
 
-    def deleteComment(self, id: str) -> Response_deleteComment:
+    def deleteComment(self, id: str) -> typ.Response_deleteComment:
         """Deletes a comment. Can be deleted by the comment author (with comment permissions) or project manager.
 
         Args:
             id (str): ID of the comment to delete)
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
-            Planka internal status codes and names are included here for disambiguation
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            Forbidden: 403 
-            NotFound: 404 
-        """
+            ValidationError: 400
+            Unauthorized: 401
+            Forbidden: 403
+            NotFound: 404
+         """
         resp = self.client.delete(f"api/comments/{id}")
         raise_planka_err(resp)
         return resp.json()
 
-    def updateComments(self, id: str, **kwargs: Unpack[Request_updateComments]) -> Response_updateComments:
+    def updateComments(self, id: str, **kwargs: Unpack[typ.Request_updateComments]) -> typ.Response_updateComments:
         """Updates a comment. Only the author of the comment can update it.
 
         Args:
@@ -893,28 +895,28 @@ class PlankaEndpoints:
             text (str): Content of the comment
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
-            Planka internal status codes and names are included here for disambiguation
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            Forbidden: 403 
-            NotFound: 404 
-        """
+            ValidationError: 400
+            Unauthorized: 401
+            Forbidden: 403
+            NotFound: 404
+         """
         resp = self.client.patch(f"api/comments/{id}", json=kwargs)
         raise_planka_err(resp)
         return resp.json()
 
-    def getConfig(self) -> Response_getConfig:
+    def getConfig(self) -> typ.Response_getConfig:
         """Retrieves the application configuration. Requires admin privileges.
         """
         resp = self.client.get("api/config")
         raise_planka_err(resp)
         return resp.json()
 
-    def updateConfig(self, **kwargs: Unpack[Request_updateConfig]) -> Response_updateConfig:
+    def updateConfig(self, **kwargs: Unpack[typ.Request_updateConfig]) -> typ.Response_updateConfig:
         """Updates the application configuration. Requires admin privileges.
 
         Args:
@@ -931,23 +933,23 @@ class PlankaEndpoints:
         raise_planka_err(resp)
         return resp.json()
 
-    def testSmtpConfig(self) -> Response_testSmtpConfig:
+    def testSmtpConfig(self) -> typ.Response_testSmtpConfig:
         """Sends a test email to verify the SMTP is configured correctly. Only available when SMTP is configured via the UI.
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
-            Planka internal status codes and names are included here for disambiguation
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            Unauthorized: 401 
-            Forbidden: 403 
-        """
+            Unauthorized: 401
+             Forbidden: 403
+         """
         resp = self.client.post("api/config/test-smtp")
         raise_planka_err(resp)
         return resp.json()
 
-    def createBoardCustomFieldGroup(self, boardId: str, **kwargs: Unpack[Request_createBoardCustomFieldGroup]) -> Response_createBoardCustomFieldGroup:
+    def createBoardCustomFieldGroup(self, boardId: str, **kwargs: Unpack[typ.Request_createBoardCustomFieldGroup]) -> typ.Response_createBoardCustomFieldGroup:
         """Creates a custom field group within a board. Either `baseCustomFieldGroupId` or `name` must be provided. Requires board editor permissions.
 
         Args:
@@ -957,22 +959,22 @@ class PlankaEndpoints:
             name (str | None): Name/title of the custom field group (required if `baseCustomFieldGroupId` is not provided)
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
-            Planka internal status codes and names are included here for disambiguation
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            Forbidden: 403 
-            NotFound: 404 
-            UnprocessableEntity: 422 
-        """
+            ValidationError: 400
+            Unauthorized: 401
+            Forbidden: 403
+            NotFound: 404
+            UnprocessableEntity: 422
+         """
         resp = self.client.post(f"api/boards/{boardId}/custom-field-groups", json=kwargs)
         raise_planka_err(resp)
         return resp.json()
 
-    def createCardCustomFieldGroup(self, cardId: str, **kwargs: Unpack[Request_createCardCustomFieldGroup]) -> Response_createCardCustomFieldGroup:
+    def createCardCustomFieldGroup(self, cardId: str, **kwargs: Unpack[typ.Request_createCardCustomFieldGroup]) -> typ.Response_createCardCustomFieldGroup:
         """Creates a custom field group within a card. Either `baseCustomFieldGroupId` or `name` must be provided. Requires board editor permissions.
 
         Args:
@@ -982,63 +984,63 @@ class PlankaEndpoints:
             name (str | None): Name/title of the custom field group (required if `baseCustomFieldGroupId` is not provided)
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
-            Planka internal status codes and names are included here for disambiguation
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            Forbidden: 403 
-            NotFound: 404 
-            UnprocessableEntity: 422 
-        """
+            ValidationError: 400
+            Unauthorized: 401
+            Forbidden: 403
+            NotFound: 404
+            UnprocessableEntity: 422
+         """
         resp = self.client.post(f"api/cards/{cardId}/custom-field-groups", json=kwargs)
         raise_planka_err(resp)
         return resp.json()
 
-    def deleteCustomFieldGroup(self, id: str) -> Response_deleteCustomFieldGroup:
+    def deleteCustomFieldGroup(self, id: str) -> typ.Response_deleteCustomFieldGroup:
         """Deletes a custom field group. Requires board editor permissions.
 
         Args:
             id (str): ID of the custom field group to delete)
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
-            Planka internal status codes and names are included here for disambiguation
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            Forbidden: 403 
-            NotFound: 404 
-        """
+            ValidationError: 400
+            Unauthorized: 401
+            Forbidden: 403
+            NotFound: 404
+         """
         resp = self.client.delete(f"api/custom-field-groups/{id}")
         raise_planka_err(resp)
         return resp.json()
 
-    def getCustomFieldGroup(self, id: str) -> Response_getCustomFieldGroup:
+    def getCustomFieldGroup(self, id: str) -> typ.Response_getCustomFieldGroup:
         """Retrieves comprehensive custom field group information, including fields and values. Requires access to the board/card.
 
         Args:
             id (str): ID of the custom field group to retrieve)
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
-            Planka internal status codes and names are included here for disambiguation
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            NotFound: 404 
-        """
+            ValidationError: 400
+            Unauthorized: 401
+            NotFound: 404
+         """
         resp = self.client.get(f"api/custom-field-groups/{id}")
         raise_planka_err(resp)
         return resp.json()
 
-    def updateCustomFieldGroup(self, id: str, **kwargs: Unpack[Request_updateCustomFieldGroup]) -> Response_updateCustomFieldGroup:
+    def updateCustomFieldGroup(self, id: str, **kwargs: Unpack[typ.Request_updateCustomFieldGroup]) -> typ.Response_updateCustomFieldGroup:
         """Updates a custom field group. Supports both board-wide and card-specific groups. Requires board editor permissions.
 
         Args:
@@ -1047,22 +1049,22 @@ class PlankaEndpoints:
             name (str | None): Name/title of the custom field group
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
-            Planka internal status codes and names are included here for disambiguation
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            Forbidden: 403 
-            NotFound: 404 
-            UnprocessableEntity: 422 
-        """
+            ValidationError: 400
+            Unauthorized: 401
+            Forbidden: 403
+            NotFound: 404
+            UnprocessableEntity: 422
+         """
         resp = self.client.patch(f"api/custom-field-groups/{id}", json=kwargs)
         raise_planka_err(resp)
         return resp.json()
 
-    def updateCustomFieldValue(self, cardId: str, customFieldGroupId: str, customFieldId: str, **kwargs: Unpack[Request_updateCustomFieldValue]) -> Response_updateCustomFieldValue:
+    def updateCustomFieldValue(self, cardId: str, customFieldGroupId: str, customFieldId: str, **kwargs: Unpack[typ.Request_updateCustomFieldValue]) -> typ.Response_updateCustomFieldValue:
         """Creates or updates a custom field value for a card. Requires board editor permissions.
 
         Args:
@@ -1072,21 +1074,21 @@ class PlankaEndpoints:
             content (str): Content/value of the custom field
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
-            Planka internal status codes and names are included here for disambiguation
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            Forbidden: 403 
-            NotFound: 404 
-        """
+            ValidationError: 400
+            Unauthorized: 401
+            Forbidden: 403
+            NotFound: 404
+         """
         resp = self.client.patch(f"api/cards/{cardId}/custom-field-values/customFieldGroupId:{customFieldGroupId}:customFieldId:{customFieldId}", json=kwargs)
         raise_planka_err(resp)
         return resp.json()
 
-    def deleteCustomFieldValue(self, cardId: str, customFieldGroupId: str, customFieldId: str) -> Response_deleteCustomFieldValue:
+    def deleteCustomFieldValue(self, cardId: str, customFieldGroupId: str, customFieldId: str) -> typ.Response_deleteCustomFieldValue:
         """Deletes a custom field value for a specific card. Requires board editor permissions.
 
         Args:
@@ -1095,21 +1097,21 @@ class PlankaEndpoints:
             customFieldId (str): ID of the custom field the value belongs to)
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
-            Planka internal status codes and names are included here for disambiguation
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            Forbidden: 403 
-            NotFound: 404 
-        """
+            ValidationError: 400
+            Unauthorized: 401
+            Forbidden: 403
+            NotFound: 404
+         """
         resp = self.client.delete(f"api/cards/{cardId}/custom-field-value/customFieldGroupId:{customFieldGroupId}:customFieldId:{customFieldId}")
         raise_planka_err(resp)
         return resp.json()
 
-    def createCustomFieldInBaseGroup(self, baseCustomFieldGroupId: str, **kwargs: Unpack[Request_createCustomFieldInBaseGroup]) -> Response_createCustomFieldInBaseGroup:
+    def createCustomFieldInBaseGroup(self, baseCustomFieldGroupId: str, **kwargs: Unpack[typ.Request_createCustomFieldInBaseGroup]) -> typ.Response_createCustomFieldInBaseGroup:
         """Creates a custom field within a base custom field group. Requires project manager permissions.
 
         Args:
@@ -1119,20 +1121,20 @@ class PlankaEndpoints:
             showOnFrontOfCard (bool): Whether to show the field on the front of cards
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
-            Planka internal status codes and names are included here for disambiguation
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            NotFound: 404 
-        """
+            ValidationError: 400
+            Unauthorized: 401
+            NotFound: 404
+         """
         resp = self.client.post(f"api/base-custom-field-groups/{baseCustomFieldGroupId}/custom-fields", json=kwargs)
         raise_planka_err(resp)
         return resp.json()
 
-    def createCustomFieldInGroup(self, customFieldGroupId: str, **kwargs: Unpack[Request_createCustomFieldInGroup]) -> Response_createCustomFieldInGroup:
+    def createCustomFieldInGroup(self, customFieldGroupId: str, **kwargs: Unpack[typ.Request_createCustomFieldInGroup]) -> typ.Response_createCustomFieldInGroup:
         """Creates a custom field within a custom field group. Requires board editor permissions.
 
         Args:
@@ -1142,42 +1144,42 @@ class PlankaEndpoints:
             showOnFrontOfCard (bool): Whether to show the field on the front of cards
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
-            Planka internal status codes and names are included here for disambiguation
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            Forbidden: 403 
-            NotFound: 404 
-        """
+            ValidationError: 400
+            Unauthorized: 401
+            Forbidden: 403
+            NotFound: 404
+         """
         resp = self.client.post(f"api/custom-field-groups/{customFieldGroupId}/custom-fields", json=kwargs)
         raise_planka_err(resp)
         return resp.json()
 
-    def deleteCustomField(self, id: str) -> Response_deleteCustomField:
+    def deleteCustomField(self, id: str) -> typ.Response_deleteCustomField:
         """Deletes a custom field. Can delete the in base custom field group (requires project manager permissions) or the custom field group (requires board editor permissions).
 
         Args:
             id (str): ID of the custom field to delete)
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
-            Planka internal status codes and names are included here for disambiguation
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            Forbidden: 403 
-            NotFound: 404 
-        """
+            ValidationError: 400
+            Unauthorized: 401
+            Forbidden: 403
+            NotFound: 404
+         """
         resp = self.client.delete(f"api/custom-fields/{id}")
         raise_planka_err(resp)
         return resp.json()
 
-    def updateCustomField(self, id: str, **kwargs: Unpack[Request_updateCustomField]) -> Response_updateCustomField:
+    def updateCustomField(self, id: str, **kwargs: Unpack[typ.Request_updateCustomField]) -> typ.Response_updateCustomField:
         """Updates a custom field. Can update in the base custom field group (requires project manager permissions) or the custom field group (requires board editor permissions).
 
         Args:
@@ -1187,21 +1189,21 @@ class PlankaEndpoints:
             showOnFrontOfCard (bool): Whether to show the field on the front of cards
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
-            Planka internal status codes and names are included here for disambiguation
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            Forbidden: 403 
-            NotFound: 404 
-        """
+            ValidationError: 400
+            Unauthorized: 401
+            Forbidden: 403
+            NotFound: 404
+         """
         resp = self.client.patch(f"api/custom-fields/{id}", json=kwargs)
         raise_planka_err(resp)
         return resp.json()
 
-    def createLabel(self, boardId: str, **kwargs: Unpack[Request_createLabel]) -> Response_createLabel:
+    def createLabel(self, boardId: str, **kwargs: Unpack[typ.Request_createLabel]) -> typ.Response_createLabel:
         """Creates a label within a board. Requires board editor permissions.
 
         Args:
@@ -1211,42 +1213,42 @@ class PlankaEndpoints:
             color (Literal['muddy-grey', 'autumn-leafs', 'morning-sky', 'antique-blue', 'egg-yellow', 'desert-sand', 'dark-granite', 'fresh-salad', 'lagoon-blue', 'midnight-blue', 'light-orange', 'pumpkin-orange', 'light-concrete', 'sunny-grass', 'navy-blue', 'lilac-eyes', 'apricot-red', 'orange-peel', 'silver-glint', 'bright-moss', 'deep-ocean', 'summer-sky', 'berry-red', 'light-cocoa', 'grey-stone', 'tank-green', 'coral-green', 'sugar-plum', 'pink-tulip', 'shady-rust', 'wet-rock', 'wet-moss', 'turquoise-sea', 'lavender-fields', 'piggy-red', 'light-mud', 'gun-metal', 'modern-green', 'french-coast', 'sweet-lilac', 'red-burgundy', 'pirate-gold']): Color of the label
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
-            Planka internal status codes and names are included here for disambiguation
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            Forbidden: 403 
-            NotFound: 404 
-        """
+            ValidationError: 400
+            Unauthorized: 401
+            Forbidden: 403
+            NotFound: 404
+         """
         resp = self.client.post(f"api/boards/{boardId}/labels", json=kwargs)
         raise_planka_err(resp)
         return resp.json()
 
-    def deleteLabel(self, id: str) -> Response_deleteLabel:
+    def deleteLabel(self, id: str) -> typ.Response_deleteLabel:
         """Deletes a label. Requires board editor permissions.
 
         Args:
             id (str): ID of the label to delete)
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
-            Planka internal status codes and names are included here for disambiguation
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            Forbidden: 403 
-            NotFound: 404 
-        """
+            ValidationError: 400
+            Unauthorized: 401
+            Forbidden: 403
+            NotFound: 404
+         """
         resp = self.client.delete(f"api/labels/{id}")
         raise_planka_err(resp)
         return resp.json()
 
-    def updateLabel(self, id: str, **kwargs: Unpack[Request_updateLabel]) -> Response_updateLabel:
+    def updateLabel(self, id: str, **kwargs: Unpack[typ.Request_updateLabel]) -> typ.Response_updateLabel:
         """Updates a label. Requires board editor permissions.
 
         Args:
@@ -1256,42 +1258,42 @@ class PlankaEndpoints:
             color (Literal['muddy-grey', 'autumn-leafs', 'morning-sky', 'antique-blue', 'egg-yellow', 'desert-sand', 'dark-granite', 'fresh-salad', 'lagoon-blue', 'midnight-blue', 'light-orange', 'pumpkin-orange', 'light-concrete', 'sunny-grass', 'navy-blue', 'lilac-eyes', 'apricot-red', 'orange-peel', 'silver-glint', 'bright-moss', 'deep-ocean', 'summer-sky', 'berry-red', 'light-cocoa', 'grey-stone', 'tank-green', 'coral-green', 'sugar-plum', 'pink-tulip', 'shady-rust', 'wet-rock', 'wet-moss', 'turquoise-sea', 'lavender-fields', 'piggy-red', 'light-mud', 'gun-metal', 'modern-green', 'french-coast', 'sweet-lilac', 'red-burgundy', 'pirate-gold']): Color of the label
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
-            Planka internal status codes and names are included here for disambiguation
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            Forbidden: 403 
-            NotFound: 404 
-        """
+            ValidationError: 400
+            Unauthorized: 401
+            Forbidden: 403
+            NotFound: 404
+         """
         resp = self.client.patch(f"api/labels/{id}", json=kwargs)
         raise_planka_err(resp)
         return resp.json()
 
-    def clearList(self, id: str) -> Response_clearList:
+    def clearList(self, id: str) -> typ.Response_clearList:
         """Deletes all cards from a list. Only works with trash-type lists. Requires project manager or board editor permissions.
 
         Args:
             id (str): ID of the list to clear (must be a trash-type list))
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
-            Planka internal status codes and names are included here for disambiguation
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            Forbidden: 403 
-            NotFound: 404 
-        """
+            ValidationError: 400
+            Unauthorized: 401
+            Forbidden: 403
+            NotFound: 404
+         """
         resp = self.client.post(f"api/lists/{id}/clear")
         raise_planka_err(resp)
         return resp.json()
 
-    def createList(self, boardId: str, **kwargs: Unpack[Request_createList]) -> Response_createList:
+    def createList(self, boardId: str, **kwargs: Unpack[typ.Request_createList]) -> typ.Response_createList:
         """Creates a list within a board. Requires board editor permissions.
 
         Args:
@@ -1301,62 +1303,62 @@ class PlankaEndpoints:
             name (str): Name/title of the list
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
-            Planka internal status codes and names are included here for disambiguation
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            Forbidden: 403 
-            NotFound: 404 
-        """
+            ValidationError: 400
+            Unauthorized: 401
+            Forbidden: 403
+            NotFound: 404
+         """
         resp = self.client.post(f"api/boards/{boardId}/lists", json=kwargs)
         raise_planka_err(resp)
         return resp.json()
 
-    def deleteList(self, id: str) -> Response_deleteList:
+    def deleteList(self, id: str) -> typ.Response_deleteList:
         """Deletes a list and moves its cards to a trash list. Can only delete finite lists. Requires board editor permissions.
 
         Args:
             id (str): ID of the list to delete)
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
-            Planka internal status codes and names are included here for disambiguation
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            Forbidden: 403 
-            NotFound: 404 
-        """
+            ValidationError: 400
+            Unauthorized: 401
+            Forbidden: 403
+            NotFound: 404
+         """
         resp = self.client.delete(f"api/lists/{id}")
         raise_planka_err(resp)
         return resp.json()
 
-    def getList(self, id: str) -> Response_getList:
+    def getList(self, id: str) -> typ.Response_getList:
         """Retrieves comprehensive list information, including cards, attachments, and other related data. Requires access to the board.
 
         Args:
             id (str): ID of the list to retrieve)
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
-            Planka internal status codes and names are included here for disambiguation
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            NotFound: 404 
-        """
+            ValidationError: 400
+            Unauthorized: 401
+            NotFound: 404
+         """
         resp = self.client.get(f"api/lists/{id}")
         raise_planka_err(resp)
         return resp.json()
 
-    def updateList(self, id: str, **kwargs: Unpack[Request_updateList]) -> Response_updateList:
+    def updateList(self, id: str, **kwargs: Unpack[typ.Request_updateList]) -> typ.Response_updateList:
         """Updates a list. Can move lists between boards. Requires board editor permissions.
 
         Args:
@@ -1368,21 +1370,21 @@ class PlankaEndpoints:
             color (Literal['berry-red', 'pumpkin-orange', 'lagoon-blue', 'pink-tulip', 'light-mud', 'orange-peel', 'bright-moss', 'antique-blue', 'dark-granite', 'turquoise-sea'] | None): Color for the list
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
-            Planka internal status codes and names are included here for disambiguation
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            Forbidden: 403 
-            NotFound: 404 
-        """
+            ValidationError: 400
+            Unauthorized: 401
+            Forbidden: 403
+            NotFound: 404
+         """
         resp = self.client.patch(f"api/lists/{id}", json=kwargs)
         raise_planka_err(resp)
         return resp.json()
 
-    def moveListCards(self, id: str, **kwargs: Unpack[Request_moveListCards]) -> Response_moveListCards:
+    def moveListCards(self, id: str, **kwargs: Unpack[typ.Request_moveListCards]) -> typ.Response_moveListCards:
         """Moves all cards from a closed list to an archive list. Requires board editor permissions.
 
         Args:
@@ -1390,21 +1392,21 @@ class PlankaEndpoints:
             listId (str): ID of the target list (must be an archive-type list)
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
-            Planka internal status codes and names are included here for disambiguation
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            Forbidden: 403 
-            NotFound: 404 
-        """
+            ValidationError: 400
+            Unauthorized: 401
+            Forbidden: 403
+            NotFound: 404
+         """
         resp = self.client.post(f"api/lists/{id}/move-cards", json=kwargs)
         raise_planka_err(resp)
         return resp.json()
 
-    def sortList(self, id: str, **kwargs: Unpack[Request_sortList]) -> Response_sortList:
+    def sortList(self, id: str, **kwargs: Unpack[typ.Request_sortList]) -> typ.Response_sortList:
         """Sorts all cards within a list. Requires board editor permissions.
 
         Args:
@@ -1413,22 +1415,22 @@ class PlankaEndpoints:
             order (Literal['asc', 'desc']): Sorting order
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
-            Planka internal status codes and names are included here for disambiguation
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            Forbidden: 403 
-            NotFound: 404 
-            UnprocessableEntity: 422 
-        """
+            ValidationError: 400
+            Unauthorized: 401
+            Forbidden: 403
+            NotFound: 404
+            UnprocessableEntity: 422
+         """
         resp = self.client.post(f"api/lists/{id}/sort", json=kwargs)
         raise_planka_err(resp)
         return resp.json()
 
-    def createBoardNotificationService(self, boardId: str, **kwargs: Unpack[Request_createBoardNotificationService]) -> Response_createBoardNotificationService:
+    def createBoardNotificationService(self, boardId: str, **kwargs: Unpack[typ.Request_createBoardNotificationService]) -> typ.Response_createBoardNotificationService:
         """Creates a new notification service for a board. Requires project manager permissions.
 
         Args:
@@ -1437,21 +1439,21 @@ class PlankaEndpoints:
             format (Literal['text', 'markdown', 'html']): Format for notification messages
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
-            Planka internal status codes and names are included here for disambiguation
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            NotFound: 404 
-            Conflict: 409 
-        """
+            ValidationError: 400
+            Unauthorized: 401
+            NotFound: 404
+            Conflict: 409
+         """
         resp = self.client.post(f"api/boards/{boardId}/notification-services", json=kwargs)
         raise_planka_err(resp)
         return resp.json()
 
-    def createUserNotificationService(self, userId: str, **kwargs: Unpack[Request_createUserNotificationService]) -> Response_createUserNotificationService:
+    def createUserNotificationService(self, userId: str, **kwargs: Unpack[typ.Request_createUserNotificationService]) -> typ.Response_createUserNotificationService:
         """Creates a new notification service for a user. Users can only create services for themselves.
 
         Args:
@@ -1460,41 +1462,41 @@ class PlankaEndpoints:
             format (Literal['text', 'markdown', 'html']): Format for notification messages
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
-            Planka internal status codes and names are included here for disambiguation
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            NotFound: 404 
-            Conflict: 409 
-        """
+            ValidationError: 400
+            Unauthorized: 401
+            NotFound: 404
+            Conflict: 409
+         """
         resp = self.client.post(f"api/users/{userId}/notification-services", json=kwargs)
         raise_planka_err(resp)
         return resp.json()
 
-    def deleteNotificationService(self, id: str) -> Response_deleteNotificationService:
+    def deleteNotificationService(self, id: str) -> typ.Response_deleteNotificationService:
         """Deletes a notification service. Users can delete their own services, project managers can delete board services.
 
         Args:
             id (str): ID of the notification service to delete)
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
-            Planka internal status codes and names are included here for disambiguation
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            NotFound: 404 
-        """
+            ValidationError: 400
+            Unauthorized: 401
+            NotFound: 404
+         """
         resp = self.client.delete(f"api/notification-services/{id}")
         raise_planka_err(resp)
         return resp.json()
 
-    def updateNotificationService(self, id: str, **kwargs: Unpack[Request_updateNotificationService]) -> Response_updateNotificationService:
+    def updateNotificationService(self, id: str, **kwargs: Unpack[typ.Request_updateNotificationService]) -> typ.Response_updateNotificationService:
         """Updates a notification service. Users can update their own services, project managers can update board services.
 
         Args:
@@ -1503,92 +1505,92 @@ class PlankaEndpoints:
             format (Literal['text', 'markdown', 'html']): Format for notification messages
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
-            Planka internal status codes and names are included here for disambiguation
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            NotFound: 404 
-        """
+            ValidationError: 400
+            Unauthorized: 401
+            NotFound: 404
+         """
         resp = self.client.patch(f"api/notification-services/{id}", json=kwargs)
         raise_planka_err(resp)
         return resp.json()
 
-    def testNotificationService(self, id: str) -> Response_testNotificationService:
+    def testNotificationService(self, id: str) -> typ.Response_testNotificationService:
         """Sends a test notification to verify the notification service is working. Users can test their own services, project managers can test board services.
 
         Args:
             id (str): ID of the notification service to test)
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
-            Planka internal status codes and names are included here for disambiguation
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            NotFound: 404 
-        """
+            ValidationError: 400
+            Unauthorized: 401
+            NotFound: 404
+         """
         resp = self.client.post(f"api/notification-services/{id}/test")
         raise_planka_err(resp)
         return resp.json()
 
-    def getNotifications(self) -> Response_getNotifications:
+    def getNotifications(self) -> typ.Response_getNotifications:
         """Retrieves all unread notifications for the current user, including creator users.
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
-            Planka internal status codes and names are included here for disambiguation
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-        """
+            ValidationError: 400
+             Unauthorized: 401
+         """
         resp = self.client.get("api/notifications")
         raise_planka_err(resp)
         return resp.json()
 
-    def readAllNotifications(self) -> Response_readAllNotifications:
+    def readAllNotifications(self) -> typ.Response_readAllNotifications:
         """Marks all notifications for the current user as read.
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
-            Planka internal status codes and names are included here for disambiguation
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-        """
+            ValidationError: 400
+             Unauthorized: 401
+         """
         resp = self.client.post("api/notifications/read-all")
         raise_planka_err(resp)
         return resp.json()
 
-    def getNotification(self, id: str) -> Response_getNotification:
+    def getNotification(self, id: str) -> typ.Response_getNotification:
         """Retrieves notification, including creator users. Users can only access their own notifications.
 
         Args:
             id (str): ID of the notification to retrieve)
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
-            Planka internal status codes and names are included here for disambiguation
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            NotFound: 404 
-        """
+            ValidationError: 400
+            Unauthorized: 401
+            NotFound: 404
+         """
         resp = self.client.get(f"api/notifications/{id}")
         raise_planka_err(resp)
         return resp.json()
 
-    def updateNotification(self, id: str, **kwargs: Unpack[Request_updateNotification]) -> Response_updateNotification:
+    def updateNotification(self, id: str, **kwargs: Unpack[typ.Request_updateNotification]) -> typ.Response_updateNotification:
         """Updates a notification. Users can only update their own notifications.
 
         Args:
@@ -1596,20 +1598,20 @@ class PlankaEndpoints:
             isRead (bool): Whether the notification has been read
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
-            Planka internal status codes and names are included here for disambiguation
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            NotFound: 404 
-        """
+            ValidationError: 400
+            Unauthorized: 401
+            NotFound: 404
+         """
         resp = self.client.patch(f"api/notifications/{id}", json=kwargs)
         raise_planka_err(resp)
         return resp.json()
 
-    def createProjectManager(self, projectId: str, **kwargs: Unpack[Request_createProjectManager]) -> Response_createProjectManager:
+    def createProjectManager(self, projectId: str, **kwargs: Unpack[typ.Request_createProjectManager]) -> typ.Response_createProjectManager:
         """Creates a project manager within a project. Requires admin privileges for shared projects or existing project manager permissions. The user must be an admin or project owner.
 
         Args:
@@ -1617,45 +1619,45 @@ class PlankaEndpoints:
             userId (str): ID of the user who is assigned as project manager
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
-            Planka internal status codes and names are included here for disambiguation
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            Forbidden: 403 
-            NotFound: 404 
-            Conflict: 409 
-            UnprocessableEntity: 422 
-        """
+            ValidationError: 400
+            Unauthorized: 401
+            Forbidden: 403
+            NotFound: 404
+            Conflict: 409
+            UnprocessableEntity: 422
+         """
         resp = self.client.post(f"api/projects/{projectId}/project-managers", json=kwargs)
         raise_planka_err(resp)
         return resp.json()
 
-    def deleteProjectManager(self, id: str) -> Response_deleteProjectManager:
+    def deleteProjectManager(self, id: str) -> typ.Response_deleteProjectManager:
         """Deletes a project manager. Requires admin privileges for shared projects or existing project manager permissions. Cannot remove the last project manager.
 
         Args:
             id (str): ID of the project manager to delete)
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
-            Planka internal status codes and names are included here for disambiguation
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            Forbidden: 403 
-            NotFound: 404 
-            UnprocessableEntity: 422 
-        """
+            ValidationError: 400
+            Unauthorized: 401
+            Forbidden: 403
+            NotFound: 404
+            UnprocessableEntity: 422
+         """
         resp = self.client.delete(f"api/project-managers/{id}")
         raise_planka_err(resp)
         return resp.json()
 
-    def createProject(self, **kwargs: Unpack[Request_createProject]) -> Response_createProject:
+    def createProject(self, **kwargs: Unpack[typ.Request_createProject]) -> typ.Response_createProject:
         """Creates a project. The current user automatically becomes a project manager.
 
         Args:
@@ -1664,76 +1666,76 @@ class PlankaEndpoints:
             description (str | None): Detailed description of the project
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
-            Planka internal status codes and names are included here for disambiguation
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-        """
+            ValidationError: 400
+             Unauthorized: 401
+         """
         resp = self.client.post("api/projects", json=kwargs)
         raise_planka_err(resp)
         return resp.json()
 
-    def getProjects(self) -> Response_getProjects:
+    def getProjects(self) -> typ.Response_getProjects:
         """Retrieves all projects the current user has access to, including managed projects, membership projects, and shared projects (for admins).
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
-            Planka internal status codes and names are included here for disambiguation
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-        """
+            ValidationError: 400
+             Unauthorized: 401
+         """
         resp = self.client.get("api/projects")
         raise_planka_err(resp)
         return resp.json()
 
-    def deleteProject(self, id: str) -> Response_deleteProject:
+    def deleteProject(self, id: str) -> typ.Response_deleteProject:
         """Deletes a project. The project must not have any boards. Requires project manager permissions.
 
         Args:
             id (str): ID of the project to delete)
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
-            Planka internal status codes and names are included here for disambiguation
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            NotFound: 404 
-            UnprocessableEntity: 422 
-        """
+            ValidationError: 400
+            Unauthorized: 401
+            NotFound: 404
+            UnprocessableEntity: 422
+         """
         resp = self.client.delete(f"api/projects/{id}")
         raise_planka_err(resp)
         return resp.json()
 
-    def getProject(self, id: str) -> Response_getProject:
+    def getProject(self, id: str) -> typ.Response_getProject:
         """Retrieves comprehensive project information, including boards, board memberships, and other related data.
 
         Args:
             id (str): ID of the project to retrieve)
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
-            Planka internal status codes and names are included here for disambiguation
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            NotFound: 404 
-        """
+            ValidationError: 400
+            Unauthorized: 401
+            NotFound: 404
+         """
         resp = self.client.get(f"api/projects/{id}")
         raise_planka_err(resp)
         return resp.json()
 
-    def updateProject(self, id: str, **kwargs: Unpack[Request_updateProject]) -> Response_updateProject:
+    def updateProject(self, id: str, **kwargs: Unpack[typ.Request_updateProject]) -> typ.Response_updateProject:
         """Updates a project. Accessible fields depend on user permissions.
 
         Args:
@@ -1748,23 +1750,23 @@ class PlankaEndpoints:
             isFavorite (bool): Whether the project is marked as favorite by the current user
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
-            Planka internal status codes and names are included here for disambiguation
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            Forbidden: 403 
-            NotFound: 404 
-            Conflict: 409 
-            UnprocessableEntity: 422 
-        """
+            ValidationError: 400
+            Unauthorized: 401
+            Forbidden: 403
+            NotFound: 404
+            Conflict: 409
+            UnprocessableEntity: 422
+         """
         resp = self.client.patch(f"api/projects/{id}", json=kwargs)
         raise_planka_err(resp)
         return resp.json()
 
-    def createTaskList(self, cardId: str, **kwargs: Unpack[Request_createTaskList]) -> Response_createTaskList:
+    def createTaskList(self, cardId: str, **kwargs: Unpack[typ.Request_createTaskList]) -> typ.Response_createTaskList:
         """Creates a task list within a card. Requires board editor permissions.
 
         Args:
@@ -1775,62 +1777,62 @@ class PlankaEndpoints:
             hideCompletedTasks (bool): Whether to hide completed tasks
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
-            Planka internal status codes and names are included here for disambiguation
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            Forbidden: 403 
-            NotFound: 404 
-        """
+            ValidationError: 400
+            Unauthorized: 401
+            Forbidden: 403
+            NotFound: 404
+         """
         resp = self.client.post(f"api/cards/{cardId}/task-lists", json=kwargs)
         raise_planka_err(resp)
         return resp.json()
 
-    def deleteTaskList(self, id: str) -> Response_deleteTaskList:
+    def deleteTaskList(self, id: str) -> typ.Response_deleteTaskList:
         """Deletes a task list and all its tasks. Requires board editor permissions.
 
         Args:
             id (str): ID of the task list to delete)
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
-            Planka internal status codes and names are included here for disambiguation
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            Forbidden: 403 
-            NotFound: 404 
-        """
+            ValidationError: 400
+            Unauthorized: 401
+            Forbidden: 403
+            NotFound: 404
+         """
         resp = self.client.delete(f"api/task-lists/{id}")
         raise_planka_err(resp)
         return resp.json()
 
-    def getTaskList(self, id: str) -> Response_getTaskList:
+    def getTaskList(self, id: str) -> typ.Response_getTaskList:
         """Retrieves task list information, including tasks. Requires access to the card.
 
         Args:
             id (str): ID of the task list to retrieve)
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
-            Planka internal status codes and names are included here for disambiguation
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            NotFound: 404 
-        """
+            ValidationError: 400
+            Unauthorized: 401
+            NotFound: 404
+         """
         resp = self.client.get(f"api/task-lists/{id}")
         raise_planka_err(resp)
         return resp.json()
 
-    def updateTaskList(self, id: str, **kwargs: Unpack[Request_updateTaskList]) -> Response_updateTaskList:
+    def updateTaskList(self, id: str, **kwargs: Unpack[typ.Request_updateTaskList]) -> typ.Response_updateTaskList:
         """Updates a task list. Requires board editor permissions.
 
         Args:
@@ -1841,21 +1843,21 @@ class PlankaEndpoints:
             hideCompletedTasks (bool): Whether to hide completed tasks
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
-            Planka internal status codes and names are included here for disambiguation
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            Forbidden: 403 
-            NotFound: 404 
-        """
+            ValidationError: 400
+            Unauthorized: 401
+            Forbidden: 403
+            NotFound: 404
+         """
         resp = self.client.patch(f"api/task-lists/{id}", json=kwargs)
         raise_planka_err(resp)
         return resp.json()
 
-    def createTask(self, taskListId: str, **kwargs: Unpack[Request_createTask]) -> Response_createTask:
+    def createTask(self, taskListId: str, **kwargs: Unpack[typ.Request_createTask]) -> typ.Response_createTask:
         """Creates a task within a task list. Either `linkedCardId` or `name` must be provided. Requires board editor permissions.
 
         Args:
@@ -1866,43 +1868,43 @@ class PlankaEndpoints:
             isCompleted (bool): Whether the task is completed
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
-            Planka internal status codes and names are included here for disambiguation
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            Forbidden: 403 
-            NotFound: 404 
-            UnprocessableEntity: 422 
-        """
+            ValidationError: 400
+            Unauthorized: 401
+            Forbidden: 403
+            NotFound: 404
+            UnprocessableEntity: 422
+         """
         resp = self.client.post(f"api/task-lists/{taskListId}/tasks", json=kwargs)
         raise_planka_err(resp)
         return resp.json()
 
-    def deleteTask(self, id: str) -> Response_deleteTask:
+    def deleteTask(self, id: str) -> typ.Response_deleteTask:
         """Deletes a task. Requires board editor permissions.
 
         Args:
             id (str): ID of the task to delete)
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
-            Planka internal status codes and names are included here for disambiguation
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            Forbidden: 403 
-            NotFound: 404 
-        """
+            ValidationError: 400
+            Unauthorized: 401
+            Forbidden: 403
+            NotFound: 404
+         """
         resp = self.client.delete(f"api/tasks/{id}")
         raise_planka_err(resp)
         return resp.json()
 
-    def updateTask(self, id: str, **kwargs: Unpack[Request_updateTask]) -> Response_updateTask:
+    def updateTask(self, id: str, **kwargs: Unpack[typ.Request_updateTask]) -> typ.Response_updateTask:
         """Updates a task. Linked card tasks have limited update options. Requires board editor permissions.
 
         Args:
@@ -1914,63 +1916,63 @@ class PlankaEndpoints:
             isCompleted (bool): Whether the task is completed
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
-            Planka internal status codes and names are included here for disambiguation
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            Forbidden: 403 
-            NotFound: 404 
-        """
+            ValidationError: 400
+            Unauthorized: 401
+            Forbidden: 403
+            NotFound: 404
+         """
         resp = self.client.patch(f"api/tasks/{id}", json=kwargs)
         raise_planka_err(resp)
         return resp.json()
 
-    def getTerms(self, **kwargs: Unpack[Request_getTerms]) -> Response_getTerms:
+    def getTerms(self, **kwargs: Unpack[typ.Request_getTerms]) -> typ.Response_getTerms:
         """Retrieves terms and conditions in the specified language.
 
         Args:
             language (str): Language code for terms localization) (optional)
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
-            Planka internal status codes and names are included here for disambiguation
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            NotFound: 404 
-        """
+            ValidationError: 400
+            Unauthorized: 401
+            NotFound: 404
+         """
         valid_params = ('language',)
         passed_params = {k: v for k, v in kwargs.items() if k in valid_params if isinstance(v, str | int | float)}
         resp = self.client.get("api/terms", params=passed_params)
         raise_planka_err(resp)
         return resp.json()
 
-    def createUserApiKey(self, id: str) -> Response_createUserApiKey:
+    def createUserApiKey(self, id: str) -> typ.Response_createUserApiKey:
         """Generates a user's API key. The full API key is returned only once and cannot be retrieved again.
 
         Args:
             id (str): ID of the user to create API key for)
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
-            Planka internal status codes and names are included here for disambiguation
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            NotFound: 404 
-        """
+            ValidationError: 400
+            Unauthorized: 401
+            NotFound: 404
+         """
         resp = self.client.post(f"api/users/{id}/api-key")
         raise_planka_err(resp)
         return resp.json()
 
-    def createUser(self, **kwargs: Unpack[Request_createUser]) -> Response_createUser:
+    def createUser(self, **kwargs: Unpack[typ.Request_createUser]) -> typ.Response_createUser:
         """Creates a user account. Requires admin privileges.
 
         Args:
@@ -1987,59 +1989,59 @@ class PlankaEndpoints:
             turnOffRecentCardHighlighting (bool): Whether recent card highlighting is disabled
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
-            Planka internal status codes and names are included here for disambiguation
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            Forbidden: 403 
-            Conflict: 409 
-        """
+            ValidationError: 400
+             Unauthorized: 401
+             Forbidden: 403
+            Conflict: 409
+         """
         resp = self.client.post("api/users", json=kwargs)
         raise_planka_err(resp)
         return resp.json()
 
-    def getUsers(self) -> Response_getUsers:
+    def getUsers(self) -> typ.Response_getUsers:
         """Retrieves a list of all users. Requires admin or project owner privileges.
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
-            Planka internal status codes and names are included here for disambiguation
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            Forbidden: 403 
-        """
+            ValidationError: 400
+             Unauthorized: 401
+             Forbidden: 403
+         """
         resp = self.client.get("api/users")
         raise_planka_err(resp)
         return resp.json()
 
-    def deleteUser(self, id: str) -> Response_deleteUser:
+    def deleteUser(self, id: str) -> typ.Response_deleteUser:
         """Deletes a user account. Cannot delete the default admin user. Requires admin privileges.
 
         Args:
             id (str): ID of the user to delete)
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
-            Planka internal status codes and names are included here for disambiguation
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            Forbidden: 403 
-            NotFound: 404 
-        """
+            ValidationError: 400
+            Unauthorized: 401
+            Forbidden: 403
+            NotFound: 404
+         """
         resp = self.client.delete(f"api/users/{id}")
         raise_planka_err(resp)
         return resp.json()
 
-    def getUser(self, id: str, **kwargs: Unpack[Request_getUser]) -> Response_getUser:
+    def getUser(self, id: str, **kwargs: Unpack[typ.Request_getUser]) -> typ.Response_getUser:
         """Retrieves a user. Use 'me' as ID to get the current user.
 
         Args:
@@ -2047,22 +2049,22 @@ class PlankaEndpoints:
             subscribe (bool): Whether to subscribe to real-time updates for this user (only for socket connections)) (optional)
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
-            Planka internal status codes and names are included here for disambiguation
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            NotFound: 404 
-        """
+            ValidationError: 400
+            Unauthorized: 401
+            NotFound: 404
+         """
         valid_params = ('subscribe',)
         passed_params = {k: v for k, v in kwargs.items() if k in valid_params if isinstance(v, str | int | float)}
         resp = self.client.get(f"api/users/{id}", params=passed_params)
         raise_planka_err(resp)
         return resp.json()
 
-    def updateUser(self, id: str, **kwargs: Unpack[Request_updateUser]) -> Response_updateUser:
+    def updateUser(self, id: str, **kwargs: Unpack[typ.Request_updateUser]) -> typ.Response_updateUser:
         """Updates a user. Users can update their own profile, admins can update any user.
 
         Args:
@@ -2085,22 +2087,22 @@ class PlankaEndpoints:
             isDeactivated (bool): Whether the user account is deactivated and cannot log in (for admins)
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
-            Planka internal status codes and names are included here for disambiguation
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            Forbidden: 403 
-            NotFound: 404 
-            Conflict: 409 
-        """
+            ValidationError: 400
+            Unauthorized: 401
+            Forbidden: 403
+            NotFound: 404
+            Conflict: 409
+         """
         resp = self.client.patch(f"api/users/{id}", json=kwargs)
         raise_planka_err(resp)
         return resp.json()
 
-    def updateUserAvatar(self, id: str, mime_type: str | None=None ,**kwargs: Unpack[Request_updateUserAvatar]) -> Response_updateUserAvatar:
+    def updateUserAvatar(self, id: str, mime_type: str | None = None, **kwargs: Unpack[typ.Request_updateUserAvatar]) -> typ.Response_updateUserAvatar:
         """Updates a user's avatar image. Users can update their own avatar, admins can update any user's avatar.
 
         Args:
@@ -2109,24 +2111,23 @@ class PlankaEndpoints:
             file (bytes): Avatar image file (must be an image format)
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
-            Planka internal status codes and names are included here for disambiguation
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            NotFound: 404 
-            UnprocessableEntity: 422 
-        """
-        resp = self.client.post(f"api/users/{id}/avatar", 
-            files={'file': ('avatar', kwargs['file'], mime_type)}, 
+            ValidationError: 400
+            Unauthorized: 401
+            NotFound: 404
+            UnprocessableEntity: 422
+         """
+        resp = self.client.post(f"api/users/{id}/avatar",
+            files={'file': ('avatar', kwargs['file'], mime_type)},
         )
         raise_planka_err(resp)
         return resp.json()
 
-
-    def updateUserEmail(self, id: str, **kwargs: Unpack[Request_updateUserEmail]) -> Response_updateUserEmail:
+    def updateUserEmail(self, id: str, **kwargs: Unpack[typ.Request_updateUserEmail]) -> typ.Response_updateUserEmail:
         """Updates a user's email address. Users must provide current password when updating their own email. Admins can update any user's email without a password.
 
         Args:
@@ -2135,22 +2136,22 @@ class PlankaEndpoints:
             currentPassword (str): Current password (required when updating own email)
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
-            Planka internal status codes and names are included here for disambiguation
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            Forbidden: 403 
-            NotFound: 404 
-            Conflict: 409 
-        """
+            ValidationError: 400
+            Unauthorized: 401
+            Forbidden: 403
+            NotFound: 404
+            Conflict: 409
+         """
         resp = self.client.patch(f"api/users/{id}/email", json=kwargs)
         raise_planka_err(resp)
         return resp.json()
 
-    def updateUserPassword(self, id: str, **kwargs: Unpack[Request_updateUserPassword]) -> Response_updateUserPassword:
+    def updateUserPassword(self, id: str, **kwargs: Unpack[typ.Request_updateUserPassword]) -> typ.Response_updateUserPassword:
         """Updates a user's password. Users must provide a current password when updating their own password. Admins can update any user's password without the current password. Returns a new access token when updating own password.
 
         Args:
@@ -2159,21 +2160,21 @@ class PlankaEndpoints:
             currentPassword (str): Current password (required when updating own password)
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
-            Planka internal status codes and names are included here for disambiguation
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            Forbidden: 403 
-            NotFound: 404 
-        """
+            ValidationError: 400
+            Unauthorized: 401
+            Forbidden: 403
+            NotFound: 404
+         """
         resp = self.client.patch(f"api/users/{id}/password", json=kwargs)
         raise_planka_err(resp)
         return resp.json()
 
-    def updateUserUsername(self, id: str, **kwargs: Unpack[Request_updateUserUsername]) -> Response_updateUserUsername:
+    def updateUserUsername(self, id: str, **kwargs: Unpack[typ.Request_updateUserUsername]) -> typ.Response_updateUserUsername:
         """Updates a user's username. Users must provide a current password when updating their own username (unless they are SSO users with `oidcIgnoreUsername` enabled). Admins can update any user's username without the current password.
 
         Args:
@@ -2182,22 +2183,22 @@ class PlankaEndpoints:
             currentPassword (str): Current password (required when updating own username)
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
-            Planka internal status codes and names are included here for disambiguation
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            Forbidden: 403 
-            NotFound: 404 
-            Conflict: 409 
-        """
+            ValidationError: 400
+            Unauthorized: 401
+            Forbidden: 403
+            NotFound: 404
+            Conflict: 409
+         """
         resp = self.client.patch(f"api/users/{id}/username", json=kwargs)
         raise_planka_err(resp)
         return resp.json()
 
-    def createWebhook(self, **kwargs: Unpack[Request_createWebhook]) -> Response_createWebhook:
+    def createWebhook(self, **kwargs: Unpack[typ.Request_createWebhook]) -> typ.Response_createWebhook:
         """Creates a webhook. Requires admin privileges.
 
         Args:
@@ -2208,56 +2209,56 @@ class PlankaEndpoints:
             excludedEvents (str | None): Comma-separated list of events excluded from the webhook
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
-            Planka internal status codes and names are included here for disambiguation
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            Conflict: 409 
-        """
+            ValidationError: 400
+             Unauthorized: 401
+            Conflict: 409
+         """
         resp = self.client.post("api/webhooks", json=kwargs)
         raise_planka_err(resp)
         return resp.json()
 
-    def getWebhooks(self) -> Response_getWebhooks:
+    def getWebhooks(self) -> typ.Response_getWebhooks:
         """Retrieves a list of all configured webhooks. Requires admin privileges.
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
-            Planka internal status codes and names are included here for disambiguation
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-        """
+            ValidationError: 400
+             Unauthorized: 401
+         """
         resp = self.client.get("api/webhooks")
         raise_planka_err(resp)
         return resp.json()
 
-    def deleteWebhook(self, id: str) -> Response_deleteWebhook:
+    def deleteWebhook(self, id: str) -> typ.Response_deleteWebhook:
         """Deletes a webhook. Requires admin privileges.
 
         Args:
             id (str): ID of the webhook to delete)
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
-            Planka internal status codes and names are included here for disambiguation
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            NotFound: 404 
-        """
+            ValidationError: 400
+            Unauthorized: 401
+            NotFound: 404
+         """
         resp = self.client.delete(f"api/webhooks/{id}")
         raise_planka_err(resp)
         return resp.json()
 
-    def updateWebhook(self, id: str, **kwargs: Unpack[Request_updateWebhook]) -> Response_updateWebhook:
+    def updateWebhook(self, id: str, **kwargs: Unpack[typ.Request_updateWebhook]) -> typ.Response_updateWebhook:
         """Updates a webhook. Requires admin privileges.
 
         Args:
@@ -2269,15 +2270,15 @@ class PlankaEndpoints:
             excludedEvents (str | None): Comma-separated list of events excluded from the webhook
 
         Note:
-            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`). 
-            If a matching PlankaError exists, it will be raised (see `api.errors`) 
-            Planka internal status codes and names are included here for disambiguation
+            All status errors are instances of `httpx.HTTPStatusError` at runtime (`response.raise_for_status()`).
+             If a matching PlankaError exists, it will be raised (see `api.errors`)
+             Planka internal status codes and names are included here for disambiguation
 
         Raises:
-            ValidationError: 400 
-            Unauthorized: 401 
-            NotFound: 404 
-        """
+            ValidationError: 400
+            Unauthorized: 401
+            NotFound: 404
+         """
         resp = self.client.patch(f"api/webhooks/{id}", json=kwargs)
         raise_planka_err(resp)
         return resp.json()

--- a/src/plankapy/v2/api/paths.py
+++ b/src/plankapy/v2/api/paths.py
@@ -14,12 +14,9 @@ def raise_planka_err(resp: Response) -> None:
     try:
         resp.raise_for_status()
     except HTTPStatusError as status_err:
-        try:
-            planka_code = status_err.response.json().get('code')
-            planka_err = ERRORS.get(planka_code, PlankaError)
-            raise planka_err(status_err)
-        except Exception as e:
-            raise status_err from e
+        planka_code = status_err.response.json().get('code')
+        planka_err = ERRORS.get(planka_code, PlankaError)
+        raise planka_err(status_err) from status_err
 
 
 class PlankaEndpoints:

--- a/src/plankapy/v2/api/pro_paths.py
+++ b/src/plankapy/v2/api/pro_paths.py
@@ -1,17 +1,17 @@
 from __future__ import annotations
 
-from . import paths
-from typing import (
-    Literal,
-    Unpack,
+from httpx import Response
+
+from . import (
+    paths,
+    # typ,
+    # pro_schemas as ps,
 )
-from httpx import Client, Response, HTTPStatusError
-from .pro_schemas import *
-from .typ import *
-from .errors import *
+
 
 def raise_planka_err(resp: Response) -> None:
     paths.raise_planka_err(resp)
+
 
 # For implememtation of Planka Pro endpoints
 class PlankaEndpoints(paths.PlankaEndpoints): ...

--- a/src/plankapy/v2/api/pro_schemas.py
+++ b/src/plankapy/v2/api/pro_schemas.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
-from typing import Literal, NotRequired, TypedDict
+from typing import Literal, TypedDict
+
 from . import schemas
 
 __all__ = (
     "Card",
 )
+
 
 class Card(schemas.Card):
     isDraft: bool
@@ -22,7 +24,7 @@ class Card(schemas.Card):
     sourceLabels: list[str]
     sourceId: str
     coverLinkAttachmentId: str
-    
+
 
 class Recurrence(TypedDict):
     time: str
@@ -49,14 +51,14 @@ class Board(schemas.Board):
 
 class List(schemas.List):
     # Added a `recurring` list type
-    type: Literal['active', 'closed', 'archive', 'trash', 'recurring'] # type: ignore
+    type: Literal['active', 'closed', 'archive', 'trash', 'recurring']  # type: ignore
 
 
 class User(schemas.User):
     hideIdentityFromGuests: bool
 
     # Added `guest?`
-    role: Literal['admin', 'projectOwner', 'boardUser', 'guest'] # type: ignore
+    role: Literal['admin', 'projectOwner', 'boardUser', 'guest']  # type: ignore
     canBeUsedByWorkers: bool
     canBeUsedByGuests: bool
 
@@ -86,7 +88,7 @@ class Comment(schemas.Comment):
     isIdentityHiddenFromGuests: bool | None
     isPinned: bool
 
+
 class TaskList(schemas.TaskList):
     canBeEditedByWorkers: bool
     isVisibleToGuests: bool
-    

--- a/src/plankapy/v2/api/schemas.py
+++ b/src/plankapy/v2/api/schemas.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
-from typing import TypedDict, NotRequired, Any, Literal
+
+from typing import Any, Literal, NotRequired, TypedDict
 
 from .events import PlankaEvent
 
@@ -10,6 +11,7 @@ __all__ = (
     "BaseCustomFieldGroup",
     "Board",
     "BoardMembership",
+    "Bootstrap",
     "Card",
     "CardLabel",
     "CardMembership",
@@ -24,13 +26,13 @@ __all__ = (
     "NotificationService",
     "Project",
     "ProjectManager",
+    "Stopwatch",
     "Task",
     "TaskList",
     "User",
     "Webhook",
-    "Stopwatch",
-    "Bootstrap",
 )
+
 
 class Action(TypedDict):
     id: str
@@ -50,6 +52,7 @@ class Action(TypedDict):
     updatedAt: str
     """When the action was last updated"""
 
+
 class Attachment(TypedDict):
     id: str
     """Unique identifier for the attachment"""
@@ -68,6 +71,7 @@ class Attachment(TypedDict):
     updatedAt: str
     """When the attachment was last updated"""
 
+
 class BackgroundImage(TypedDict):
     id: str
     """Unique identifier for the background image"""
@@ -84,6 +88,7 @@ class BackgroundImage(TypedDict):
     updatedAt: str
     """When the background image was last updated"""
 
+
 class BaseCustomFieldGroup(TypedDict):
     id: str
     """Unique identifier for the base custom field group"""
@@ -95,6 +100,7 @@ class BaseCustomFieldGroup(TypedDict):
     """When the base custom field group was created"""
     updatedAt: str
     """When the base custom field group was last updated"""
+
 
 class Board(TypedDict):
     id: str
@@ -120,6 +126,7 @@ class Board(TypedDict):
     updatedAt: str
     """When the board was last updated"""
 
+
 class BoardMembership(TypedDict):
     id: str
     """Unique identifier for the board membership"""
@@ -138,6 +145,7 @@ class BoardMembership(TypedDict):
     updatedAt: str
     """When the board membership was last updated"""
 
+
 class Bootstrap(TypedDict):
     oidc: OIDC
     "OpenID Connect configuration (null if not configured)"
@@ -149,7 +157,8 @@ class Bootstrap(TypedDict):
     "URL to the customer management panel (conditionally added for admins if configured)"
     termsLanguages: NotRequired[list[str]]
     "List of available language codes for terms localization"
-    
+
+
 class OIDC(TypedDict):
     """OIDC response schema"""
     authorizationUrl: str
@@ -158,6 +167,7 @@ class OIDC(TypedDict):
     "OIDC end session URL for logout (null if not supported by provider)"
     isEnforced: bool
     "Whether OIDC authentication is enforced (users must use OIDC to login)"
+
 
 class Card(TypedDict):
     id: str
@@ -199,6 +209,7 @@ class Card(TypedDict):
     isSubscribed: NotRequired[bool]
     """If the current user is subscribed to the card"""
 
+
 class CardLabel(TypedDict):
     id: str
     """Unique identifier for the card-label association"""
@@ -211,6 +222,7 @@ class CardLabel(TypedDict):
     updatedAt: str
     """When the card-label association was last updated"""
 
+
 class CardMembership(TypedDict):
     id: str
     """Unique identifier for the card membership"""
@@ -222,6 +234,7 @@ class CardMembership(TypedDict):
     """When the card membership was created"""
     updatedAt: str
     """When the card membership was last updated"""
+
 
 class Comment(TypedDict):
     id: str
@@ -236,6 +249,7 @@ class Comment(TypedDict):
     """When the comment was created"""
     updatedAt: str
     """When the comment was last updated"""
+
 
 class Config(TypedDict):
     id: str
@@ -261,6 +275,7 @@ class Config(TypedDict):
     updatedAt: NotRequired[str]
     """When the config was last updated"""
 
+
 class CustomField(TypedDict):
     id: str
     """Unique identifier for the custom field"""
@@ -278,6 +293,7 @@ class CustomField(TypedDict):
     """When the custom field was created"""
     updatedAt: str
     """When the custom field was last updated"""
+
 
 class CustomFieldGroup(TypedDict):
     id: str
@@ -297,6 +313,7 @@ class CustomFieldGroup(TypedDict):
     updatedAt: str
     """When the custom field group was last updated"""
 
+
 class CustomFieldValue(TypedDict):
     id: str
     """Unique identifier for the custom field value"""
@@ -313,6 +330,7 @@ class CustomFieldValue(TypedDict):
     updatedAt: str
     """When the custom field value was last updated"""
 
+
 class Label(TypedDict):
     id: str
     """Unique identifier for the label"""
@@ -328,6 +346,7 @@ class Label(TypedDict):
     """When the label was created"""
     updatedAt: str
     """When the label was last updated"""
+
 
 class List(TypedDict):
     id: str
@@ -346,6 +365,7 @@ class List(TypedDict):
     """When the list was created"""
     updatedAt: str
     """When the list was last updated"""
+
 
 class Notification(TypedDict):
     id: str
@@ -373,6 +393,7 @@ class Notification(TypedDict):
     updatedAt: str
     """When the notification was last updated"""
 
+
 class NotificationService(TypedDict):
     id: str
     """Unique identifier for the notification service"""
@@ -388,6 +409,7 @@ class NotificationService(TypedDict):
     """When the notification service was created"""
     updatedAt: str
     """When the notification service was last updated"""
+
 
 class Project(TypedDict):
     id: str
@@ -413,6 +435,7 @@ class Project(TypedDict):
     isFavorite: NotRequired[bool]
     """If the project is in the current user's favorites"""
 
+
 class ProjectManager(TypedDict):
     id: str
     """Unique identifier for the project manager"""
@@ -424,6 +447,7 @@ class ProjectManager(TypedDict):
     """When the project manager was created"""
     updatedAt: str
     """When the project manager was last updated"""
+
 
 class Task(TypedDict):
     id: str
@@ -445,6 +469,7 @@ class Task(TypedDict):
     updatedAt: str
     """When the task was last updated"""
 
+
 class TaskList(TypedDict):
     id: str
     """Unique identifier for the task list"""
@@ -462,6 +487,7 @@ class TaskList(TypedDict):
     """When the task list was created"""
     updatedAt: str
     """When the task list was last updated"""
+
 
 class User(TypedDict):
     id: str
@@ -513,6 +539,7 @@ class User(TypedDict):
     updatedAt: str
     """When the user was last updated"""
 
+
 class Webhook(TypedDict):
     id: str
     """Unique identifier for the webhook"""
@@ -532,6 +559,7 @@ class Webhook(TypedDict):
     """When the webhook was created"""
     updatedAt: str
     """When the webhook was last updated"""
+
 
 class Stopwatch(TypedDict):
     startedAt: str | None

--- a/src/plankapy/v2/api/typ.py
+++ b/src/plankapy/v2/api/typ.py
@@ -11,7 +11,6 @@ from typing import (
 from . import schemas as sch
 
 
-# Request Typing
 class Request_acceptTerms(TypedDict):
     pendingToken: str
     """Pending token received from the authentication flow"""
@@ -588,7 +587,6 @@ class Request_updateWebhook(TypedDict):
     """Comma-separated list of events excluded from the webhook"""
 
 
-# Response Typing
 class Response_acceptTerms(TypedDict):
     """Terms accepted successfully"""
     item: str
@@ -739,7 +737,7 @@ class Included_getBoard_all(sch.Card):
 
 
 class Item_getBoard(sch.Board):
-    isSubscribed: bool
+    isSubscribed: NotRequired[bool]
     """Whether the current user is subscribed to the board"""
 
 

--- a/src/plankapy/v2/api/typ.py
+++ b/src/plankapy/v2/api/typ.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
+
 from datetime import datetime
 from typing import (
     Any,
     Literal,
-    TypedDict,
     NotRequired,
+    TypedDict,
 )
-from .schemas import *
+
+from . import schemas as sch
 
 
 # Request Typing
@@ -18,6 +20,7 @@ class Request_acceptTerms(TypedDict):
     initialLanguage: NotRequired[Literal['ar-YE', 'bg-BG', 'ca-ES', 'cs-CZ', 'da-DK', 'de-DE', 'el-GR', 'en-GB', 'en-US', 'es-ES', 'et-EE', 'fa-IR', 'fi-FI', 'fr-FR', 'hu-HU', 'id-ID', 'it-IT', 'ja-JP', 'ko-KR', 'nl-NL', 'pl-PL', 'pt-BR', 'pt-PT', 'ro-RO', 'ru-RU', 'sk-SK', 'sr-Cyrl-RS', 'sr-Latn-RS', 'sv-SE', 'tr-TR', 'uk-UA', 'uz-UZ', 'vi-VN', 'zh-CN', 'zh-TW'] | None]
     """Preferred language for user interface and notifications (used only if user language is not set)"""
 
+
 class Request_createAccessToken(TypedDict):
     emailOrUsername: str
     """Email address or username of the user"""
@@ -25,6 +28,7 @@ class Request_createAccessToken(TypedDict):
     """Password of the user"""
     withHttpOnlyToken: NotRequired[bool]
     """Whether to include an HTTP-only authentication cookie"""
+
 
 class Request_exchangeForAccessTokenWithOidc(TypedDict):
     code: str
@@ -34,17 +38,21 @@ class Request_exchangeForAccessTokenWithOidc(TypedDict):
     withHttpOnlyToken: NotRequired[bool]
     """Whether to include HTTP-only authentication cookie"""
 
+
 class Request_revokePendingToken(TypedDict):
     pendingToken: str
     """Pending token to revoke"""
+
 
 class Request_getBoardActions(TypedDict):
     beforeId: NotRequired[str]
     """ID to get actions before (for pagination)"""
 
+
 class Request_getCardActions(TypedDict):
     beforeId: NotRequired[str]
     """ID to get actions before (for pagination)"""
+
 
 class Request_createAttachment(TypedDict):
     type: Literal['file', 'link']
@@ -58,9 +66,11 @@ class Request_createAttachment(TypedDict):
     requestId: NotRequired[str]
     """Request ID for tracking"""
 
+
 class Request_updateAttachment(TypedDict):
     name: NotRequired[str]
     """Name/title of the attachment"""
+
 
 class Request_createBackgroundImage(TypedDict):
     file: bytes
@@ -68,13 +78,16 @@ class Request_createBackgroundImage(TypedDict):
     requestId: NotRequired[str]
     """Request ID for tracking"""
 
+
 class Request_createBaseCustomFieldGroup(TypedDict):
     name: str
     """Name/title of the base custom field group"""
 
+
 class Request_updateBaseCustomFieldGroup(TypedDict):
     name: NotRequired[str]
     """Name/title of the base custom field group"""
+
 
 class Request_createBoardMembership(TypedDict):
     userId: str
@@ -84,11 +97,13 @@ class Request_createBoardMembership(TypedDict):
     canComment: NotRequired[bool | None]
     """Whether the user can comment on cards (applies only to viewers)"""
 
+
 class Request_updateBoardMembership(TypedDict):
     role: NotRequired[Literal['editor', 'viewer']]
     """Role of the user in the board"""
     canComment: NotRequired[bool | None]
     """Whether the user can comment on cards (applies only to viewers)"""
+
 
 class Request_createBoard(TypedDict):
     position: int
@@ -102,9 +117,11 @@ class Request_createBoard(TypedDict):
     requestId: NotRequired[str]
     """Request ID for tracking"""
 
+
 class Request_getBoard(TypedDict):
     subscribe: NotRequired[bool]
     """Whether to subscribe to real-time updates for this board (only for socket connections)"""
+
 
 class Request_updateBoard(TypedDict):
     position: NotRequired[int]
@@ -124,13 +141,16 @@ class Request_updateBoard(TypedDict):
     isSubscribed: NotRequired[bool]
     """Whether the current user is subscribed to the board"""
 
+
 class Request_createCardLabel(TypedDict):
     labelId: str
     """ID of the label to add to the card"""
 
+
 class Request_createCardMembership(TypedDict):
     userId: str
     """ID of the card to add the user to"""
+
 
 class Request_createCard(TypedDict):
     type: Literal['project', 'story']
@@ -148,6 +168,7 @@ class Request_createCard(TypedDict):
     stopwatch: NotRequired[dict[str, Any] | None]
     """Stopwatch data for time tracking"""
 
+
 class Request_getCards(TypedDict):
     before_listChangedAt: NotRequired[str]
     """Pagination cursor field `listChangedAt` (use together with `before_id`)"""
@@ -159,6 +180,7 @@ class Request_getCards(TypedDict):
     """Comma-separated user IDs to filter by members or task assignees"""
     labelIds: NotRequired[str]
     """Comma-separated label IDs to filter by labels"""
+
 
 class Request_updateCard(TypedDict):
     boardId: NotRequired[str]
@@ -179,10 +201,11 @@ class Request_updateCard(TypedDict):
     """Due date for the card"""
     isDueCompleted: NotRequired[bool | None]
     """Whether the due date is completed"""
-    stopwatch: NotRequired[Stopwatch | None]
+    stopwatch: NotRequired[sch.Stopwatch | None]
     """Stopwatch data for time tracking"""
     isSubscribed: NotRequired[bool]
     """Whether the current user is subscribed to the card"""
+
 
 class Request_duplicateCard(TypedDict):
     boardId: NotRequired[str]
@@ -194,17 +217,21 @@ class Request_duplicateCard(TypedDict):
     name: NotRequired[str | None]
     """Name/title for the duplicated card"""
 
+
 class Request_createComment(TypedDict):
     text: str
     """Content of the comment"""
+
 
 class Request_getComments(TypedDict):
     beforeId: NotRequired[str]
     """ID to get comments before (for pagination)"""
 
+
 class Request_updateComments(TypedDict):
     text: NotRequired[str]
     """Content of the comment"""
+
 
 class Request_updateConfig(TypedDict):
     smtpHost: NotRequired[str | None]
@@ -224,6 +251,7 @@ class Request_updateConfig(TypedDict):
     smtpFrom: NotRequired[str | None]
     """Default "from" used for outgoing SMTP emails"""
 
+
 class Request_createBoardCustomFieldGroup(TypedDict):
     baseCustomFieldGroupId: NotRequired[str]
     """ID of the base custom field group used as a template"""
@@ -231,6 +259,7 @@ class Request_createBoardCustomFieldGroup(TypedDict):
     """Position of the custom field group within the board"""
     name: NotRequired[str | None]
     """Name/title of the custom field group (required if `baseCustomFieldGroupId` is not provided)"""
+
 
 class Request_createCardCustomFieldGroup(TypedDict):
     baseCustomFieldGroupId: NotRequired[str]
@@ -240,15 +269,18 @@ class Request_createCardCustomFieldGroup(TypedDict):
     name: NotRequired[str | None]
     """Name/title of the custom field group (required if `baseCustomFieldGroupId` is not provided)"""
 
+
 class Request_updateCustomFieldGroup(TypedDict):
     position: NotRequired[int]
     """Position of the custom field group within the board/card"""
     name: NotRequired[str | None]
     """Name/title of the custom field group"""
 
+
 class Request_updateCustomFieldValue(TypedDict):
     content: str
     """Content/value of the custom field"""
+
 
 class Request_createCustomFieldInBaseGroup(TypedDict):
     position: int
@@ -258,6 +290,7 @@ class Request_createCustomFieldInBaseGroup(TypedDict):
     showOnFrontOfCard: NotRequired[bool]
     """Whether to show the field on the front of cards"""
 
+
 class Request_createCustomFieldInGroup(TypedDict):
     position: int
     """Position of the custom field within the group"""
@@ -265,6 +298,7 @@ class Request_createCustomFieldInGroup(TypedDict):
     """Name/title of the custom field"""
     showOnFrontOfCard: NotRequired[bool]
     """Whether to show the field on the front of cards"""
+
 
 class Request_updateCustomField(TypedDict):
     position: NotRequired[int]
@@ -274,6 +308,7 @@ class Request_updateCustomField(TypedDict):
     showOnFrontOfCard: NotRequired[bool]
     """Whether to show the field on the front of cards"""
 
+
 class Request_createLabel(TypedDict):
     position: int
     """Position of the label within the board"""
@@ -281,6 +316,7 @@ class Request_createLabel(TypedDict):
     """Name/title of the label"""
     color: Literal['muddy-grey', 'autumn-leafs', 'morning-sky', 'antique-blue', 'egg-yellow', 'desert-sand', 'dark-granite', 'fresh-salad', 'lagoon-blue', 'midnight-blue', 'light-orange', 'pumpkin-orange', 'light-concrete', 'sunny-grass', 'navy-blue', 'lilac-eyes', 'apricot-red', 'orange-peel', 'silver-glint', 'bright-moss', 'deep-ocean', 'summer-sky', 'berry-red', 'light-cocoa', 'grey-stone', 'tank-green', 'coral-green', 'sugar-plum', 'pink-tulip', 'shady-rust', 'wet-rock', 'wet-moss', 'turquoise-sea', 'lavender-fields', 'piggy-red', 'light-mud', 'gun-metal', 'modern-green', 'french-coast', 'sweet-lilac', 'red-burgundy', 'pirate-gold']
     """Color of the label"""
+
 
 class Request_updateLabel(TypedDict):
     position: NotRequired[int]
@@ -290,6 +326,7 @@ class Request_updateLabel(TypedDict):
     color: NotRequired[Literal['muddy-grey', 'autumn-leafs', 'morning-sky', 'antique-blue', 'egg-yellow', 'desert-sand', 'dark-granite', 'fresh-salad', 'lagoon-blue', 'midnight-blue', 'light-orange', 'pumpkin-orange', 'light-concrete', 'sunny-grass', 'navy-blue', 'lilac-eyes', 'apricot-red', 'orange-peel', 'silver-glint', 'bright-moss', 'deep-ocean', 'summer-sky', 'berry-red', 'light-cocoa', 'grey-stone', 'tank-green', 'coral-green', 'sugar-plum', 'pink-tulip', 'shady-rust', 'wet-rock', 'wet-moss', 'turquoise-sea', 'lavender-fields', 'piggy-red', 'light-mud', 'gun-metal', 'modern-green', 'french-coast', 'sweet-lilac', 'red-burgundy', 'pirate-gold']]
     """Color of the label"""
 
+
 class Request_createList(TypedDict):
     type: Literal['active', 'closed']
     """Type/status of the list"""
@@ -297,6 +334,7 @@ class Request_createList(TypedDict):
     """Position of the list within the board"""
     name: str
     """Name/title of the list"""
+
 
 class Request_updateList(TypedDict):
     boardId: NotRequired[str]
@@ -310,9 +348,11 @@ class Request_updateList(TypedDict):
     color: NotRequired[Literal['berry-red', 'pumpkin-orange', 'lagoon-blue', 'pink-tulip', 'light-mud', 'orange-peel', 'bright-moss', 'antique-blue', 'dark-granite', 'turquoise-sea'] | None]
     """Color for the list"""
 
+
 class Request_moveListCards(TypedDict):
     listId: str
     """ID of the target list (must be an archive-type list)"""
+
 
 class Request_sortList(TypedDict):
     fieldName: Literal['name', 'dueDate', 'createdAt']
@@ -320,11 +360,13 @@ class Request_sortList(TypedDict):
     order: NotRequired[Literal['asc', 'desc']]
     """Sorting order"""
 
+
 class Request_createBoardNotificationService(TypedDict):
     url: str
     """URL endpoint for notifications"""
     format: Literal['text', 'markdown', 'html']
     """Format for notification messages"""
+
 
 class Request_createUserNotificationService(TypedDict):
     url: str
@@ -332,19 +374,23 @@ class Request_createUserNotificationService(TypedDict):
     format: Literal['text', 'markdown', 'html']
     """Format for notification messages"""
 
+
 class Request_updateNotificationService(TypedDict):
     url: NotRequired[str]
     """URL endpoint for notifications"""
     format: NotRequired[Literal['text', 'markdown', 'html']]
     """Format for notification messages"""
 
+
 class Request_updateNotification(TypedDict):
     isRead: NotRequired[bool]
     """Whether the notification has been read"""
 
+
 class Request_createProjectManager(TypedDict):
     userId: str
     """ID of the user who is assigned as project manager"""
+
 
 class Request_createProject(TypedDict):
     type: Literal['private', 'shared']
@@ -353,6 +399,7 @@ class Request_createProject(TypedDict):
     """Name/title of the project"""
     description: NotRequired[str | None]
     """Detailed description of the project"""
+
 
 class Request_updateProject(TypedDict):
     ownerProjectManagerId: NotRequired[str | None]
@@ -372,6 +419,7 @@ class Request_updateProject(TypedDict):
     isFavorite: NotRequired[bool]
     """Whether the project is marked as favorite by the current user"""
 
+
 class Request_createTaskList(TypedDict):
     position: int
     """Position of the task list within the card"""
@@ -381,6 +429,7 @@ class Request_createTaskList(TypedDict):
     """Whether to show the task list on the front of the card"""
     hideCompletedTasks: NotRequired[bool]
     """Whether to hide completed tasks"""
+
 
 class Request_updateTaskList(TypedDict):
     position: NotRequired[int]
@@ -392,6 +441,7 @@ class Request_updateTaskList(TypedDict):
     hideCompletedTasks: NotRequired[bool]
     """Whether to hide completed tasks"""
 
+
 class Request_createTask(TypedDict):
     linkedCardId: NotRequired[str]
     """ID of the card linked to the task"""
@@ -401,6 +451,7 @@ class Request_createTask(TypedDict):
     """Name/title of the task (required if `linkedCardId` is not provided)"""
     isCompleted: NotRequired[bool]
     """Whether the task is completed"""
+
 
 class Request_updateTask(TypedDict):
     taskListId: NotRequired[str]
@@ -414,9 +465,11 @@ class Request_updateTask(TypedDict):
     isCompleted: NotRequired[bool]
     """Whether the task is completed"""
 
+
 class Request_getTerms(TypedDict):
     language: NotRequired[str]
     """Language code for terms localization"""
+
 
 class Request_createUser(TypedDict):
     email: str
@@ -442,9 +495,11 @@ class Request_createUser(TypedDict):
     turnOffRecentCardHighlighting: NotRequired[bool]
     """Whether recent card highlighting is disabled"""
 
+
 class Request_getUser(TypedDict):
     subscribe: NotRequired[bool]
     """Whether to subscribe to real-time updates for this user (only for socket connections)"""
+
 
 class Request_updateUser(TypedDict):
     role: NotRequired[Literal['admin', 'projectOwner', 'boardUser']]
@@ -480,9 +535,11 @@ class Request_updateUser(TypedDict):
     isDeactivated: NotRequired[bool]
     """Whether the user account is deactivated and cannot log in (for admins)"""
 
+
 class Request_updateUserAvatar(TypedDict):
     file: bytes
     """Avatar image file (must be an image format)"""
+
 
 class Request_updateUserEmail(TypedDict):
     email: str
@@ -490,17 +547,20 @@ class Request_updateUserEmail(TypedDict):
     currentPassword: NotRequired[str]
     """Current password (required when updating own email)"""
 
+
 class Request_updateUserPassword(TypedDict):
     password: str
     """Password (must meet password requirements)"""
     currentPassword: NotRequired[str]
     """Current password (required when updating own password)"""
 
+
 class Request_updateUserUsername(TypedDict):
     username: NotRequired[str | None]
     """Unique username for user identification"""
     currentPassword: NotRequired[str]
     """Current password (required when updating own username)"""
+
 
 class Request_createWebhook(TypedDict):
     name: str
@@ -513,6 +573,7 @@ class Request_createWebhook(TypedDict):
     """Comma-separated list of events that trigger the webhook"""
     excludedEvents: NotRequired[str | None]
     """Comma-separated list of events excluded from the webhook"""
+
 
 class Request_updateWebhook(TypedDict):
     name: NotRequired[str]
@@ -527,598 +588,726 @@ class Request_updateWebhook(TypedDict):
     """Comma-separated list of events excluded from the webhook"""
 
 
-
 # Response Typing
 class Response_acceptTerms(TypedDict):
     """Terms accepted successfully"""
     item: str
     """Access token for API authentication"""
 
+
 class Response_createAccessToken(TypedDict):
     """Login successful"""
     item: str
     """Access token for API authentication"""
+
 
 class Response_deleteAccessToken(TypedDict):
     """Logout successful"""
     item: str
     """Revoked access token"""
 
+
 class Response_exchangeForAccessTokenWithOidc(TypedDict):
     """OIDC exchange successful"""
     item: str
     """Access token for API authentication"""
+
 
 class Response_revokePendingToken(TypedDict):
     """Pending token revoked successfully"""
     item: dict[str, Any] | None
     """No data returned"""
 
+
 class Response_getBoardActions(TypedDict):
     """Board actions retrieved successfully"""
-    items: list[Action]
+    items: list[sch.Action]
     included: Included_getBoardActions
 
+
 class Included_getBoardActions(TypedDict):
-    users: list[User]
+    users: list[sch.User]
+
 
 class Response_getCardActions(TypedDict):
     """Card actions retrieved successfully"""
-    items: list[Action]
+    items: list[sch.Action]
     included: Included_getCardActions
 
+
 class Included_getCardActions(TypedDict):
-    users: list[User]
+    users: list[sch.User]
+
 
 class Response_createAttachment(TypedDict):
     """Attachment created successfully"""
-    item: Attachment
+    item: sch.Attachment
+
 
 class Response_deleteAttachment(TypedDict):
     """Attachment deleted successfully"""
-    item: Attachment
+    item: sch.Attachment
+
 
 class Response_updateAttachment(TypedDict):
     """Attachment updated successfully"""
-    item: Attachment
+    item: sch.Attachment
+
 
 class Response_createBackgroundImage(TypedDict):
     """Background image uploaded successfully"""
-    item: BackgroundImage
+    item: sch.BackgroundImage
+
 
 class Response_deleteBackgroundImage(TypedDict):
     """Background image deleted successfully"""
-    item: BackgroundImage
+    item: sch.BackgroundImage
+
 
 class Response_createBaseCustomFieldGroup(TypedDict):
     """Base custom field group created successfully"""
-    item: BaseCustomFieldGroup
+    item: sch.BaseCustomFieldGroup
+
 
 class Response_deleteBaseCustomFieldGroup(TypedDict):
     """Base custom field group deleted successfully"""
-    item: BaseCustomFieldGroup
+    item: sch.BaseCustomFieldGroup
+
 
 class Response_updateBaseCustomFieldGroup(TypedDict):
     """Base custom field group updated successfully"""
-    item: BaseCustomFieldGroup
+    item: sch.BaseCustomFieldGroup
+
 
 class Response_createBoardMembership(TypedDict):
     """Board membership created successfully"""
-    item: BoardMembership
+    item: sch.BoardMembership
+
 
 class Response_deleteBoardMembership(TypedDict):
     """Board membership deleted successfully"""
-    item: BoardMembership
+    item: sch.BoardMembership
+
 
 class Response_updateBoardMembership(TypedDict):
     """Board membership updated successfully"""
-    item: BoardMembership
+    item: sch.BoardMembership
+
 
 class Response_createBoard(TypedDict):
     """Board created successfully"""
-    item: Board
+    item: sch.Board
     included: Included_createBoard
 
+
 class Included_createBoard(TypedDict):
-    boardMemberships: list[BoardMembership]
+    boardMemberships: list[sch.BoardMembership]
+
 
 class Response_deleteBoard(TypedDict):
     """Board deleted successfully"""
-    item: Board
+    item: sch.Board
+
 
 class Response_getBoard(TypedDict):
     """Board details retrieved successfully"""
     item: Item_getBoard
     included: Included_getBoard
 
+
 class Included_getBoard(TypedDict):
-    users: list[User]
-    projects: list[Project]
-    boardMemberships: list[BoardMembership]
-    labels: list[Label]
-    lists: list[List]
+    users: list[sch.User]
+    projects: list[sch.Project]
+    boardMemberships: list[sch.BoardMembership]
+    labels: list[sch.Label]
+    lists: list[sch.List]
     cards: list[Included_getBoard_all]
     """Related cards"""
-    cardMemberships: list[CardMembership]
-    cardLabels: list[CardLabel]
-    taskLists: list[TaskList]
-    tasks: list[Task]
-    attachments: list[Attachment]
-    customFieldGroups: list[CustomFieldGroup]
-    customFields: list[CustomField]
-    customFieldValues: list[CustomFieldValue]
+    cardMemberships: list[sch.CardMembership]
+    cardLabels: list[sch.CardLabel]
+    taskLists: list[sch.TaskList]
+    tasks: list[sch.Task]
+    attachments: list[sch.Attachment]
+    customFieldGroups: list[sch.CustomFieldGroup]
+    customFields: list[sch.CustomField]
+    customFieldValues: list[sch.CustomFieldValue]
 
-class Included_getBoard_all(Card):
+
+class Included_getBoard_all(sch.Card):
     isSubscribed: NotRequired[bool]
     """Whether the current user is subscribed to the card"""
 
-class Item_getBoard(Board):
+
+class Item_getBoard(sch.Board):
     isSubscribed: bool
     """Whether the current user is subscribed to the board"""
 
+
 class Response_updateBoard(TypedDict):
     """Board updated successfully"""
-    item: Board
+    item: sch.Board
+
 
 class Response_getBootstrap(TypedDict):
     """Bootstrap retrieved successfully"""
-    item: Bootstrap
+    item: sch.Bootstrap
+
 
 class Response_createCardLabel(TypedDict):
     """Label added to card successfully"""
-    item: CardLabel
+    item: sch.CardLabel
+
 
 class Response_deleteCardLabel(TypedDict):
     """Label removed from card successfully"""
-    item: CardLabel
+    item: sch.CardLabel
+
 
 class Response_createCardMembership(TypedDict):
     """User added to card successfully"""
-    item: CardMembership
+    item: sch.CardMembership
+
 
 class Response_deleteCardMembership(TypedDict):
     """User removed from card successfully"""
-    item: CardMembership
+    item: sch.CardMembership
+
 
 class Response_createCard(TypedDict):
     """Card created successfully"""
-    item: Card
+    item: sch.Card
+
 
 class Response_getCards(TypedDict):
     """Cards retrieved successfully"""
     items: list[Items_getCards]
     included: Included_getCards
 
-class Included_getCards(TypedDict):
-    users: list[User]
-    cardMemberships: list[CardMembership]
-    cardLabels: list[CardLabel]
-    taskLists: list[TaskList]
-    tasks: list[Task]
-    attachments: list[Attachment]
-    customFieldGroups: list[CustomFieldGroup]
-    customFields: list[CustomField]
-    customFieldValues: list[CustomFieldValue]
 
-class Items_getCards(Card):
+class Included_getCards(TypedDict):
+    users: list[sch.User]
+    cardMemberships: list[sch.CardMembership]
+    cardLabels: list[sch.CardLabel]
+    taskLists: list[sch.TaskList]
+    tasks: list[sch.Task]
+    attachments: list[sch.Attachment]
+    customFieldGroups: list[sch.CustomFieldGroup]
+    customFields: list[sch.CustomField]
+    customFieldValues: list[sch.CustomFieldValue]
+
+
+class Items_getCards(sch.Card):
     isSubscribed: NotRequired[bool]
     """Whether the current user is subscribed to the card"""
 
+
 class Response_deleteCard(TypedDict):
     """Card deleted successfully"""
-    item: Card
+    item: sch.Card
+
 
 class Response_getCard(TypedDict):
     """Card details retrieved successfully"""
     item: Item_getCard
     included: Included_getCard
 
-class Included_getCard(TypedDict):
-    users: list[User]
-    cardMemberships: list[CardMembership]
-    cardLabels: list[CardLabel]
-    taskLists: list[TaskList]
-    tasks: list[Task]
-    attachments: list[Attachment]
-    customFieldGroups: list[CustomFieldGroup]
-    customFields: list[CustomField]
-    customFieldValues: list[CustomFieldValue]
 
-class Item_getCard(Card):
+class Included_getCard(TypedDict):
+    users: list[sch.User]
+    cardMemberships: list[sch.CardMembership]
+    cardLabels: list[sch.CardLabel]
+    taskLists: list[sch.TaskList]
+    tasks: list[sch.Task]
+    attachments: list[sch.Attachment]
+    customFieldGroups: list[sch.CustomFieldGroup]
+    customFields: list[sch.CustomField]
+    customFieldValues: list[sch.CustomFieldValue]
+
+
+class Item_getCard(sch.Card):
     isSubscribed: NotRequired[bool]
     """Whether the current user is subscribed to the card"""
+
 
 class Response_updateCard(TypedDict):
     """Card updated successfully"""
-    item: Card
+    item: sch.Card
+
 
 class Response_duplicateCard(TypedDict):
     """Card duplicated successfully"""
-    item: Card
+    item: sch.Card
     included: Included_duplicateCard
 
+
 class Included_duplicateCard(TypedDict):
-    cardMemberships: list[CardMembership]
-    cardLabels: list[CardLabel]
-    taskLists: list[TaskList]
-    tasks: list[Task]
-    attachments: list[Attachment]
-    customFieldGroups: list[CustomFieldGroup]
-    customFields: list[CustomField]
-    customFieldValues: list[CustomFieldValue]
+    cardMemberships: list[sch.CardMembership]
+    cardLabels: list[sch.CardLabel]
+    taskLists: list[sch.TaskList]
+    tasks: list[sch.Task]
+    attachments: list[sch.Attachment]
+    customFieldGroups: list[sch.CustomFieldGroup]
+    customFields: list[sch.CustomField]
+    customFieldValues: list[sch.CustomFieldValue]
+
 
 class Response_readCardNotifications(TypedDict):
     """Notifications marked as read successfully"""
-    item: Card
+    item: sch.Card
     included: Included_readCardNotifications
 
+
 class Included_readCardNotifications(TypedDict):
-    notifications: list[Notification]
+    notifications: list[sch.Notification]
+
 
 class Response_createComment(TypedDict):
     """Comment created successfully"""
-    item: Comment
+    item: sch.Comment
+
 
 class Response_getComments(TypedDict):
     """Comments retrieved successfully"""
-    items: list[Comment]
+    items: list[sch.Comment]
     included: Included_getComments
 
+
 class Included_getComments(TypedDict):
-    users: list[User]
+    users: list[sch.User]
+
 
 class Response_deleteComment(TypedDict):
     """Comment deleted successfully"""
-    item: Comment
+    item: sch.Comment
+
 
 class Response_updateComments(TypedDict):
     """Comment updated successfully"""
-    item: Comment
+    item: sch.Comment
+
 
 class Response_getConfig(TypedDict):
     """Configuration retrieved successfully"""
-    item: Config
+    item: sch.Config
+
 
 class Response_updateConfig(TypedDict):
     """Configuration updated successfully"""
-    item: Config
+    item: sch.Config
+
 
 class Response_testSmtpConfig(TypedDict):
     """Test email sent successfully"""
-    item: Config
+    item: sch.Config
+
 
 class Response_createBoardCustomFieldGroup(TypedDict):
     """Custom field group created successfully"""
-    item: CustomFieldGroup
+    item: sch.CustomFieldGroup
+
 
 class Response_createCardCustomFieldGroup(TypedDict):
     """Custom field group created successfully"""
-    item: CustomFieldGroup
+    item: sch.CustomFieldGroup
+
 
 class Response_deleteCustomFieldGroup(TypedDict):
     """Custom field group deleted successfully"""
-    item: CustomFieldGroup
+    item: sch.CustomFieldGroup
+
 
 class Response_getCustomFieldGroup(TypedDict):
     """Custom field group details retrieved successfully"""
-    item: CustomFieldGroup
+    item: sch.CustomFieldGroup
     included: Included_getCustomFieldGroup
 
+
 class Included_getCustomFieldGroup(TypedDict):
-    customFields: list[CustomField]
-    customFieldValues: list[CustomFieldValue]
+    customFields: list[sch.CustomField]
+    customFieldValues: list[sch.CustomFieldValue]
+
 
 class Response_updateCustomFieldGroup(TypedDict):
     """Custom field group updated successfully"""
-    item: CustomFieldGroup
+    item: sch.CustomFieldGroup
+
 
 class Response_updateCustomFieldValue(TypedDict):
     """Custom field value created or updated successfully"""
-    item: CustomFieldValue
+    item: sch.CustomFieldValue
+
 
 class Response_deleteCustomFieldValue(TypedDict):
     """Custom field value deleted successfully"""
-    item: CustomFieldValue
+    item: sch.CustomFieldValue
+
 
 class Response_createCustomFieldInBaseGroup(TypedDict):
     """Custom field created successfully"""
-    item: CustomField
+    item: sch.CustomField
+
 
 class Response_createCustomFieldInGroup(TypedDict):
     """Custom field created successfully"""
-    item: CustomField
+    item: sch.CustomField
+
 
 class Response_deleteCustomField(TypedDict):
     """Custom field deleted successfully"""
-    item: CustomField
+    item: sch.CustomField
+
 
 class Response_updateCustomField(TypedDict):
     """Custom field updated successfully"""
-    item: CustomField
+    item: sch.CustomField
+
 
 class Response_createLabel(TypedDict):
     """Label created successfully"""
-    item: Label
+    item: sch.Label
+
 
 class Response_deleteLabel(TypedDict):
     """Label deleted successfully"""
-    item: Label
+    item: sch.Label
+
 
 class Response_updateLabel(TypedDict):
     """Label updated successfully"""
-    item: Label
+    item: sch.Label
+
 
 class Response_clearList(TypedDict):
     """List cleared successfully"""
-    item: List
+    item: sch.List
+
 
 class Response_createList(TypedDict):
     """List created successfully"""
-    item: List
+    item: sch.List
+
 
 class Response_deleteList(TypedDict):
     """List deleted successfully"""
-    item: List
+    item: sch.List
     included: Included_deleteList
 
+
 class Included_deleteList(TypedDict):
-    cards: list[Card]
+    cards: list[sch.Card]
+
 
 class Response_getList(TypedDict):
     """List details retrieved successfully"""
-    item: List
+    item: sch.List
     included: Included_getList
 
+
 class Included_getList(TypedDict):
-    users: list[User]
+    users: list[sch.User]
     cards: list[Included_getList_all]
     """Related cards"""
-    cardMemberships: list[CardMembership]
-    cardLabels: list[CardLabel]
-    taskLists: list[TaskList]
-    tasks: list[Task]
-    attachments: list[Attachment]
-    customFieldGroups: list[CustomFieldGroup]
-    customFields: list[CustomField]
-    customFieldValues: list[CustomFieldValue]
+    cardMemberships: list[sch.CardMembership]
+    cardLabels: list[sch.CardLabel]
+    taskLists: list[sch.TaskList]
+    tasks: list[sch.Task]
+    attachments: list[sch.Attachment]
+    customFieldGroups: list[sch.CustomFieldGroup]
+    customFields: list[sch.CustomField]
+    customFieldValues: list[sch.CustomFieldValue]
 
-class Included_getList_all(Card):
+
+class Included_getList_all(sch.Card):
     isSubscribed: NotRequired[bool]
     """Whether the current user is subscribed to the card"""
 
+
 class Response_updateList(TypedDict):
     """List updated successfully"""
-    item: List
+    item: sch.List
+
 
 class Response_moveListCards(TypedDict):
     """Cards moved successfully"""
-    item: List
+    item: sch.List
     included: Included_moveListCards
 
+
 class Included_moveListCards(TypedDict):
-    cards: list[Card]
-    actions: list[Action]
+    cards: list[sch.Card]
+    actions: list[sch.Action]
+
 
 class Response_sortList(TypedDict):
     """List sorted successfully"""
-    item: List
+    item: sch.List
     included: Included_sortList
 
+
 class Included_sortList(TypedDict):
-    cards: list[Card]
+    cards: list[sch.Card]
+
 
 class Response_createBoardNotificationService(TypedDict):
     """Notification service created successfully"""
-    item: NotificationService
+    item: sch.NotificationService
+
 
 class Response_createUserNotificationService(TypedDict):
     """Notification service created successfully"""
-    item: NotificationService
+    item: sch.NotificationService
+
 
 class Response_deleteNotificationService(TypedDict):
     """Notification service deleted successfully"""
-    item: NotificationService
+    item: sch.NotificationService
+
 
 class Response_updateNotificationService(TypedDict):
     """Notification service updated successfully"""
-    item: NotificationService
+    item: sch.NotificationService
+
 
 class Response_testNotificationService(TypedDict):
     """Test notification sent successfully"""
-    item: NotificationService
+    item: sch.NotificationService
+
 
 class Response_getNotifications(TypedDict):
     """Notifications retrieved successfully"""
-    items: list[Notification]
+    items: list[sch.Notification]
     included: Included_getNotifications
 
+
 class Included_getNotifications(TypedDict):
-    users: list[User]
+    users: list[sch.User]
+
 
 class Response_readAllNotifications(TypedDict):
     """Notifications marked as read successfully"""
-    items: list[Notification]
+    items: list[sch.Notification]
+
 
 class Response_getNotification(TypedDict):
     """Notification details retrieved successfully"""
-    item: Notification
+    item: sch.Notification
     included: Included_getNotification
 
+
 class Included_getNotification(TypedDict):
-    users: list[User]
+    users: list[sch.User]
+
 
 class Response_updateNotification(TypedDict):
     """Notification updated successfully"""
-    item: Notification
+    item: sch.Notification
+
 
 class Response_createProjectManager(TypedDict):
     """Project manager created successfully"""
-    item: ProjectManager
+    item: sch.ProjectManager
+
 
 class Response_deleteProjectManager(TypedDict):
     """Project manager deleted successfully"""
-    item: ProjectManager
+    item: sch.ProjectManager
+
 
 class Response_createProject(TypedDict):
     """Project created successfully"""
-    item: Project
+    item: sch.Project
     included: Included_createProject
 
+
 class Included_createProject(TypedDict):
-    projectManagers: list[ProjectManager]
+    projectManagers: list[sch.ProjectManager]
+
 
 class Response_getProjects(TypedDict):
     """Projects retrieved successfully"""
     items: list[Items_getProjects]
     included: Included_getProjects
 
-class Included_getProjects(TypedDict):
-    users: list[User]
-    projectManagers: list[ProjectManager]
-    backgroundImages: list[BackgroundImage]
-    baseCustomFieldGroups: list[BaseCustomFieldGroup]
-    boards: list[Board]
-    boardMemberships: list[BoardMembership]
-    customFields: list[CustomField]
-    notificationServices: list[NotificationService]
 
-class Items_getProjects(Project):
+class Included_getProjects(TypedDict):
+    users: list[sch.User]
+    projectManagers: list[sch.ProjectManager]
+    backgroundImages: list[sch.BackgroundImage]
+    baseCustomFieldGroups: list[sch.BaseCustomFieldGroup]
+    boards: list[sch.Board]
+    boardMemberships: list[sch.BoardMembership]
+    customFields: list[sch.CustomField]
+    notificationServices: list[sch.NotificationService]
+
+
+class Items_getProjects(sch.Project):
     isFavorite: NotRequired[bool]
     """Whether the project is marked as favorite by the current user"""
 
+
 class Response_deleteProject(TypedDict):
     """Project deleted successfully"""
-    item: Project
+    item: sch.Project
+
 
 class Response_getProject(TypedDict):
     """Project details retrieved successfully"""
     item: Item_getProject
     included: Included_getProject
 
-class Included_getProject(TypedDict):
-    users: list[User]
-    projectManagers: list[ProjectManager]
-    backgroundImages: list[BackgroundImage]
-    baseCustomFieldGroups: list[BaseCustomFieldGroup]
-    boards: list[Board]
-    boardMemberships: list[BoardMembership]
-    customFields: list[CustomField]
-    notificationServices: list[NotificationService]
 
-class Item_getProject(Project):
+class Included_getProject(TypedDict):
+    users: list[sch.User]
+    projectManagers: list[sch.ProjectManager]
+    backgroundImages: list[sch.BackgroundImage]
+    baseCustomFieldGroups: list[sch.BaseCustomFieldGroup]
+    boards: list[sch.Board]
+    boardMemberships: list[sch.BoardMembership]
+    customFields: list[sch.CustomField]
+    notificationServices: list[sch.NotificationService]
+
+
+class Item_getProject(sch.Project):
     isFavorite: NotRequired[bool]
     """Whether the project is marked as favorite by the current user"""
 
+
 class Response_updateProject(TypedDict):
     """Project updated successfully"""
-    item: Project
+    item: sch.Project
+
 
 class Response_createTaskList(TypedDict):
     """Task list created successfully"""
-    item: TaskList
+    item: sch.TaskList
+
 
 class Response_deleteTaskList(TypedDict):
     """Task list deleted successfully"""
-    item: TaskList
+    item: sch.TaskList
+
 
 class Response_getTaskList(TypedDict):
     """Task list details retrieved successfully"""
-    item: TaskList
+    item: sch.TaskList
     included: Included_getTaskList
 
+
 class Included_getTaskList(TypedDict):
-    tasks: list[Task]
+    tasks: list[sch.Task]
+
 
 class Response_updateTaskList(TypedDict):
     """Task list updated successfully"""
-    item: TaskList
+    item: sch.TaskList
+
 
 class Response_createTask(TypedDict):
     """Task created successfully"""
-    item: Task
+    item: sch.Task
+
 
 class Response_deleteTask(TypedDict):
     """Task deleted successfully"""
-    item: Task
+    item: sch.Task
+
 
 class Response_updateTask(TypedDict):
     """Task updated successfully"""
-    item: Task
+    item: sch.Task
+
 
 class Response_getTerms(TypedDict):
     """Terms content retrieved successfully"""
     item: Item_getTerms
+
 
 class Item_getTerms(TypedDict):
     language: str
     content: str
     signature: str
 
+
 class Response_createUserApiKey(TypedDict):
     """API key created successfully"""
-    item: User
+    item: sch.User
     included: Included_createUserApiKey
+
 
 class Included_createUserApiKey(TypedDict):
     apiKey: str
 
+
 class Response_createUser(TypedDict):
     """User created successfully"""
-    item: User
+    item: sch.User
+
 
 class Response_getUsers(TypedDict):
     """Users retrieved successfully"""
-    items: list[User]
+    items: list[sch.User]
+
 
 class Response_deleteUser(TypedDict):
     """User deleted successfully"""
-    item: User
+    item: sch.User
+
 
 class Response_getUser(TypedDict):
     """User details retrieved successfully"""
-    item: User
+    item: sch.User
     included: Included_getUser
 
+
 class Included_getUser(TypedDict):
-    notificationServices: list[NotificationService]
+    notificationServices: list[sch.NotificationService]
+
 
 class Response_updateUser(TypedDict):
     """User updated successfully"""
-    item: User
+    item: sch.User
+
 
 class Response_updateUserAvatar(TypedDict):
     """Avatar updated successfully"""
-    item: User
+    item: sch.User
+
 
 class Response_updateUserEmail(TypedDict):
     """Email updated successfully"""
-    item: User
+    item: sch.User
+
 
 class Response_updateUserPassword(TypedDict):
     """Password updated successfully"""
-    item: User
+    item: sch.User
     included: Included_updateUserPassword
+
 
 class Included_updateUserPassword(TypedDict):
     accessToken: str
 
+
 class Response_updateUserUsername(TypedDict):
     """Username updated successfully"""
-    item: User
+    item: sch.User
+
 
 class Response_createWebhook(TypedDict):
     """Webhook created successfully"""
-    item: Webhook
+    item: sch.Webhook
+
 
 class Response_getWebhooks(TypedDict):
     """Webhooks retrieved successfully"""
-    items: list[Webhook]
+    items: list[sch.Webhook]
+
 
 class Response_deleteWebhook(TypedDict):
     """Webhook deleted successfully"""
-    item: Webhook
+    item: sch.Webhook
+
 
 class Response_updateWebhook(TypedDict):
     """Webhook updated successfully"""
-    item: Webhook
-
+    item: sch.Webhook

--- a/src/plankapy/v2/dispatcher.py
+++ b/src/plankapy/v2/dispatcher.py
@@ -1,10 +1,12 @@
 # TODO: A Server class that can be bound to a webhook and dispatch functions
 
+import datetime as dt
 from collections.abc import Callable
 from datetime import datetime
 from typing import Any
-from .interface import Planka
+
 from .api.events import PlankaEvent, PlankaEvents
+from .interface import Planka
 
 EventHandler = Callable[[Planka, Any], Any]
 """Type Signature for an Event Handler
@@ -22,50 +24,56 @@ EventHandlerMap = dict[PlankaEvent | tuple[PlankaEvent, ...], list[EventHandler]
 Keys can be a single event or a tuple of events, values are a list of handlers to be called on that event
 """
 
+
 def print_card_deleted(planka: Planka, hook_response: Any):
     print(f'{planka.me.name} says: Card Deleted: {hook_response}')
+
 
 def print_card_created(planka: Planka, hook_response: Any):
     print(f'{planka.me.name} says: Card Created: {hook_response}')
 
+
 def print_card_updated(planka: Planka, hook_response: Any):
     print(f'{planka.me.name} says: Card Updated: {hook_response}')
 
+
 def print_hello_world(planka: Planka, hook_response: Any):
-    print(f'Something happened! Hello World! We\'re doing it again!')
+    print('Something happened! Hello World! We\'re doing it again!')
+
 
 DEFAULT_HANDLERS: EventHandlerMap = {
     'cardCreate': [print_card_created],
     'cardUpdate': [print_card_updated],
     'cardDelete': [print_card_deleted],
     ('cardCreate', 'cardUpdate', 'cardDelete'): [
-        print_hello_world, 
-        print_card_created, 
-        print_card_updated, 
+        print_hello_world,
+        print_card_created,
+        print_card_updated,
         print_card_deleted
     ],
 }
 
+
 class EventDispatcher:
-    """A simple server that creates or binds to an existing webhook and dispatches 
-    automation scripts when pinged
+    """A simple server that creates or binds to an existing webhook and dispatches
+     automation scripts when pinged
     """
 
     __events__ = PlankaEvents
 
     def __init__(self, name: str, url: str,
-                 *, 
-                 planka: Planka, 
-                 handlers: EventHandlerMap=DEFAULT_HANDLERS):
+                 *,
+                 planka: Planka,
+                 handlers: EventHandlerMap = DEFAULT_HANDLERS):
         self.handlers = handlers
         self.url = url
         self.planka = planka
 
     async def run(self):
         """Run the dispatcher (should be in an event loop)"""
-        rcvd_event = str()
-        rcvd_data: dict[str, Any] = dict()
+        rcvd_event = ''
+        rcvd_data = dict[str, Any]()
 
         for event, handlers in self.handlers.items():
             if (isinstance(event, tuple) and rcvd_event in event) or (rcvd_event == event):
-                yield (event, {h.__name__: h(self.planka, rcvd_data) for h in handlers}, datetime.now())
+                yield (event, {h.__name__: h(self.planka, rcvd_data) for h in handlers}, datetime.now(tz=dt.UTC))

--- a/src/plankapy/v2/interface.py
+++ b/src/plankapy/v2/interface.py
@@ -1,9 +1,9 @@
 """
 Base interface for Planka
 
-When reading the documentation, all returned `list[PlankaModel]` types are 
-actually `models.ModelLists` at runtime. These will also be properly type hinted by 
-your static type checker and expose some alternate ways of indexing into model lists:
+When reading the documentation, all returned `list[PlankaModel]` types are
+ actually `models.ModelLists` at runtime. These will also be properly type hinted by
+ your static type checker and expose some alternate ways of indexing into model lists:
 
 Example:
 ```python
@@ -23,11 +23,11 @@ ModelList
 [<previous results>..., Project('Another Project I Own', ...)]
 ```
 
-All dictionary based schema filtering can be done per key and the model will only 
-be included in the output if all filters match.
+All dictionary based schema filtering can be done per key and the model will only
+ be included in the output if all filters match.
 
-Additionally, a `dpop` method is included that allows popping from a model list with 
-a default value if no results
+Additionally, a `dpop` method is included that allows popping from a model list with
+ a default value if no results
 ```python
 >>> filtered = to_do_list.cards[lambda c: c.due_date and (c.due_date - datetime.now()).days < 4]
 >>> if next_card := filtered.dpop():
@@ -43,31 +43,39 @@ No results
 """
 
 from __future__ import annotations
-from functools import cached_property
-from collections.abc import Sequence
-from datetime import timezone
-from typing import Unpack
-
-from httpx import Client, HTTPStatusError, URL
-
-from .api import (
-    PlankaEndpoints, 
-    events,
-    typ,
-)
-from .models import *
-from .models._helpers import model_list
-from .models._literals import Language, UserRole, ProjectType
 
 # Allow Users to set `PLANKA_LANG` environment variable with their language
 # Default to en-US if not set
 import os
+from collections.abc import Sequence
+from datetime import UTC, timezone
+from functools import cached_property
+from typing import Unpack
+
+from httpx import URL, Client, HTTPStatusError
+
+from .api import (
+    PlankaEndpoints,
+    events,
+    typ,
+)
+from .models import (
+    Config,
+    Notification,
+    Project,
+    User,
+    Webhook,
+)
+from .models._helpers import model_list
+from .models._literals import Language, ProjectType, UserRole
+
 DEFAULT_LANG = os.environ.get('PLANKA_LANG', 'en-US')
 del os
 
+
 class Planka:
     """Root object for connecting to a Planka instance
-    
+
     A Planka instance can be initialized using a `base_url` or a `httpx.Client` objcet.
     If both arguments are passed, the `base_url` of the passed client will be overriden with
     the url passed to the `base_url` argument
@@ -89,12 +97,12 @@ class Planka:
         ... planka.client.event_hooks
         {'request': [<hook1>, <hook2>], 'response': [<hook3>, <hook4>]}
         ```
-    
-    All Planka sessions will respect the configuration of the passed client object. For more configuration 
-    options, see the httpx docs: https://www.python-httpx.org/advanced/clients/
 
-    After initializing, the Planka instance required the authorization flow to 
-    take place using the `login` method
+    All Planka sessions will respect the configuration of the passed client object. For more configuration
+     options, see the httpx docs: https://www.python-httpx.org/advanced/clients/
+
+    After initializing, the Planka instance required the authorization flow to
+     take place using the `login` method
 
     Example:
         ```python
@@ -113,15 +121,15 @@ class Planka:
         [Project(...), Project(...), ...]
         ```
 
-    Logging in with a username and password will work, but it's best practice to authenticate 
-    using an api key, which you can get from your instance administrator.
+    Logging in with a username and password will work, but it's best practice to authenticate
+     using an api key, which you can get from your instance administrator.
     """
 
-    def __init__(self, 
-                 base_url: str|URL|None=None, 
-                 *, 
-                 client: Client|None=None, 
-                 timezone: timezone = timezone.utc) -> None:
+    def __init__(self,
+                 base_url: str | URL | None = None,
+                 *,
+                 client: Client | None = None,
+                 timezone: timezone = UTC) -> None:
         """
         Args:
             base_url: The base url of the instance (e.g. `https://planka.app`)
@@ -136,7 +144,7 @@ class Planka:
         elif client and base_url is None:
             if not client.base_url:
                 raise ValueError(
-                    f'If using a client, the client\'s base_url attribute must be set '
+                    'If using a client, the client\'s base_url attribute must be set '
                     'or a base_url must be passed to the Planka initializer'
                 )
             self.client = client
@@ -144,15 +152,15 @@ class Planka:
             self.client = client
             self.client.base_url = base_url
         else:
-            raise ValueError(f'base_url and/or client must be passed')
-        
+            raise ValueError('base_url and/or client must be passed')
+
         self.endpoints = PlankaEndpoints(self.client)
         self.timezone = timezone
-        
+
         # Assigned after login() is called
         self.current_role: UserRole | None = None
-        self.current_id : str | None = None
-    
+        self.current_id: str | None = None
+
     def accept_terms(self, pending_token: str, lang: Language | None = None):
         """If the User has never logged on, or is required to accept new terms, allow them to do so"""
         if lang:
@@ -162,31 +170,31 @@ class Planka:
         print(terms['content'])
         sig = terms['signature']
         self.endpoints.acceptTerms(pendingToken=pending_token, signature=sig)
-    
-    def login(self, 
-              *, 
-              username: str | None = None, 
-              password: str | None = None, 
-              api_key: str | None = None, 
+
+    def login(self,
+              *,
+              username: str | None = None,
+              password: str | None = None,
+              api_key: str | None = None,
               accept_terms: bool | None = None,
               terms_lang: Language | None = None) -> None:
-        
+
         """Authenticate with the planka instance
-        
+
         Args:
-            username: User username/email 
+            username: User username/email
             password: User password
             api_key: User API Key
             accept_terms: Set to `True` to accept terms on first login
             terms_lang: If accepting terms, request them in this language
-            
+
         Note:
             After logging in for the first time, please get an API key from the Planka server.
         """
         # API Key
         if api_key:
             self.client.headers['X-Api-Key'] = api_key
-        
+
         # User/Pass with term acceptance flow
         elif username and password:
             try:
@@ -195,21 +203,21 @@ class Planka:
                 self.client.headers['Authorization'] = f'Bearer {token}'
             except HTTPStatusError as e:
                 if not accept_terms:
-                    raise PermissionError(f'Please logon again with `accept_terms` set to `True` to login the first time')
+                    raise PermissionError('Please logon again with `accept_terms` set to `True` to login the first time') from e
                 self.accept_terms(e.response.json()['pendingToken'], lang=terms_lang)
                 self.login(username=username, password=password)
-        
+
         # Invalid Creds
         else:
-            raise PermissionError(f'No credentials supplied! Must provide a user/password or an api_key')
-            
+            raise PermissionError('No credentials supplied! Must provide a user/password or an api_key')
+
         self.current_role = self.me.role
         self.current_id = self.me.id
-    
+
     def logout(self) -> None:
         """Logout the current User"""
         self.endpoints.deleteAccessToken()
-    
+
     @cached_property
     def me(self) -> User:
         """Get the User object for the currently logged in user"""
@@ -236,15 +244,15 @@ class Planka:
     def config(self) -> Config:
         """(*deprecated: Use `Planka.bootstrap` instead*) Get the configuration info for the current Planka server"""
         return self.bootstrap
-    
+
     @property
-    def smtp_config(self): 
+    def smtp_config(self):
         """Get the server SMTP config (this also tests the current config)"""
         return self.endpoints.testSmtpConfig()['item']
 
     def update_smtp_config(self, **opts: Unpack[typ.Request_updateConfig]):
         """Update the server SMTP config (all args are optional and only passed args will be updated)
-        
+
         Args:
             smtpHost: Hostname or IP address of the SMTP server
             smtpPort: Port number of the SMTP server
@@ -262,7 +270,7 @@ class Planka:
     def webhooks(self) -> list[Webhook]:
         """Get all configured Webhooks (requires admin)"""
         return [
-            Webhook(w, self) 
+            Webhook(w, self)
             for w in self.endpoints.getWebhooks()['items']
             if self.me.role == 'admin'
         ]
@@ -271,7 +279,7 @@ class Planka:
     @model_list
     def projects(self) -> list[Project]:
         """Get all Projects available to the current user
-        
+
         Note:
             admins will get all instance Projects
             projectOwners will get all owned projects and shared projects
@@ -283,32 +291,32 @@ class Planka:
     @model_list
     def users(self) -> list[User]:
         """Get all Users on the current instance (requires admin or projectOwner role)
-        
+
         Note:
             projectOwners will only get Users in their Projects
             admins will get all instance Users
-            all others will get an empty list 
+            all others will get an empty list
         """
         return [
-            User(u, self) 
+            User(u, self)
             for u in self.endpoints.getUsers()['items']
             if self.current_role in ('admin', 'projectOwner')
         ]
-    
+
     @model_list
     def read_notifications(self) -> list[Notification]:
         """Read all Notifications for the current User"""
         return [Notification(n, self) for n in self.endpoints.readAllNotifications()['items']]
-    
-    def create_project(self, 
+
+    def create_project(self,
                        *,
                        name: str,
                        type: ProjectType,
-                       description: str|None=None) -> Project:
+                       description: str | None = None) -> Project:
         """Creates a project. The current user automatically becomes a project manager.
 
         Must be a Project Owner or an Admin
-        
+
         Args:
             type: Type of the project
             name: Name/title of the project
@@ -316,26 +324,26 @@ class Planka:
         """
         return Project(
             self.endpoints.createProject(
-                name=name, 
-                type=type, 
+                name=name,
+                type=type,
                 description=description,
-            )['item'], 
+            )['item'],
             self
         )
-    
-    def create_user(self, 
+
+    def create_user(self,
                     *,
                     email: str,
                     password: str,
                     role: UserRole,
                     name: str,
-                    username: str|None=None,
-                    phone: str|None=None,
-                    organization: str|None=None,
-                    language: Language|None=None,
-                    subscribe_to_own_cards: bool=False,
-                    subscribe_to_cards_when_commenting: bool=True,
-                    turn_off_recent_card_highlighting: bool=False) -> User:
+                    username: str | None = None,
+                    phone: str | None = None,
+                    organization: str | None = None,
+                    language: Language | None = None,
+                    subscribe_to_own_cards: bool = False,
+                    subscribe_to_cards_when_commenting: bool = True,
+                    turn_off_recent_card_highlighting: bool = False) -> User:
         """Creates a user account. Requires admin privileges.
 
         Only `email`, `password`, `role`, and `name` are required
@@ -367,19 +375,19 @@ class Planka:
                 subscribeToOwnCards=subscribe_to_own_cards,
                 subscribeToCardWhenCommenting=subscribe_to_cards_when_commenting,
                 turnOffRecentCardHighlighting=turn_off_recent_card_highlighting,
-            )['item'], 
+            )['item'],
             self
         )
 
-    def create_webhook(self, 
+    def create_webhook(self,
                        *,
                        name: str,
                        url: str,
-                       access_token: str|None=None,
-                       events: Sequence[events.PlankaEvent]|None=None,
-                       excluded_events: Sequence[events.PlankaEvent]|None=None) -> Webhook:
+                       access_token: str | None = None,
+                       events: Sequence[events.PlankaEvent] | None = None,
+                       excluded_events: Sequence[events.PlankaEvent] | None = None) -> Webhook:
         """Create a Webhook. Requires admin
-        
+
         Args:
             name: Name/title of the webhook
             url: URL endpoint for the webhook
@@ -398,5 +406,3 @@ class Planka:
         if access_token:
             args['accessToken'] = access_token
         return Webhook(self.endpoints.createWebhook(**args)['item'], self)
-        
-        

--- a/src/plankapy/v2/models/__init__.py
+++ b/src/plankapy/v2/models/__init__.py
@@ -1,7 +1,6 @@
 """All Object Models for Plankapy v2.5+ (Planka 2.0.0+)"""
 
-__all__ = (
-    "PlankaModel",
+__all__ = [
     "Action",
     "Attachment",
     "BackgroundImage",
@@ -20,59 +19,63 @@ __all__ = (
     "List",
     "Notification",
     "NotificationService",
+    "PlankaModel",
     "Project",
     "ProjectManager",
+    "Stopwatch",
     "Task",
     "TaskList",
     "User",
     "Webhook",
-    "Stopwatch",
-    
-    # Literal tuples
-    "BoardViews",
-    "CardTypes",
-    "BoardRoles",
-    "LabelColors",
-    "ListColors",
-    "BackgroundGradients",
-    "Languages",
-    "EditorModes",
-    "HomeViews",
-    "ProjectOrderings",
-    "TermsTypes",
-    "LockableFields",
-    "NotificationTypes",
-    "UserRoles",
+]
+
+__all__.extend(
+    [
+        "BackgroundGradients",
+        "BoardRoles",
+        "BoardViews",
+        "CardTypes",
+        "EditorModes",
+        "HomeViews",
+        "LabelColors",
+        "Languages",
+        "ListColors",
+        "LockableFields",
+        "NotificationTypes",
+        "ProjectOrderings",
+        "TermsTypes",
+        "UserRoles",
+    ]
 )
 
 from ._base import PlankaModel
+from ._literals import *
 from .action import Action
 from .attachment import Attachment
 from .background_image import BackgroundImage
 from .base_custom_field_group import BaseCustomFieldGroup
-from .board_membership import BoardMembership
 from .board import Board
+from .board_membership import BoardMembership
+from .card import Card, Stopwatch
 from .card_label import CardLabel
 from .card_membership import CardMembership
-from .card import Card, Stopwatch
 from .comment import Comment
 from .config import Config
+from .custom_field import CustomField
 from .custom_field_group import CustomFieldGroup
 from .custom_field_value import CustomFieldValue
-from .custom_field import CustomField
 from .label import Label
 from .list_ import List
-from .notification_service import NotificationService
 from .notification import Notification
-from .project_manager import ProjectManager
+from .notification_service import NotificationService
 from .project import Project
-from .task_list import TaskList
+from .project_manager import ProjectManager
 from .task import Task
+from .task_list import TaskList
 from .user import User
 from .webhook import Webhook
-from ._literals import *
 
-############################ Model Format #####################################
+# Model Format #####################################
 # 1) add_*: For creating an association between a model and another model     #
 #   - Card.add_label(label: Label): ...                                       #
 #                                                                             #
@@ -89,7 +92,7 @@ from ._literals import *
 #   - board.delete_label(label)                                               #
 #                                                                             #
 # 6) sync, update, delete: If possible allow GET, PATCH, DELETE passthroughs  #
-#   - If sync required more than 2 requests, don't implement it               # 
+#   - If sync required more than 2 requests, don't implement it               #
 #                                                                             #
 # 7) @property: All attributes and includes that require 1 request            #
 #   - board.labels (in board['included'])                                     #
@@ -115,4 +118,3 @@ from ._literals import *
 #   - If your operation is slow, do not cache to prevent de-syncing           #
 #       - Slow is ~1-2s We want to capture accurate board states              #
 ###############################################################################
-

--- a/src/plankapy/v2/models/_base.py
+++ b/src/plankapy/v2/models/_base.py
@@ -1,29 +1,31 @@
 from __future__ import annotations
 
-__all__ = ("PlankaModel", )
-
-import json
 import copy
-
+import json
+from collections.abc import Callable, Mapping
 from typing import Any, Self
-from collections.abc import Mapping, Callable
 
 TYPE_CHECKING = False
 if TYPE_CHECKING:
     # Models take a Planka session to allow checking User permissions
     from ..interface import Planka
 
+
+__all__ = ("PlankaModel", )
+
+
 type Diff = dict[str, tuple[Any, Any]]
 type ModelFormatter[M: PlankaModel[Any]] = Callable[[M], str]
 
-DEFAULT_FORMATTER: ModelFormatter[PlankaModel[Any]] = (
-    lambda m: f"{m.__class__.__name__}({getattr(m, 'name', getattr(m, 'id', 'Unknown'))})"
-)
-"""Default Model Formatter: `Model(name/id/'Unknown')`"""
+
+def DEFAULT_FORMATTER(m: PlankaModel[Any]) -> str:
+    """Default Model Formatter: `Model(name/id/'Unknown')`"""
+    return (f"{m.__class__.__name__}({getattr(m, 'name', getattr(m, 'id', 'Unknown'))})")
+
 
 class PlankaModel[Schema: Mapping[str, Any]]:
     """Base Planka object interface"""
-    
+
     __formatter__: ModelFormatter[Self] = DEFAULT_FORMATTER
     """Formatter func that allows overriding __str__ behavior for models"""
 
@@ -34,33 +36,34 @@ class PlankaModel[Schema: Mapping[str, Any]]:
         self.client = session.client
         self.current_role = session.current_role
         self.current_id = session.current_id
-    
+
     @property
     def schema(self) -> Schema:
         return self._schema
+
     @schema.setter
     def schema(self, schema: Schema) -> None:
         self._schema = schema
-    
+
     @property
     def id(self) -> str:
         if 'id' not in self.schema:
             # Should only happen for schemas.Config
             raise AttributeError(f'{self.__class__.__name__}: Does not have an `id` attribute')
         return self.schema['id']
-    
+
     def __eq__(self, other: object) -> bool:
         if isinstance(other, PlankaModel):
             try:
                 return (
-                    self.id == other.id 
-                    and self.__class__ == other.__class__ # type: ignore
+                    self.id == other.id
+                    and self.__class__ == other.__class__  # type: ignore
                 )
-            except AttributeError: # handle no id case (Config)
+            except AttributeError:  # handle no id case (Config)
                 return False
         else:
             return super().__eq__(other)
-    
+
     def __hash__(self) -> int:
         if 'id' not in self.schema:
             raise AttributeError(f'{self.__class__.__name__} does not have a hashable id attribute')
@@ -73,19 +76,19 @@ class PlankaModel[Schema: Mapping[str, Any]]:
     def __setitem__(self, key: Any, val: Any) -> Any:
         # Don't allow writes to the cached values
         raise TypeError(
-            f'Model attributes are read only. '
+            'Model attributes are read only. '
             'To update use associated property'
         )
-    
+
     def copy(self) -> Self:
         """Create a deepcopy of the model and its associated schema.
 
         Note:
-            Since the endpoints for both instances of the Model are the same, any 
-            calls to update will restore the state and bring both copies into sync. 
-            copies like this are meant more for comparing changes when running a sync 
-            or update/assignemnt operation.
-        
+            Since the endpoints for both instances of the Model are the same, any
+             calls to update will restore the state and bring both copies into sync.
+             copies like this are meant more for comparing changes when running a sync
+             or update/assignemnt operation.
+
         Example:
         ```python
             >>> card_copy = card.copy()
@@ -105,14 +108,14 @@ class PlankaModel[Schema: Mapping[str, Any]]:
         """Get a schema diff between two model schemas.
 
         Note:
-            Only matching keys are diffed. Any schema keys that are not in the source schema 
-            will not be checked in the target schema
+            Only matching keys are diffed. Any schema keys that are not in the source schema
+             will not be checked in the target schema
         """
         return {
-            k: (source, delta) 
+            k: (source, delta)
             for k, source in self.schema
             if k in other.schema
-            and (delta := other.schema[k]) 
+            and (delta := other.schema[k])
             and delta != source
         }
 
@@ -120,7 +123,7 @@ class PlankaModel[Schema: Mapping[str, Any]]:
         return self.__class__.__formatter__(self)
 
     def __repr__(self) -> str:
-        return f'{self.__class__.__name__}({self.schema})'          
-    
+        return f'{self.__class__.__name__}({self.schema})'
+
     def json(self, **kwargs: Any) -> str:
         return json.dumps(self.schema, **kwargs)

--- a/src/plankapy/v2/models/_helpers.py
+++ b/src/plankapy/v2/models/_helpers.py
@@ -3,24 +3,23 @@ Helper objects for implemented model classes
 """
 from __future__ import annotations
 
-from datetime import datetime, timezone
-from collections.abc import Sequence, Callable, Mapping
+from collections.abc import Callable, Mapping, Sequence
+from datetime import UTC, datetime, timezone
 from functools import wraps
 from typing import (
-    Any, 
+    Any,
     Literal,
-    ParamSpec,
-    Protocol, 
+    Protocol,
     SupportsIndex,
-    TypeVar, 
     overload,
 )
 
 from ._base import PlankaModel
 
-__all__ = ('dtfromiso', 'get_position', 'Position')
+__all__ = ('Position', 'dtfromiso', 'get_position')
 
-def dtfromiso(iso: str, default_timezone: timezone=timezone.utc) -> datetime:
+
+def dtfromiso(iso: str, default_timezone: timezone = UTC) -> datetime:
     """Convert an ISO 8601 string to an offset aware datetime
 
     Args:
@@ -28,18 +27,18 @@ def dtfromiso(iso: str, default_timezone: timezone=timezone.utc) -> datetime:
         default_timezone (timezone): The timezone to interpret the ISO string in (default: timezone.utc)
 
     Note:
-        If the ISO 8601 timestamp contains tzinfo, that will be used. The `default_timezone` arg 
-        will only be used on ISO 8601 strings that don't contain timezone info 
+        If the ISO 8601 timestamp contains tzinfo, that will be used. The `default_timezone` arg
+         will only be used on ISO 8601 strings that don't contain timezone info.
     """
     dt = datetime.fromisoformat(iso)
     if not dt.tzinfo:
         return dt.replace(tzinfo=default_timezone)
     return dt
 
-def dttoiso(dt: datetime, default_timezone: timezone=timezone.utc) -> str:
-    """Convert an offset aware datetime to an ISO 8601 string. 
-    
-    timezone check is `dt.tzinfo` -> `default_timezone`
+
+def dttoiso(dt: datetime, default_timezone: timezone = UTC) -> str:
+    """Convert an offset aware datetime to an ISO 8601 string.
+     timezone check is `dt.tzinfo` -> `default_timezone`
 
     Args:
         dt (datetime): The datetime to convert
@@ -49,15 +48,19 @@ def dttoiso(dt: datetime, default_timezone: timezone=timezone.utc) -> str:
         dt = dt.replace(tzinfo=default_timezone)
     return str(dt)
 
+
 # Position Offset
 POSITION_GAP = 65536
 """Base position gap for all `positon` fields `(1 == POSITION_GAP*1, 2 == POSITON_GAP*2, ...)`"""
+
 
 class HasPosition(Protocol):
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         self.position: int
 
+
 Position = Literal['top', 'bottom'] | int
+
 
 def get_position(items: Sequence[HasPosition], position: Literal['top', 'bottom'] | int) -> int:
     """Get a top/bottom position"""
@@ -67,12 +70,13 @@ def get_position(items: Sequence[HasPosition], position: Literal['top', 'bottom'
         return 0
     return max((i.position for i in items), default=0) + POSITION_GAP
 
+
 def match[M: PlankaModel[Any]](item: M, pred: Callable[[M], bool] | M) -> bool:
     """Evaluate a Callable on the item if provided, else evaluate equality
-    
+
     Note:
-        predicate functions are not checked for validity, the value will be passed 
-        directly and exceptions will be raised if the predicate raises one
+        predicate functions are not checked for validity, the value will be passed
+         directly and exceptions will be raised if the predicate raises one
     """
     if isinstance(pred, Callable):
         return pred(item)
@@ -80,10 +84,11 @@ def match[M: PlankaModel[Any]](item: M, pred: Callable[[M], bool] | M) -> bool:
 
 
 # Type declarations for the filter indexing options available to a ModelList
-type FilterFunc[M, *P] = Callable[[M,*P], bool]
+type FilterFunc[M, *P] = Callable[[M, *P], bool]
 type KeyFilter[T, *P] = dict[str, Callable[[T, *P], bool]]
 type Id = str
 type ModelListIndexable[T, M] = SupportsIndex | slice | KeyFilter[T] | dict[str, Any] | Id | FilterFunc[M] | M
+
 
 class ModelList[M: PlankaModel[Mapping[str, Any]]](list[M]):
     @overload
@@ -126,20 +131,20 @@ class ModelList[M: PlankaModel[Mapping[str, Any]]](list[M]):
             case _:
                 raise ValueError(f'{type(key)} not supported for indexing')
 
-    def dpop[D](self, index: SupportsIndex=-1, *, default: D=None) -> M | D:
+    def dpop[D](self, index: SupportsIndex = -1, *, default: D = None) -> M | D:
         """pop but accept a `default` argument"""
         try:
             return super().pop(index)
         except IndexError:
             return default
-    
+
     @overload
     def extract(self, key: str, /) -> list[Any]: ...
     @overload
     def extract(self, *keys: str) -> list[tuple[Any, ...]]: ...
     def extract(self, *keys: str) -> list[tuple[Any, ...] | Any]:
         """Extract values from the items in the ModelList
-        
+
         Args:
             keys: The schema key to extract
         """
@@ -150,19 +155,17 @@ class ModelList[M: PlankaModel[Mapping[str, Any]]](list[M]):
     def ids(self) -> list[str]:
         """A list of model ids"""
         return [i.id for i in self]
-    
+
     def format(self, func: Callable[[M], str]) -> list[str]:
         """Apply a format function to all items in the ModelList
-        
+
         Args:
             func: A function that takes a model and returns a string
         """
         return [func(i) for i in self]
-    
 
-P = ParamSpec('P')
-T = TypeVar('T', bound=PlankaModel[Any])
-def model_list(func: Callable[P, list[T]]) -> Callable[P, ModelList[T]]:
+
+def model_list[**P, T: PlankaModel[Any]](func: Callable[P, list[T]]) -> Callable[P, ModelList[T]]:
     """Wrapper that turns a list property into a ModelList"""
     @wraps(func)
     def _wrapper(*args: Any, **kwargs: Any) -> ModelList[T]:

--- a/src/plankapy/v2/models/_literals.py
+++ b/src/plankapy/v2/models/_literals.py
@@ -1,39 +1,35 @@
 from typing import Literal, get_args
 
-__all__ =   (
-    
-    # Literal Types for hinting
-    "BoardView",
-    "CardType",
-    "BoardRole",
-    "LabelColor",
-    "ListColor",
+__all__ = (
     "BackgroundGradient",
-    "Language",
-    "EditorMode",
-    "HomeView",
-    "ProjectOrdering",
-    "ProjectType",
-    "TermsType",
-    "LockableField",
-    "NotificationType",
-    "UserRole",
-    
-    # String Tuples (for in/choice operations)
-    "BoardViews",
-    "CardTypes",
-    "BoardRoles",
-    "LabelColors",
-    "ListColors",
     "BackgroundGradients",
-    "Languages",
+    "BoardRole",
+    "BoardRoles",
+    "BoardView",
+    "BoardViews",
+    "CardType",
+    "CardTypes",
+    "EditorMode",
     "EditorModes",
+    "HomeView",
     "HomeViews",
-    "ProjectOrderings",
-    "ProjectTypes",
-    "TermsTypes",
+    "LabelColor",
+    "LabelColors",
+    "Language",
+    "Languages",
+    "ListColor",
+    "ListColors",
+    "LockableField",
     "LockableFields",
+    "NotificationType",
     "NotificationTypes",
+    "ProjectOrdering",
+    "ProjectOrderings",
+    "ProjectType",
+    "ProjectTypes",
+    "TermsType",
+    "TermsTypes",
+    "UserRole",
     "UserRoles",
 )
 
@@ -42,7 +38,7 @@ BoardViews: tuple[BoardView, ...] = get_args(BoardView)
 
 # Single element literals throw warnings on __args__ access
 BoardImportType = Literal['trello']
-BoardImportTypes: tuple[BoardImportType, ...] = BoardImportType # type: ignore
+BoardImportTypes: tuple[BoardImportType, ...] = BoardImportType  # type: ignore
 
 CardType = Literal['project', 'story']
 CardTypes: tuple[CardType, ...] = get_args(CardType)
@@ -51,22 +47,22 @@ BoardRole = Literal['editor', 'viewer']
 BoardRoles: tuple[BoardRole, ...] = get_args(BoardRole)
 
 LabelColor = Literal[
-    'muddy-grey', 'autumn-leafs', 'morning-sky', 'antique-blue', 
-    'egg-yellow', 'desert-sand', 'dark-granite', 'fresh-salad', 
-    'lagoon-blue', 'midnight-blue', 'light-orange', 'pumpkin-orange', 
-    'light-concrete', 'sunny-grass', 'navy-blue', 'lilac-eyes', 
-    'apricot-red', 'orange-peel', 'silver-glint', 'bright-moss', 
-    'deep-ocean', 'summer-sky', 'berry-red', 'light-cocoa', 'grey-stone', 
-    'tank-green', 'coral-green', 'sugar-plum', 'pink-tulip', 'shady-rust', 
-    'wet-rock', 'wet-moss', 'turquoise-sea', 'lavender-fields', 'piggy-red', 
-    'light-mud', 'gun-metal', 'modern-green', 'french-coast', 'sweet-lilac', 
+    'muddy-grey', 'autumn-leafs', 'morning-sky', 'antique-blue',
+    'egg-yellow', 'desert-sand', 'dark-granite', 'fresh-salad',
+    'lagoon-blue', 'midnight-blue', 'light-orange', 'pumpkin-orange',
+    'light-concrete', 'sunny-grass', 'navy-blue', 'lilac-eyes',
+    'apricot-red', 'orange-peel', 'silver-glint', 'bright-moss',
+    'deep-ocean', 'summer-sky', 'berry-red', 'light-cocoa', 'grey-stone',
+    'tank-green', 'coral-green', 'sugar-plum', 'pink-tulip', 'shady-rust',
+    'wet-rock', 'wet-moss', 'turquoise-sea', 'lavender-fields', 'piggy-red',
+    'light-mud', 'gun-metal', 'modern-green', 'french-coast', 'sweet-lilac',
     'red-burgundy', 'pirate-gold',
 ]
 LabelColors: tuple[LabelColor, ...] = get_args(LabelColor)
 
 ListColor = Literal[
-    'berry-red', 'pumpkin-orange', 'lagoon-blue', 'pink-tulip', 
-    'light-mud', 'orange-peel', 'bright-moss', 'antique-blue', 
+    'berry-red', 'pumpkin-orange', 'lagoon-blue', 'pink-tulip',
+    'light-mud', 'orange-peel', 'bright-moss', 'antique-blue',
     'dark-granite', 'turquoise-sea',
 ]
 ListColors: tuple[ListColor, ...] = get_args(ListColor)
@@ -90,21 +86,21 @@ BackgroundType = Literal['gradient', 'image']
 BackgroundTypes: tuple[BackgroundType, ...] = get_args(BackgroundType)
 
 BackgroundGradient = Literal[
-    'old-lime', 'ocean-dive', 'tzepesch-style', 'jungle-mesh', 
-    'strawberry-dust', 'purple-rose', 'sun-scream', 'warm-rust', 
-    'sky-change', 'green-eyes', 'blue-xchange', 'blood-orange', 
-    'sour-peel', 'green-ninja', 'algae-green', 'coral-reef', 
-    'steel-grey', 'heat-waves', 'velvet-lounge', 'purple-rain', 
-    'blue-steel', 'blueish-curve', 'prism-light', 'green-mist', 
+    'old-lime', 'ocean-dive', 'tzepesch-style', 'jungle-mesh',
+    'strawberry-dust', 'purple-rose', 'sun-scream', 'warm-rust',
+    'sky-change', 'green-eyes', 'blue-xchange', 'blood-orange',
+    'sour-peel', 'green-ninja', 'algae-green', 'coral-reef',
+    'steel-grey', 'heat-waves', 'velvet-lounge', 'purple-rain',
+    'blue-steel', 'blueish-curve', 'prism-light', 'green-mist',
     'red-curtain'
 ]
 BackgroundGradients = get_args(BackgroundGradient)
 
 Language = Literal[
-    'ar-YE', 'bg-BG', 'ca-ES', 'cs-CZ', 'da-DK', 'de-DE', 'el-GR', 'en-GB', 'en-US', 
-    'es-ES', 'et-EE', 'fa-IR', 'fi-FI', 'fr-FR', 'hu-HU', 'id-ID', 'it-IT', 
-    'ja-JP', 'ko-KR', 'nl-NL', 'pl-PL', 'pt-BR', 'pt-PT', 'ro-RO', 'ru-RU', 
-    'sk-SK', 'sr-Cyrl-RS', 'sr-Latn-RS', 'sv-SE', 'tr-TR', 'uk-UA', 'uz-UZ', 
+    'ar-YE', 'bg-BG', 'ca-ES', 'cs-CZ', 'da-DK', 'de-DE', 'el-GR', 'en-GB', 'en-US',
+    'es-ES', 'et-EE', 'fa-IR', 'fi-FI', 'fr-FR', 'hu-HU', 'id-ID', 'it-IT',
+    'ja-JP', 'ko-KR', 'nl-NL', 'pl-PL', 'pt-BR', 'pt-PT', 'ro-RO', 'ru-RU',
+    'sk-SK', 'sr-Cyrl-RS', 'sr-Latn-RS', 'sv-SE', 'tr-TR', 'uk-UA', 'uz-UZ',
     'vi-VN', 'zh-CN', 'zh-TW',
 ]
 Languages: tuple[Language, ...] = get_args(Language)

--- a/src/plankapy/v2/models/action.py
+++ b/src/plankapy/v2/models/action.py
@@ -1,17 +1,13 @@
 from __future__ import annotations
 
 from datetime import datetime
+from typing import Any
 
 from ..api import events, schemas
 from ._base import PlankaModel
 from ._helpers import dtfromiso
 
 # Deferred Model imports at bottom of file
-
-TYPE_CHECKING = False
-if TYPE_CHECKING:
-    from typing import Any
-    # from models import *
 
 __all__ = ('Action', )
 
@@ -44,9 +40,8 @@ class Action(PlankaModel[schemas.Action]):
     @property
     def user(self) -> User:
         """The User who performed the Action (Raise LookupError if User is not found in Board)"""
-        usrs = [u for u in self.card.board.users if self.schema['userId'] == u.id]
-        if usrs:
-            return usrs.pop()
+        if usr := self.card.board.users[{'id': self.schema['userId']}].dpop():
+            return usr
         raise LookupError(f"Cannot find User: {self.schema['userId']}")
 
     @property

--- a/src/plankapy/v2/models/action.py
+++ b/src/plankapy/v2/models/action.py
@@ -1,66 +1,65 @@
 from __future__ import annotations
 
-__all__ = ('Action', )
-
 from datetime import datetime
 
+from ..api import events, schemas
 from ._base import PlankaModel
 from ._helpers import dtfromiso
-from ..api import schemas, events
-
 
 # Deferred Model imports at bottom of file
 
 TYPE_CHECKING = False
 if TYPE_CHECKING:
     from typing import Any
-    #from models import *
+    # from models import *
+
+__all__ = ('Action', )
 
 
 class Action(PlankaModel[schemas.Action]):
     """Python interface for Planka Actions"""
-    
+
     __events__ = events.ActionEvents
 
     @property
     def created_at(self) -> datetime:
         """When the Action was created"""
         return dtfromiso(self.schema['createdAt'], self.session.timezone)
-    
+
     @property
     def updated_at(self) -> datetime:
         """When the Action was last updated"""
         return dtfromiso(self.schema['updatedAt'], self.session.timezone)
-    
+
     @property
     def card(self) -> Card:
         """The Card where the Action occurred"""
         return Card(self.endpoints.getCard(self.schema['cardId'])['item'], self.session)
-    
+
     @property
     def board(self) -> Board:
         """The Board where the Action occurred"""
         return Board(self.endpoints.getBoard(self.schema['boardId'])['item'], self.session)
-    
+
     @property
     def user(self) -> User:
         """The User who performed the Action (Raise LookupError if User is not found in Board)"""
-        _usrs = [u for u in self.card.board.users if self.schema['userId'] == u.id]
-        if _usrs:
-            return _usrs.pop()
+        usrs = [u for u in self.card.board.users if self.schema['userId'] == u.id]
+        if usrs:
+            return usrs.pop()
         raise LookupError(f"Cannot find User: {self.schema['userId']}")
-    
+
     @property
     def data(self) -> dict[str, Any]:
         """The specific data associated with the Action (type dependant)"""
         return self.schema['data']
-    
+
     @property
     def type(self):
         """The type of the Action"""
         return self.schema['type']
-    
 
-from .card import Card
+
 from .board import Board
+from .card import Card
 from .user import User

--- a/src/plankapy/v2/models/action.py
+++ b/src/plankapy/v2/models/action.py
@@ -54,6 +54,11 @@ class Action(PlankaModel[schemas.Action]):
         """The type of the Action"""
         return self.schema['type']
 
+    # Special Methods
+    def sync(self) -> None:
+        """Sync the Action with the Planka server"""
+        self.schema = self.card.actions[self].dpop(default=self).schema
+
 
 from .board import Board
 from .card import Card

--- a/src/plankapy/v2/models/attachment.py
+++ b/src/plankapy/v2/models/attachment.py
@@ -3,9 +3,10 @@ from __future__ import annotations
 __all__ = ('Attachment', )
 
 from datetime import datetime
+
+from ..api import events, schemas, typ
 from ._base import PlankaModel
 from ._helpers import dtfromiso
-from ..api import schemas, paths, events
 
 # Deferred Model imports at bottom of file
 
@@ -13,72 +14,73 @@ TYPE_CHECKING = False
 if TYPE_CHECKING:
     from collections.abc import Iterator
     from typing import Any, Unpack
-    #from models import *
+    # from models import *
 
 
 class Attachment(PlankaModel[schemas.Attachment]):
     """Python interface for Planka Attachments"""
-    
+
     __events__ = events.AttachmentEvents
 
     @property
     def name(self) -> str:
         """The name of the Attachment"""
         return self.schema['name']
+
     @name.setter
     def name(self, name: str) -> None:
         """Set the Attachment name"""
         self.update(name=name)
-    
+
     @property
     def created_at(self) -> datetime:
         """When the Attachment was created"""
         return dtfromiso(self.schema['createdAt'], self.session.timezone)
-    
+
     @property
     def updated_at(self) -> datetime:
         """When the Attachment was last updated"""
         return dtfromiso(self.schema['updatedAt'], self.session.timezone)
-    
+
     @property
     def card(self) -> Card:
         """The Card the Attachment belongs to"""
         return Card(self.endpoints.getCard(self.schema['cardId'])['item'], self.session)
-    
+
     @property
     def creator(self) -> User:
         """The User created the Attachment (Raises LookupError if User is not found in Board)"""
-        _usrs = [u for u in self.card.board.users if self.schema['creatorUserId'] == u.id]
-        if _usrs:
-            return _usrs.pop()
+        usrs = [u for u in self.card.board.users if self.schema['creatorUserId'] == u.id]
+        if usrs:
+            return usrs.pop()
         raise LookupError(f"Cannot find User: {self.schema['creatorUserId']}")
-    
+
     @property
     def data(self) -> dict[str, Any]:
         """The specific data associated with the action (type dependant)"""
         return self.schema['data']
-    
+
     @property
     def type(self):
         """The type of the action"""
         return self.schema['type']
-    
+
     # Special Methods
     def sync(self) -> None:
         """Pull the latest state of the Attachment from the Planka Server"""
         # No endpoint for attachments, need to get it through the associated Card
-        _new = [a for a in self.card.attachments if a.id == self.id]
-        if not _new:
-            self.schema = _new.pop().schema
+        new = [a for a in self.card.attachments if a.id == self.id]
+        if not new:
+            self.schema = new.pop().schema
 
-    def update(self, **kwargs: Unpack[paths.Request_updateAttachment]) -> None:
+    def update(self, **kwargs: Unpack[typ.Request_updateAttachment]) -> None:
         """Update the Attachment with the provided values"""
         self.schema = self.endpoints.updateAttachment(self.id, **kwargs)['item']
 
     def delete(self):
         """Delete the Attachment"""
         return self.endpoints.deleteAttachment(self.id)
-    
+
     def download(self) -> Iterator[bytes]:
         """Get a byte Iterator for stream downloading"""
         return self.client.get(self.schema['data']['url']).iter_bytes()

--- a/src/plankapy/v2/models/attachment.py
+++ b/src/plankapy/v2/models/attachment.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
-__all__ = ('Attachment', )
-
+from collections.abc import Iterator
 from datetime import datetime
+from typing import Any, Unpack
 
 from ..api import events, schemas, typ
 from ._base import PlankaModel
@@ -10,11 +10,7 @@ from ._helpers import dtfromiso
 
 # Deferred Model imports at bottom of file
 
-TYPE_CHECKING = False
-if TYPE_CHECKING:
-    from collections.abc import Iterator
-    from typing import Any, Unpack
-    # from models import *
+__all__ = ('Attachment', )
 
 
 class Attachment(PlankaModel[schemas.Attachment]):
@@ -50,9 +46,8 @@ class Attachment(PlankaModel[schemas.Attachment]):
     @property
     def creator(self) -> User:
         """The User created the Attachment (Raises LookupError if User is not found in Board)"""
-        usrs = [u for u in self.card.board.users if self.schema['creatorUserId'] == u.id]
-        if usrs:
-            return usrs.pop()
+        if usr := self.card.board.users[{'id': self.schema['creatorUserId']}].dpop():
+            return usr
         raise LookupError(f"Cannot find User: {self.schema['creatorUserId']}")
 
     @property
@@ -69,9 +64,7 @@ class Attachment(PlankaModel[schemas.Attachment]):
     def sync(self) -> None:
         """Pull the latest state of the Attachment from the Planka Server"""
         # No endpoint for attachments, need to get it through the associated Card
-        new = [a for a in self.card.attachments if a.id == self.id]
-        if not new:
-            self.schema = new.pop().schema
+        self.schema = self.card.attachments[self].dpop(default=self).schema
 
     def update(self, **kwargs: Unpack[typ.Request_updateAttachment]) -> None:
         """Update the Attachment with the provided values"""

--- a/src/plankapy/v2/models/attachment.py
+++ b/src/plankapy/v2/models/attachment.py
@@ -62,8 +62,7 @@ class Attachment(PlankaModel[schemas.Attachment]):
 
     # Special Methods
     def sync(self) -> None:
-        """Pull the latest state of the Attachment from the Planka Server"""
-        # No endpoint for attachments, need to get it through the associated Card
+        """Sync the Attachment with the Planka server"""
         self.schema = self.card.attachments[self].dpop(default=self).schema
 
     def update(self, **kwargs: Unpack[typ.Request_updateAttachment]) -> None:

--- a/src/plankapy/v2/models/background_image.py
+++ b/src/plankapy/v2/models/background_image.py
@@ -3,16 +3,17 @@ from __future__ import annotations
 __all__ = ('BackgroundImage', )
 
 from datetime import datetime
+
+from ..api import events, schemas
 from ._base import PlankaModel
 from ._helpers import dtfromiso
-from ..api import schemas, events
 
 # Deferred Model imports at bottom of file
 
 TYPE_CHECKING = False
 if TYPE_CHECKING:
     from collections.abc import Generator, Iterator
-    #from models import *
+    # from models import *
 
 
 class BackgroundImage(PlankaModel[schemas.BackgroundImage]):
@@ -25,50 +26,50 @@ class BackgroundImage(PlankaModel[schemas.BackgroundImage]):
     def created_at(self) -> datetime:
         """When the BackgroundImage was created"""
         return dtfromiso(self.schema['createdAt'], self.session.timezone)
-    
+
     @property
     def updated_at(self) -> datetime:
         """When the BackgroundImage was last updated"""
         return dtfromiso(self.schema['updatedAt'], self.session.timezone)
-    
+
     @property
     def project(self) -> Project:
         """The Project the BackgroundImage belongs to"""
         return Project(self.endpoints.getProject(self.schema['projectId'])['item'], self.session)
-    
+
     @property
     def size(self) -> int:
         """The size of the BackgroundImage in bytes"""
         return int(self.schema.get('size', self.schema.get('sizeInBytes')))
-    
+
     @property
     def url(self) -> str:
         """The URL to access the BackgroundImage"""
         return self.schema['url']
-    
+
     @property
     def thumbnails(self) -> dict[str, str]:
         """URLs for different thumbnail sizes of the background image"""
         return self.schema['thumbnailUrls']
-    
+
     # Special Methods
     def download(self) -> Iterator[bytes]:
-        """Get bytes for the full image
-        
+        """Get bytes for the full image.
+
         Returns:
             (Iterator[bytes]): A byte iterator for the full image
         """
         return self.client.get(self.url).iter_bytes()
-    
+
     def download_thumbnails(self) -> Generator[tuple[str, Iterator[bytes]]]:
-        """Get byte iterators for all thumbnails
-        
+        """Get byte iterators for all thumbnails.
+
         Yields:
             (tuple[str, Iterator[bytes]]): A tuple containing the size key and the thumbnail byte iterator
         """
         for size, url in self.thumbnails.items():
             yield size, self.client.get(url).iter_bytes()
-        
+
     def delete(self):
         """Delete the BackgroundImage"""
         return self.endpoints.deleteBackgroundImage(self.id)

--- a/src/plankapy/v2/models/background_image.py
+++ b/src/plankapy/v2/models/background_image.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
-__all__ = ('BackgroundImage', )
-
+from collections.abc import Generator, Iterator
 from datetime import datetime
 
 from ..api import events, schemas
@@ -10,10 +9,7 @@ from ._helpers import dtfromiso
 
 # Deferred Model imports at bottom of file
 
-TYPE_CHECKING = False
-if TYPE_CHECKING:
-    from collections.abc import Generator, Iterator
-    # from models import *
+__all__ = ('BackgroundImage', )
 
 
 class BackgroundImage(PlankaModel[schemas.BackgroundImage]):

--- a/src/plankapy/v2/models/background_image.py
+++ b/src/plankapy/v2/models/background_image.py
@@ -49,6 +49,10 @@ class BackgroundImage(PlankaModel[schemas.BackgroundImage]):
         return self.schema['thumbnailUrls']
 
     # Special Methods
+    def sync(self) -> None:
+        """Sync the BackgroundImage with the Planka server"""
+        self.schema = self.project.background_images[self].dpop(default=self).schema
+
     def download(self) -> Iterator[bytes]:
         """Get bytes for the full image.
 

--- a/src/plankapy/v2/models/base_custom_field_group.py
+++ b/src/plankapy/v2/models/base_custom_field_group.py
@@ -53,9 +53,7 @@ class BaseCustomFieldGroup(PlankaModel[schemas.BaseCustomFieldGroup]):
     # Special Methods
     def sync(self):
         """Sync the BaseCustomFieldGroup with the Planka server."""
-        for bcfg in self.project.base_custom_field_groups:
-            if bcfg == self:
-                self.schema = bcfg.schema
+        self.schema = self.project.base_custom_field_groups[self].dpop(default=self).schema
 
     def update(self, **base_custom_field_group: Unpack[typ.Request_updateBaseCustomFieldGroup]):
         """Update the BaseCustomFieldGroup."""

--- a/src/plankapy/v2/models/base_custom_field_group.py
+++ b/src/plankapy/v2/models/base_custom_field_group.py
@@ -1,107 +1,109 @@
 from __future__ import annotations
+
 from collections.abc import Sequence
-
-__all__ = ('BaseCustomFieldGroup', )
-
 from datetime import datetime
+
+from ..api import events, schemas, typ
 from ._base import PlankaModel
 from ._helpers import Position, dtfromiso, get_position, model_list
-from ..api import paths, schemas, events
 
 # Deferred Model imports at bottom of file
 
 TYPE_CHECKING = False
 if TYPE_CHECKING:
     from typing import Unpack
-    #from models import *
+    # from models import *
+
+__all__ = ('BaseCustomFieldGroup', )
 
 
 class BaseCustomFieldGroup(PlankaModel[schemas.BaseCustomFieldGroup]):
-    """Python interface for Planka BaseCustomFieldGroups"""
+    """Python interface for Planka BaseCustomFieldGroups."""
 
     __events__ = events.BaseCustomFieldGroupEvents
 
     # BaseCustomFieldGroup Properties
     @property
     def project(self) -> Project:
-        """The Project that the BaseCustomFieldGroup is associated with"""
+        """The Project that the BaseCustomFieldGroup is associated with."""
         return Project(self.endpoints.getProject(self.schema['projectId'])['item'], self.session)
 
     @property
     @model_list
     def custom_fields(self) -> list[CustomField]:
-        """The CustomFields associated with the BaseCustomFieldGroup"""
+        """The CustomFields associated with the BaseCustomFieldGroup."""
         return [cf for cf in self.project.custom_fields if cf.schema['baseCustomFieldGroupId'] == self.id]
 
     @property
     def name(self) -> str:
-        """Name/title of the base custom field group"""
+        """Name/title of the base custom field group."""
         return self.schema['name']
+
     @name.setter
     def name(self, name: str) -> None:
-        """Set the name/title of the base custom field group"""
+        """Set the name/title of the base custom field group."""
         self.update(name=name)
-    
+
     @property
     def created_at(self) -> datetime:
-        """When the base custom field group was created"""
+        """When the base custom field group was created."""
         return dtfromiso(self.schema['createdAt'], self.session.timezone)
-    
+
     @property
     def updated_at(self) -> datetime:
-        """When the base custom field group was last updated"""
+        """When the base custom field group was last updated."""
         return dtfromiso(self.schema['updatedAt'], self.session.timezone)
 
     # Special Methods
     def sync(self):
-        """Sync the BaseCustomFieldGroup with the Planka server"""
+        """Sync the BaseCustomFieldGroup with the Planka server."""
         for bcfg in self.project.base_custom_field_groups:
             if bcfg == self:
                 self.schema = bcfg.schema
-                
-    def update(self, **base_custom_field_group: Unpack[paths.Request_updateBaseCustomFieldGroup]):
-        """Update the BaseCustomFieldGroup"""
+
+    def update(self, **base_custom_field_group: Unpack[typ.Request_updateBaseCustomFieldGroup]):
+        """Update the BaseCustomFieldGroup."""
         self.endpoints.updateBaseCustomFieldGroup(self.id, **base_custom_field_group)
-        
+
     def delete(self):
-        """Delete the BaseCustomFieldGroup"""
+        """Delete the BaseCustomFieldGroup."""
         return self.endpoints.deleteBaseCustomFieldGroup(self.id)
 
-    def add_field(self, field: CustomField, 
-                  *, 
-                  position: Position='top',
-                  show_on_card: bool|None=None) -> CustomField:
-        """Add an existing CustomField to the BaseGroup
-        
+    def add_field(self, field: CustomField,
+                  *,
+                  position: Position = 'top',
+                  show_on_card: bool | None = None) -> CustomField:
+        """Add an existing CustomField to the BaseGroup.
+
         Args:
             field: The existing CustomField to add
             position: The position of the new Field
             show_on_card: Override the input Field's show state
-            
+
         Note:
-            If a CustomField with a matching name already exists in the base group, it 
-            will be returned
+            If a CustomField with a matching name already exists in the base group, it
+             will be returned.
         """
 
         if (cf := self.custom_fields[field].dpop()):
             flds = ('name', 'position', 'showOnFrontOfCard')
             cf.update(**{k: field[k] for k in flds if cf[k] != field[k]})
             return cf
-        
+
         return self.create_field(
-            field.name, 
-            position=position, 
+            field.name,
+            position=position,
             show_on_card=show_on_card or field.show_on_front_of_card
         )
-        
+
     @model_list
     def add_fields(self, fields: Sequence[CustomField],
                    *,
-                   position: Position='top',
-                   show_on_card: bool|None=None) -> list[CustomField]:
-        """Add a multiple CustomFields to the field group. Useful for copying from one 
-        Project to another
-        
+                   position: Position = 'top',
+                   show_on_card: bool | None = None) -> list[CustomField]:
+        """Add a multiple CustomFields to the field group. Useful for copying from one
+         project to another.
+
         Args:
             fields: A sequence of fields to add
             position: Position override for the fields (Will be applied sequence in order)
@@ -114,39 +116,39 @@ class BaseCustomFieldGroup(PlankaModel[schemas.BaseCustomFieldGroup]):
         """
         return [
             self.add_field(
-                field, 
-                position=position or field.position, 
+                field,
+                position=position or field.position,
                 show_on_card=show_on_card
-            ) 
+            )
             for field in fields
         ]
 
-    def create_field(self, 
-                     name: str, 
+    def create_field(self,
+                     name: str,
                      *,
-                     position: Position='top', 
-                     show_on_card: bool=False) -> CustomField:
-        """Create a new CustomField in the BaseCustomFieldGroup
-        
+                     position: Position = 'top',
+                     show_on_card: bool = False) -> CustomField:
+        """Create a new CustomField in the BaseCustomFieldGroup.
+
         Args:
             name: Name/title of the custom field
             position: Position of the custom field within the group
-            show_on_card: Whether to show the field on the front of cards 
+            show_on_card: Whether to show the field on the front of cards
         """
         return CustomField(
             self.endpoints.createCustomFieldInBaseGroup(
-                self.id, 
+                self.id,
                 name=name,
                 position=get_position(self.custom_fields, position),
                 showOnFrontOfCard=show_on_card,
-                )['item'], 
+                )['item'],
             self.session
         )
 
     @model_list
     def create_fields(self, *names: str, show_on_card: bool = False) -> list[CustomField]:
-        """Create multiple fields in the group (position will be arg order)
-        
+        """Create multiple fields in the group (position will be arg order).
+
         Args:
             names: Varargs of the new field names
             show_on_card: Show the new fields on the front of Cards
@@ -157,30 +159,31 @@ class BaseCustomFieldGroup(PlankaModel[schemas.BaseCustomFieldGroup]):
         ]
 
     def delete_field(self, field: CustomField) -> CustomField | None:
-        """Delete a CustomField from the Group
-        
+        """Delete a CustomField from the Group.
+
         Args:
             field: The field to delete
 
         Note:
-            If the field is not a member of the group, None will be returned 
+            If the field is not a member of the group, ``None`` will be returned.
         """
         if (f := self.custom_fields[field].dpop()):
             f.delete()
             return f
-    
+
     @model_list
     def delete_fields(self, fields: Sequence[CustomField]) -> list[CustomField]:
         """Delete s sequence of fields from the Group
-        
+
         Args:
             fields: The fields to delete
 
         Note:
-            If the field is not a member of the group, it will not be included in 
-            the returned list
+            If the field is not a member of the group, it will not be included in
+             the returned list
         """
         return [removed for field in fields if (removed := self.delete_field(field))]
 
-from .project import Project
+
 from .custom_field import CustomField
+from .project import Project

--- a/src/plankapy/v2/models/base_custom_field_group.py
+++ b/src/plankapy/v2/models/base_custom_field_group.py
@@ -2,17 +2,13 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 from datetime import datetime
+from typing import Unpack
 
 from ..api import events, schemas, typ
 from ._base import PlankaModel
 from ._helpers import Position, dtfromiso, get_position, model_list
 
 # Deferred Model imports at bottom of file
-
-TYPE_CHECKING = False
-if TYPE_CHECKING:
-    from typing import Unpack
-    # from models import *
 
 __all__ = ('BaseCustomFieldGroup', )
 

--- a/src/plankapy/v2/models/board.py
+++ b/src/plankapy/v2/models/board.py
@@ -1,12 +1,11 @@
 from __future__ import annotations
 
-__all__ = ('Board', )
-
 from datetime import datetime
 from random import choice
+
+from ..api import events, schemas, typ
 from ._base import PlankaModel
 from ._helpers import Position, dtfromiso, get_position, model_list
-from ..api import schemas, paths, events
 from ._literals import LabelColors
 
 # Deferred Model imports at bottom of file
@@ -14,48 +13,52 @@ from ._literals import LabelColors
 TYPE_CHECKING = False
 if TYPE_CHECKING:
     from collections.abc import Sequence
-    from typing import Unpack, Literal
-    #from models import *
-    from ._literals import CardType, BoardRole, BoardView, ListColor, LabelColor
+    from typing import Literal, Unpack
+
+    # from models import *
+    from ._literals import BoardRole, BoardView, CardType, LabelColor, ListColor
+
+
+__all__ = ('Board', )
 
 
 class Board(PlankaModel[schemas.Board]):
     """Python interface for Planka Boards"""
-    
+
     __events__ = events.BoardEvent
 
     @property
     def url(self) -> str:
         return str(self.client.base_url.join(f'/boards/{self.id}'))
-    
+
     @property
     def formal_name(self) -> str:
         """Get the formal name of the board in the format `{Project}->{Board}`"""
         return f'{self.project.name}->{self.name}'
-    
+
     # Included objects
     @property
     def _included(self):
         return self.endpoints.getBoard(self.id)['included']
-    
+
     @property
     @model_list
     def labels(self) -> list[Label]:
         """Get all Labels on the Board"""
-        return [Label(l, self.session) for l in self._included['labels']]
-    
+        return [Label(lbl, self.session) for lbl in self._included['labels']]
+
     @property
     @model_list
     def cards(self) -> list[Card]:
         """Get all active Cards on the Board (use archived_cards and trashed_cards for archived/trashed Card lists)"""
         return [Card(c, self.session) for c in self._included['cards']]
-    
+
     @property
     @model_list
     def trashed_cards(self) -> list[Card]:
         """Get all Cards in the Board trash list"""
         return self.trash_list.cards
-    
+
     @property
     @model_list
     def archived_cards(self) -> list[Card]:
@@ -67,19 +70,19 @@ class Board(PlankaModel[schemas.Board]):
     def subscribed_cards(self) -> list[Card]:
         """Get all Cards on the Board that the current User is subscribed to"""
         return [Card(sc, self.session) for sc in self._included['cards'] if sc.get('isSubscribed', False)]
-    
+
     @property
     @model_list
     def projects(self) -> list[Project]:
         """Get all Projects that the Board is associated with (use `Board.Project` instead, this is always one item)"""
         return [Project(p, self.session) for p in self._included['projects']]
-    
+
     @property
     @model_list
     def board_memberships(self) -> list[BoardMembership]:
         """Get all BoardMemberships for the Board"""
         return [BoardMembership(bm, self.session) for bm in self._included['boardMemberships']]
-    
+
     @property
     @model_list
     def users(self) -> list[User]:
@@ -91,7 +94,7 @@ class Board(PlankaModel[schemas.Board]):
     def editors(self) -> list[User]:
         """Get all editor Users for the Board"""
         return [bm.user for bm in self.board_memberships if bm.role == 'editor']
-    
+
     @property
     @model_list
     def viewers(self) -> list[User]:
@@ -102,8 +105,8 @@ class Board(PlankaModel[schemas.Board]):
     @model_list
     def all_lists(self) -> list[List]:
         """Get all Lists associated with the Board (including archive and trash)"""
-        return [List(l, self.session) for l in self._included['lists']]
-    
+        return [List(lst, self.session) for lst in self._included['lists']]
+
     @property
     @model_list
     def lists(self) -> list[List]:
@@ -115,65 +118,65 @@ class Board(PlankaModel[schemas.Board]):
     def card_memberships(self) -> list[CardMembership]:
         """Get all CardMemberships associated with the Board"""
         return [CardMembership(cm, self.session) for cm in self._included['cardMemberships']]
-    
+
     @property
     @model_list
     def card_labels(self) -> list[CardLabel]:
         """Get all CardLabels associated with the Board"""
         return [CardLabel(cl, self.session) for cl in self._included['cardLabels']]
-    
+
     @property
     @model_list
     def task_lists(self) -> list[TaskList]:
         """Get all TaskLists associated with the Board"""
         return [TaskList(tl, self.session) for tl in self._included['taskLists']]
-    
+
     @property
     @model_list
     def tasks(self) -> list[Task]:
         """Get all Tasks associated with the Board"""
         return [Task(t, self.session) for t in self._included['tasks']]
-    
+
     @property
     @model_list
     def attachments(self) -> list[Attachment]:
         """Get all Attachments associated with the Board"""
         return [Attachment(a, self.session) for a in self._included['attachments']]
-    
+
     @property
     @model_list
     def custom_field_groups(self) -> list[CustomFieldGroup]:
         """Get all CustomFieldGroups associated with the Board"""
         return [CustomFieldGroup(cfg, self.session) for cfg in self._included['customFieldGroups']]
-    
+
     @property
     @model_list
     def custom_fields(self) -> list[CustomField]:
         """Get all CustomFields associated with the Board"""
         return [CustomField(cf, self.session) for cf in self._included['customFields']]
-    
+
     @property
     @model_list
     def custom_field_values(self) -> list[CustomFieldValue]:
         """Get all CustomFieldValues associated with the Board"""
         return [CustomFieldValue(cfv, self.session) for cfv in self._included['customFieldValues']]
-    
+
     @property
     def archive_list(self) -> List:
         """Get the archive List for the Board (archive List is not a normal List!)"""
         return self.all_lists[{'type': 'archive'}].pop()
-    
+
     @property
     def trash_list(self) -> List:
         """Get the trash List for the Board (trash List is not a normal List!)"""
         return self.all_lists[{'type': 'trash'}].pop()
-    
+
     @property
     @model_list
     def active_lists(self) -> list[List]:
         """Get all active Lists for the Board"""
         return self.all_lists[{'type': 'active'}]
-    
+
     @property
     @model_list
     def closed_lists(self) -> list[List]:
@@ -185,16 +188,17 @@ class Board(PlankaModel[schemas.Board]):
     def subscribed(self) -> bool:
         """Whether the current user is subscribed to the Board"""
         return self.endpoints.getBoard(self.id)['item']['isSubscribed']
-    
+
     @property
     def project(self) -> Project:
         """TheProject the Board belongs to"""
         return Project(self.endpoints.getProject(self.schema['projectId'])['item'], self.session)
-    
+
     @property
     def position(self) -> int:
         """Position of the Board within the Project"""
         return self.schema['position']
+
     @position.setter
     def position(self, position: int) -> None:
         """Position of the Board within the Project"""
@@ -204,6 +208,7 @@ class Board(PlankaModel[schemas.Board]):
     def name(self) -> str:
         """Name/title of the Board"""
         return self.schema['name']
+
     @name.setter
     def name(self, name: str) -> None:
         """Set the name/title of the Board"""
@@ -213,6 +218,7 @@ class Board(PlankaModel[schemas.Board]):
     def default_view(self) -> BoardView:
         """Default view for the board"""
         return self.schema['defaultView']
+
     @default_view.setter
     def default_view(self, default_view: BoardView) -> None:
         """Set default view for the board"""
@@ -222,6 +228,7 @@ class Board(PlankaModel[schemas.Board]):
     def default_card_type(self) -> CardType:
         """Default Card type for new Cards"""
         return self.schema['defaultCardType']
+
     @default_card_type.setter
     def default_card_type(self, default_card_type: CardType) -> None:
         """Set default Card type for new Cards"""
@@ -231,6 +238,7 @@ class Board(PlankaModel[schemas.Board]):
     def limit_card_types_to_default_one(self) -> bool:
         """Whether to limit Card types to default one"""
         return self.schema['limitCardTypesToDefaultOne']
+
     @limit_card_types_to_default_one.setter
     def limit_card_types_to_default_one(self, limit_card_types_to_default_one: bool) -> None:
         """Set whether to limit Card types to default one"""
@@ -240,6 +248,7 @@ class Board(PlankaModel[schemas.Board]):
     def always_display_card_creator(self) -> bool:
         """Whether to always display the Card creator"""
         return self.schema['alwaysDisplayCardCreator']
+
     @always_display_card_creator.setter
     def always_display_card_creator(self, always_display_card_creator: bool) -> None:
         """Set whether to always display the Card creator"""
@@ -249,6 +258,7 @@ class Board(PlankaModel[schemas.Board]):
     def expand_task_lists_by_default(self) -> bool:
         """Whether to expand TaskLists by default"""
         return self.schema['expandTaskListsByDefault']
+
     @expand_task_lists_by_default.setter
     def expand_task_lists_by_default(self, expand_task_lists_by_default: bool) -> None:
         """Set whether to expand TaskLists by default"""
@@ -258,103 +268,104 @@ class Board(PlankaModel[schemas.Board]):
     def created_at(self) -> datetime:
         """When the Board was created"""
         return dtfromiso(self.schema['createdAt'], self.session.timezone)
+
     @property
     def updated_at(self) -> datetime:
         """When the Board was last updated"""
         return dtfromiso(self.schema['updatedAt'], self.session.timezone)
-    
+
     # Special Methods
     def sync(self) -> None:
         """Sync the Board with the Planka Server"""
         self.schema = self.endpoints.getBoard(self.id)['item']
-        
-    def update(self, **board: Unpack[paths.Request_updateBoard]) -> None:
+
+    def update(self, **board: Unpack[typ.Request_updateBoard]) -> None:
         """Update the Board"""
         self.schema = self.endpoints.updateBoard(self.id, **board)['item']
-        
+
     def delete(self):
         """Delete the Board"""
         return self.endpoints.deleteBoard(self.id)
 
-    def create_list(self, 
-                    *, 
+    def create_list(self,
+                    *,
                     name: str,
-                    type: Literal['active', 'closed']='active',
+                    type: Literal['active', 'closed'] = 'active',
                     position: Position = 'top',
-                    color: ListColor|Literal['random']|None=None) -> List:
+                    color: ListColor | Literal['random'] | None = None) -> List:
         """Create a new List on the Board
-        
+
         Args:
             name: Name/title of the List
             type: Type/status of the List
             position: Position of the List within the Board
             color: An optional color to set the list to (`random` to randomize)
         """
-        l = List(
+        lst = List(
             self.endpoints.createList(
-                self.id, 
+                self.id,
                 name=name,
                 type=type,
-                position=get_position(self.active_lists + self.closed_lists, position))['item'], 
+                position=get_position(self.active_lists + self.closed_lists, position))['item'],
             self.session
         )
         if color:
-            l.color = color
-        return l
+            lst.color = color
+        return lst
 
     def remove_list(self, list: List) -> None:
         """Remove a List from the Board
-        
+
         Args:
             list (List): The list to remove (must be associated with the Board and not `trash` or `archive`)
         """
         if list in self.active_lists:
             list.delete()
 
-    def create_label(self, 
+    def create_label(self,
                      *,
                      name: str,
-                     position: Position='top',
-                     color: LabelColor|Literal['random']='random') -> Label:
+                     position: Position = 'top',
+                     color: LabelColor | Literal['random'] = 'random') -> Label:
         """Create a new Label on the Board
-        
+
         Args:
             name: The name of the Label
             positon: The position of the label in the label list
             color: An optional color for the label (a random unused color by default)
         """
-        l = Label(
+        lbl = Label(
             self.endpoints.createLabel(
-                self.id, 
+                self.id,
                 name=name,
                 position=get_position(self.labels, position),
-                color=color if color != 'random' else choice(LabelColors))['item'], 
+                color=color if color != 'random' else choice(LabelColors))['item'],  # noqa: S311
                 self.session
             )
-        return l
-    
+        return lbl
+
     def remove_label(self, label: Label) -> None:
         """Remove a Label from the Board
-        
+
         Args:
             label (Label): The Label to remove (must be associated with the board)
         """
         if label in self.labels:
             label.delete()
-    
-    def create_field_group(self, 
-                           name: str|None=None, 
-                           *, 
-                           position: Position= 'top', 
-                           base_group: BaseCustomFieldGroup|None=None) -> CustomFieldGroup:
+
+    def create_field_group(self,
+                           name: str | None = None,
+                           *,
+                           position: Position = 'top',
+                           base_group: BaseCustomFieldGroup | None = None) -> CustomFieldGroup:
         """Create a new CustomFieldGroup on the Board
-        
+
         Args:
             name: The name of the Custom Field Group
             position: The position of the field group within the board
             base_group: An optional BaseCustomFieldGroup to use as a template
         """
-        args: paths.Request_createBoardCustomFieldGroup = {
+        args: typ.Request_createBoardCustomFieldGroup = {
             'name': name,
             'position': get_position(self.custom_field_groups, position)
         }
@@ -366,12 +377,12 @@ class Board(PlankaModel[schemas.Board]):
             self.session
         )
 
-    def add_member(self, user: User, 
+    def add_member(self, user: User,
                    *,
-                   role: BoardRole='viewer',
-                   can_comment: bool=False) -> BoardMembership:
+                   role: BoardRole = 'viewer',
+                   can_comment: bool = False) -> BoardMembership:
         """Add a User to the Board
-        
+
         Args:
             user (User): The User to add
             role (Literal['viewer', 'editor']): The Role to assign to the user (default: `viewer`)
@@ -381,13 +392,13 @@ class Board(PlankaModel[schemas.Board]):
         if user not in self.users:
             BoardMembership(
                 self.endpoints.createBoardMembership(
-                    self.id, 
-                    userId=user.id, 
-                    role=role, 
-                    canComment=can_comment)['item'], 
+                    self.id,
+                    userId=user.id,
+                    role=role,
+                    canComment=can_comment)['item'],
                 self.session
             )
-        
+
         # Get existing membership and update role different
         membership = [bm for bm in self.board_memberships if bm.user == user].pop()
         if membership.role != role:
@@ -395,19 +406,19 @@ class Board(PlankaModel[schemas.Board]):
         if membership.can_comment != can_comment:
             membership.can_comment = can_comment
         return membership
-    
+
     @model_list
-    def add_members(self, users: Sequence[User], 
+    def add_members(self, users: Sequence[User],
                     *,
-                    role: BoardRole='viewer',
-                    can_comment: bool=False) -> list[BoardMembership]:
+                    role: BoardRole = 'viewer',
+                    can_comment: bool = False) -> list[BoardMembership]:
         """Add a Users to the Board
-        
+
         Args:
             users (Sequence[User]): The Users to add
             role (Literal['viewer', 'editor']): The Role to assign to the user (default: `viewer`)
             can_comment (bool): If role is `viewer` set commenting status (default: `False`)
-            
+
         Returns:
             list[BoardMembership]
         """
@@ -419,13 +430,13 @@ class Board(PlankaModel[schemas.Board]):
             )
             for user in users
         ]
-    
+
     def add_editor(self, user: User) -> BoardMembership:
         """Add a Board editor
-        
+
         Args:
             user (User): The User to add as an editor
-            
+
         Returns:
             BoardMembership
         """
@@ -434,18 +445,18 @@ class Board(PlankaModel[schemas.Board]):
     @model_list
     def add_editors(self, users: Sequence[User]) -> list[BoardMembership]:
         """Add Board editors
-        
+
         Args:
             users (Sequence[User]): The Users to add as editors
-            
+
         Returns:
             list[BoardMembership]
         """
         return [self.add_editor(user) for user in users]
 
-    def add_viewer(self, user: User, *, can_comment: bool=False) -> BoardMembership:
+    def add_viewer(self, user: User, *, can_comment: bool = False) -> BoardMembership:
         """Add a Board viewer
-        
+
         Args:
             user (User): The User to add as a viewer
             can_comment (bool): Whether the viewer User can comment on cards
@@ -453,9 +464,9 @@ class Board(PlankaModel[schemas.Board]):
         return self.add_member(user, role='viewer', can_comment=can_comment)
 
     @model_list
-    def add_viewers(self, users: Sequence[User], *, can_comment: bool=False) -> list[BoardMembership]:
+    def add_viewers(self, users: Sequence[User], *, can_comment: bool = False) -> list[BoardMembership]:
         """Add a Board viewer
-        
+
         Args:
             users (Sequence[User]): The Users to add as viewers
             can_comment (bool): Whether the viewer Users can comment on cards
@@ -464,34 +475,34 @@ class Board(PlankaModel[schemas.Board]):
 
     def remove_user(self, user: User) -> User | None:
         """Remove a User from the Board
-        
+
         Note:
-            If the User is not a member, no change will be made and None will be returned
+            If the User is not a member, no change will be made and None will be returned.
         """
         if (membership := self.board_memberships[{'userId': user.id}].dpop()):
             membership.delete()
             return user
-    
+
     @model_list
     def remove_users(self, users: Sequence[User]) -> list[User]:
         """Remove Users from the Board
-        
+
         Note:
-            If a User is not a member, no change will be made and they will 
-            be excluded from the returned user list
+            If a User is not a member, no change will be made and they will
+             be excluded from the returned user list.
         """
         return [removed for u in users if (removed := self.remove_user(u))]
 
     @model_list
-    def filter(self, 
+    def filter(self,
                *,
-               search: str|None=None,
-               users: User|Sequence[User]|None=None,
-               labels: Label|Sequence[Label]|None=None,
-               card_before: Card|None=None,
-               changed_before: datetime|None=None) -> list[Card]:
+               search: str | None = None,
+               users: User | Sequence[User] | None = None,
+               labels: Label | Sequence[Label] | None = None,
+               card_before: Card | None = None,
+               changed_before: datetime | None = None) -> list[Card]:
         """Apply a card filter to the board (apply the filter to all lists and agregate the cards)
-        
+
         Args:
             search: A search term to apply to the cards
             users: A list of Users to filter the cards by
@@ -501,15 +512,16 @@ class Board(PlankaModel[schemas.Board]):
         """
         return [
             card
-            for l in self.lists
-            for card in l.filter(
-                search=search, 
-                users=users, 
-                labels=labels, 
-                card_before=card_before, 
+            for lst in self.lists
+            for card in lst.filter(
+                search=search,
+                users=users,
+                labels=labels,
+                card_before=card_before,
                 changed_before=changed_before
-            ) 
+            )
         ]
+
 
 from .attachment import Attachment
 from .base_custom_field_group import BaseCustomFieldGroup
@@ -517,7 +529,6 @@ from .board_membership import BoardMembership
 from .card import Card
 from .card_label import CardLabel
 from .card_membership import CardMembership
-from .custom_field import CustomField
 from .custom_field import CustomField
 from .custom_field_group import CustomFieldGroup
 from .custom_field_value import CustomFieldValue

--- a/src/plankapy/v2/models/board.py
+++ b/src/plankapy/v2/models/board.py
@@ -276,7 +276,7 @@ class Board(PlankaModel[schemas.Board]):
 
     # Special Methods
     def sync(self) -> None:
-        """Sync the Board with the Planka Server"""
+        """Sync the Board with the Planka server"""
         self.schema = self.endpoints.getBoard(self.id)['item']
 
     def update(self, **board: Unpack[typ.Request_updateBoard]) -> None:

--- a/src/plankapy/v2/models/board.py
+++ b/src/plankapy/v2/models/board.py
@@ -1,23 +1,23 @@
 from __future__ import annotations
 
+from collections.abc import Sequence
 from datetime import datetime
-from random import choice
+from secrets import choice
+from typing import Literal, Unpack
 
 from ..api import events, schemas, typ
 from ._base import PlankaModel
 from ._helpers import Position, dtfromiso, get_position, model_list
-from ._literals import LabelColors
+from ._literals import (
+    BoardRole,
+    BoardView,
+    CardType,
+    LabelColor,
+    LabelColors,
+    ListColor,
+)
 
 # Deferred Model imports at bottom of file
-
-TYPE_CHECKING = False
-if TYPE_CHECKING:
-    from collections.abc import Sequence
-    from typing import Literal, Unpack
-
-    # from models import *
-    from ._literals import BoardRole, BoardView, CardType, LabelColor, ListColor
-
 
 __all__ = ('Board', )
 
@@ -187,7 +187,7 @@ class Board(PlankaModel[schemas.Board]):
     @property
     def subscribed(self) -> bool:
         """Whether the current user is subscribed to the Board"""
-        return self.endpoints.getBoard(self.id)['item']['isSubscribed']
+        return self.endpoints.getBoard(self.id)['item'].get('isSubscribed', False)
 
     @property
     def project(self) -> Project:
@@ -339,7 +339,7 @@ class Board(PlankaModel[schemas.Board]):
                 self.id,
                 name=name,
                 position=get_position(self.labels, position),
-                color=color if color != 'random' else choice(LabelColors))['item'],  # noqa: S311
+                color=color if color != 'random' else choice(LabelColors))['item'],
                 self.session
             )
         return lbl
@@ -390,7 +390,7 @@ class Board(PlankaModel[schemas.Board]):
         """
         # Create a new membership
         if user not in self.users:
-            BoardMembership(
+            bm = BoardMembership(
                 self.endpoints.createBoardMembership(
                     self.id,
                     userId=user.id,
@@ -398,9 +398,10 @@ class Board(PlankaModel[schemas.Board]):
                     canComment=can_comment)['item'],
                 self.session
             )
+            return bm
 
-        # Get existing membership and update role different
-        membership = [bm for bm in self.board_memberships if bm.user == user].pop()
+        membership = self.board_memberships[{'userId': user.id}].dpop()
+        assert membership, 'User is not a member of the board (this should be unreachable)'
         if membership.role != role:
             membership.role = role
         if membership.can_comment != can_comment:

--- a/src/plankapy/v2/models/board_membership.py
+++ b/src/plankapy/v2/models/board_membership.py
@@ -1,24 +1,27 @@
 from __future__ import annotations
 
-__all__ = ('BoardMembership', )
-
 from datetime import datetime
+
+from ..api import events, schemas, typ
 from ._base import PlankaModel
 from ._helpers import dtfromiso
-from ..api import schemas, paths, events
 
 # Deferred Model imports at bottom of file
 
 TYPE_CHECKING = False
 if TYPE_CHECKING:
     from typing import Unpack
-    #from models import *
+
+    # from models import *
     from _literals import BoardRole
+
+
+__all__ = ('BoardMembership', )
 
 
 class BoardMembership(PlankaModel[schemas.BoardMembership]):
     """Python interface for Planka BoardMemberships"""
-    
+
     __events__ = events.BoardMembershipEvents
 
     # BoardMembership properties
@@ -27,35 +30,40 @@ class BoardMembership(PlankaModel[schemas.BoardMembership]):
     def project(self) -> Project:
         """The Project the BoardMembership belongs to"""
         return Project(self.endpoints.getProject(self.schema['projectId'])['item'], self.session)
-    
+
     @property
     def board(self) -> Board:
         """The Board the BoardMembership is associated with"""
         return Board(self.endpoints.getBoard(self.schema['boardId'])['item'], self.session)
-    
+
     @property
     def user(self) -> User:
-        """The User the BoardMembership is associated with (Raises LookupError if User no longer in the Board)"""
-        _usrs = [u for u in self.board.users if self.schema['userId'] == u.id]
-        if _usrs:
-            return _usrs.pop()
+        """The User the BoardMembership is associated with
+
+        Raises:
+            LookupError: User no longer in the Board
+        """
+        if usr := self.board.users[{'userId': self.user.id}].dpop():
+            return usr
         raise LookupError(f"Cannot find User: {self.schema['userId']}")
 
     @property
     def role(self) -> BoardRole:
         """Role of the user in the board"""
         return self.schema['role']
+
     @role.setter
     def role(self, role: BoardRole) -> None:
         """Set the role of the User in the Board"""
         self.update(role=role)
-    
+
     @property
     def can_comment(self) -> bool:
         """Whether the user can comment on cards"""
         if self.role == 'viewer':
             return self.schema['canComment']
         return True
+
     @can_comment.setter
     def can_comment(self, can_comment: bool) -> None:
         """Set if a viewer User can comment"""
@@ -66,7 +74,7 @@ class BoardMembership(PlankaModel[schemas.BoardMembership]):
     def created_at(self) -> datetime:
         """When the board membership was created"""
         return dtfromiso(self.schema['createdAt'], self.session.timezone)
-    
+
     @property
     def updated_at(self) -> datetime:
         """When the board membership was last updated"""
@@ -75,11 +83,10 @@ class BoardMembership(PlankaModel[schemas.BoardMembership]):
     # Special Methods
     def sync(self):
         """Sync the BoardMembership with the Planka server"""
-        _bms = [bm for bm in self.board.board_memberships if bm == self]
-        if _bms:
-            self.schema = _bms.pop().schema
+        if bms := self.board.board_memberships[{'id': self.id}].dpop(default=self):
+            self.schema = bms.schema
 
-    def update(self, **kwargs: Unpack[paths.Request_updateBoardMembership]) -> None:
+    def update(self, **kwargs: Unpack[typ.Request_updateBoardMembership]) -> None:
         """Update the BoardMembership"""
         self.schema = self.endpoints.updateBoardMembership(self.id, **kwargs)['item']
 
@@ -88,6 +95,6 @@ class BoardMembership(PlankaModel[schemas.BoardMembership]):
         return self.endpoints.deleteBoardMembership(self.id)
 
 
-from .project import Project
 from .board import Board
+from .project import Project
 from .user import User

--- a/src/plankapy/v2/models/board_membership.py
+++ b/src/plankapy/v2/models/board_membership.py
@@ -77,8 +77,7 @@ class BoardMembership(PlankaModel[schemas.BoardMembership]):
     # Special Methods
     def sync(self):
         """Sync the BoardMembership with the Planka server"""
-        if bms := self.board.board_memberships[{'id': self.id}].dpop(default=self):
-            self.schema = bms.schema
+        self.schema = self.board.board_memberships[self].dpop(default=self).schema
 
     def update(self, **kwargs: Unpack[typ.Request_updateBoardMembership]) -> None:
         """Update the BoardMembership"""

--- a/src/plankapy/v2/models/board_membership.py
+++ b/src/plankapy/v2/models/board_membership.py
@@ -1,20 +1,14 @@
 from __future__ import annotations
 
 from datetime import datetime
+from typing import Unpack
 
 from ..api import events, schemas, typ
 from ._base import PlankaModel
 from ._helpers import dtfromiso
+from ._literals import BoardRole
 
 # Deferred Model imports at bottom of file
-
-TYPE_CHECKING = False
-if TYPE_CHECKING:
-    from typing import Unpack
-
-    # from models import *
-    from _literals import BoardRole
-
 
 __all__ = ('BoardMembership', )
 

--- a/src/plankapy/v2/models/board_membership.py
+++ b/src/plankapy/v2/models/board_membership.py
@@ -37,7 +37,7 @@ class BoardMembership(PlankaModel[schemas.BoardMembership]):
         Raises:
             LookupError: User no longer in the Board
         """
-        if usr := self.board.users[{'userId': self.user.id}].dpop():
+        if usr := self.board.users[{'id': self.schema['userId']}].dpop():
             return usr
         raise LookupError(f"Cannot find User: {self.schema['userId']}")
 

--- a/src/plankapy/v2/models/card.py
+++ b/src/plankapy/v2/models/card.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 from datetime import datetime, timedelta
+from pathlib import Path
 from typing import Any, Unpack
 
 from httpx import HTTPStatusError
@@ -385,7 +386,7 @@ class Card(PlankaModel[schemas.Card]):
             self.move(self.prev_list, position)
         return self
 
-    def add_attachment(self, attachment: str | bytes,
+    def add_attachment(self, attachment: Path | str | bytes,
                        *,
                        cover: bool = False,
                        download_url: bool = False,
@@ -393,10 +394,10 @@ class Card(PlankaModel[schemas.Card]):
         """Add an Attachment to the card
 
         Args:
-            attachment (str | bytes): The URL or raw bytes of the attachment
-            cover (bool): Set the new attachment as the cover of the card
-            download_url (bool): If a link is used, download the file from the link and attach it (default: `False`)
-            name (str | None): The optional name of the attachment (default is `hash() + mimetypes.guess_type(attachment)`)
+            attachment: Path or URL or raw bytes of the attachment
+            cover: Set the new attachment as the cover of the card
+            download_url: If a link is used, download the file from the link and attach it (default: `False`)
+            name: The optional name of the attachment (default is `hash() + mimetypes.guess_type(attachment)`)
 
         Returns:
             Attachment
@@ -417,8 +418,8 @@ class Card(PlankaModel[schemas.Card]):
         # Handle filepath or URL
         mime_type = None
         extension = '.bin'
-        if isinstance(attachment, str):
-
+        if isinstance(attachment, (Path, str)):
+            attachment = str(attachment)
             # Guess URL file type
             if attachment.startswith('http'):
                 mime_type, *_ = mimetypes.guess_type(attachment)

--- a/src/plankapy/v2/models/card.py
+++ b/src/plankapy/v2/models/card.py
@@ -1,24 +1,19 @@
 from __future__ import annotations
 
-from httpx import HTTPStatusError
-
-__all__ = ('Card', 'Stopwatch', )
-
+from collections.abc import Sequence
 from datetime import datetime, timedelta
+from typing import Any, Unpack
+
+from httpx import HTTPStatusError
 
 from ..api import events, schemas, typ
 from ._base import PlankaModel
 from ._helpers import Position, dtfromiso, dttoiso, get_position, model_list
+from ._literals import BoardRole, CardType
 
 # Deferred Model imports at bottom of file
 
-TYPE_CHECKING = False
-if TYPE_CHECKING:
-    from collections.abc import Sequence
-    from typing import Any, Unpack
-
-    # from models import *
-    from ._literals import BoardRole, CardType
+__all__ = ('Card', 'Stopwatch', )
 
 
 class Card(PlankaModel[schemas.Card]):

--- a/src/plankapy/v2/models/card.py
+++ b/src/plankapy/v2/models/card.py
@@ -5,9 +5,10 @@ from httpx import HTTPStatusError
 __all__ = ('Card', 'Stopwatch', )
 
 from datetime import datetime, timedelta
+
+from ..api import events, schemas, typ
 from ._base import PlankaModel
 from ._helpers import Position, dtfromiso, dttoiso, get_position, model_list
-from ..api import schemas, paths, events
 
 # Deferred Model imports at bottom of file
 
@@ -15,96 +16,97 @@ TYPE_CHECKING = False
 if TYPE_CHECKING:
     from collections.abc import Sequence
     from typing import Any, Unpack
-    #from models import *
-    from ._literals import CardType, BoardRole
+
+    # from models import *
+    from ._literals import BoardRole, CardType
 
 
 class Card(PlankaModel[schemas.Card]):
     """Python interface for Planka Cards"""
-    
+
     __events__ = events.CardEvents
 
     @property
     def url(self) -> str:
         """The URL to the card"""
         return str(self.client.base_url.join(f'/cards/{self.id}'))
-    
+
     @property
-    def formal_name(self)-> str:
+    def formal_name(self) -> str:
         """Get a formal name for the card `{Project}->{Board}->{List}->{Card}`"""
         return f'{self.project.name}->{self.board.name}->{self.list.name}->{self.name}'
-        
+
     # Included objects
     @property
     def _included(self):
         return self.endpoints.getCard(self.id)['included']
-    
+
     @property
     @model_list
     def attachments(self) -> list[Attachment]:
         """Get all Attachments associated with the Card"""
         return [Attachment(a, self.session) for a in self._included['attachments']]
-    
+
     @property
     @model_list
     def card_memberships(self) -> list[CardMembership]:
         """Get all CardMemberships associated with the Card"""
         return [CardMembership(cm, self.session) for cm in self._included['cardMemberships']]
-    
+
     @property
     @model_list
     def users(self) -> list[User]:
         """Get all Users associated with the Card (including Creator)"""
         return [User(u, self.session) for u in self._included['users']]
-    
+
     @property
     @model_list
     def members(self) -> list[User]:
         """Get all Users Assigned to the card"""
         return [cm.user for cm in self.card_memberships]
-    
+
     @property
     @model_list
     def card_labels(self) -> list[CardLabel]:
         """Get all CardLabel associations for the Card"""
         return [CardLabel(cl, self.session) for cl in self._included['cardLabels']]
-    
+
     @property
     @model_list
     def labels(self) -> list[Label]:
         """Get all Labels associated with the Card"""
         return [cl.label for cl in self.card_labels]
-    
+
     @property
     @model_list
     def tasks(self) -> list[Task]:
         """Get all Tasks associated with the card"""
         return [Task(t, self.session) for t in self._included['tasks']]
-    
+
     @property
     @model_list
     def task_lists(self) -> list[TaskList]:
         """Get all TaskLists associated with the Card"""
         return [TaskList(tl, self.session) for tl in self._included['taskLists']]
-    
+
     @property
     @model_list
     def custom_field_groups(self) -> list[CustomFieldGroup]:
         """Get all CustomFieldGroups associated with the Card"""
         return [CustomFieldGroup(cfg, self.session) for cfg in self._included['customFieldGroups']]
-    
+
     @property
     @model_list
     def custom_fields(self) -> list[CustomField]:
-         """Get all CustomFields associated with the Card"""
-         return [CustomField(cf, self.session) for cf in self._included['customFields']]
-    
+        """Get all CustomFields associated with the Card"""
+        return [CustomField(cf, self.session) for cf in self._included['customFields']]
+
     @property
     @model_list
     def custom_field_values(self) -> list[CustomFieldValue]:
         """Get all CustomFieldValues associated with the Card"""
         return [CustomFieldValue(cfv, self.session) for cfv in self._included['customFieldValues']]
-    
+
     @property
     @model_list
     def comments(self) -> list[Comment]:
@@ -122,11 +124,12 @@ class Card(PlankaModel[schemas.Card]):
     def subscribed(self) -> bool:
         """If the current user is subscribed to the Card"""
         return self.endpoints.getCard(self.id)['item'].get('isSubscribed', False)
+
     @subscribed.setter
     def subscribed(self, subscribed: bool) -> None:
         """Set subscription status on the Card for the current User"""
         self.update(isSubscribed=subscribed)
-    
+
     @property
     def project(self) -> Project:
         """Get the Project that the card is in"""
@@ -136,11 +139,12 @@ class Card(PlankaModel[schemas.Card]):
     def board(self) -> Board:
         """The Board the Card belongs to"""
         return Board(self.endpoints.getBoard(self.schema['boardId'])['item'], self.session)
-    
+
     @property
-    def list(self)-> List:
+    def list(self) -> List:
         """The List the Card belongs to"""
         return List(self.endpoints.getList(self.schema['listId'])['item'], self.session)
+
     @list.setter
     def list(self, list: List) -> Card:
         """Set List the Card belongs to"""
@@ -150,118 +154,124 @@ class Card(PlankaModel[schemas.Card]):
     @property
     def creator(self) -> User | None:
         """The User who Created the card
-        
-        Note: 
-            If the creator is no longer on the Board, only Admins and Project Owners 
-            can see them. Otherwise, None will be returned
-            
-            If the User has been deleted, Admins and Project Owners will get a Server error 
+
+        Note:
+            If the creator is no longer on the Board, only Admins and Project Owners
+             can see them. Otherwise, None will be returned.
+             If the User has been deleted, Admins and Project Owners will get a Server error.
         """
         for u in self.board.users:
             if u.id == self.schema['creatorUserId']:
                 return u
-        
+
         if self.current_role in ('admin', 'projectOwner'):
-            return User(self.endpoints.getUser(self.schema['creatorUserId'])['item'], self.session) 
-        
+            return User(self.endpoints.getUser(self.schema['creatorUserId'])['item'], self.session)
+
     @property
     def prev_list(self) -> List | None:
         """The previous List the card was in (available when in archive or trash)"""
         if self.schema['prevListId']:
             return List(self.endpoints.getList(self.schema['prevListId'])['item'], self.session)
-    
+
     @property
     def cover(self) -> Attachment | None:
         """The Attachment used as cover (None if no cover)"""
         for attachment in self.attachments:
             if attachment.id == self.schema['coverAttachmentId']:
                 return attachment
-            
+
     @cover.setter
     def cover(self, attachment: Attachment) -> None:
         """Set the Card cover"""
         self.update(coverAttachmentId=attachment.id)
-    
+
     @property
     def type(self):
         """Type of the Card"""
         return self.schema['type']
+
     @type.setter
     def type(self, type: CardType) -> None:
         """Set the Card type"""
         self.update(type=type)
-    
+
     @property
     def position(self) -> int:
         """Position of the Card within the List"""
         return self.schema['position']
+
     @position.setter
     def position(self, position: int) -> None:
         """Set the card position"""
         self.update(position=position)
-    
+
     @property
     def name(self) -> str:
         """Name/title of the Card"""
         return self.schema['name']
+
     @name.setter
     def name(self, name: str) -> None:
         """Set the Card name"""
         self.update(name=name)
-    
+
     @property
     def description(self) -> str:
         """Detailed description of the Card"""
         return self.schema['description']
+
     @description.setter
     def description(self, description: str) -> None:
         """Set the Card Description"""
         self.update(description=description)
-    
+
     @property
     def due_date(self) -> datetime | None:
         """Due date for the card"""
         if self.schema['dueDate']:
             return dtfromiso(self.schema['dueDate'], self.session.timezone)
         return None
+
     @due_date.setter
     def due_date(self, due_date: datetime | str) -> None:
         """Set the due date (If using a string, a valid ISO 8601 string is required)"""
         self.update(dueDate=str(due_date))
-    
+
     @property
     def due_date_completed(self) -> bool:
         """Whether the due date is completed"""
         return self.schema['isDueCompleted']
+
     @due_date_completed.setter
     def due_date_completed(self, is_completed: bool) -> None:
         """Set the due date completion status"""
         self.update(isDueCompleted=is_completed)
-    
+
     @property
     def stopwatch(self) -> Stopwatch:
         """Stopwatch for time tracking"""
         return Stopwatch(self)
-    
+
     @property
     def comments_count(self) -> int:
         """Total number of comments on the Card"""
         return self.schema['commentsTotal']
+
     @property
     def is_closed(self) -> bool:
         """Whether the Card is closed"""
         return self.schema['isClosed']
-    
+
     @property
     def list_changed_at(self) -> datetime:
         """When the Card was last moved between Lists"""
         return dtfromiso(self.schema['listChangedAt'], self.session.timezone)
-    
+
     @property
     def created_at(self) -> datetime:
         """When the Card was created"""
         return dtfromiso(self.schema['createdAt'], self.session.timezone)
-    
+
     @property
     def updated_at(self) -> datetime:
         """When the Card was last updated"""
@@ -271,8 +281,8 @@ class Card(PlankaModel[schemas.Card]):
     def sync(self):
         """Sync the Card with the Planka server"""
         self.schema = self.endpoints.getCard(self.id)['item']
-        
-    def update(self, **kwargs: Unpack[paths.Request_updateCard]):
+
+    def update(self, **kwargs: Unpack[typ.Request_updateCard]):
         """Update the Card
 
         Note:
@@ -282,7 +292,7 @@ class Card(PlankaModel[schemas.Card]):
         if 'dueDate' in kwargs:
             kwargs['dueDate'] = str(kwargs['dueDate'])
         self.schema = self.endpoints.updateCard(self.id, **kwargs)['item']
- 
+
     def delete(self):
         """Delete the Card"""
         return self.endpoints.deleteCard(self.id)
@@ -292,25 +302,25 @@ class Card(PlankaModel[schemas.Card]):
         """Read all the current User's Notifications for the Card"""
         return [Notification(n, self.session) for n in self.endpoints.readCardNotifications(self.id)['included']['notifications']]
 
-    def comment(self, comment: str, *, mentions: Sequence[User]|None=None) -> Comment:
-        """Leave a comment as this user and mention any user included in the mentions list
-        
+    def comment(self, comment: str, *, mentions: Sequence[User] | None = None) -> Comment:
+        """Leave a comment as this user and mention any user included in the mentions list.
+
         Args:
             text: The text body of the comment (`@[name|username|email]` will mention)
             mentions: A sequence of Users that will be mentioned after the body
-        
+
         Note:
-            If a user is explicitly mentioned in the comment, they will be removed from the 
-            suffix mention. e.g. 
+            If a user is explicitly mentioned in the comment, they will be removed from the
+             suffix mention. e.g.
             ```python
             >>> card.comment(
-            ...     'Fix this @user1, then send to @user2', 
+            ...     'Fix this @user1, then send to @user2',
             ...     mentions=[user1, user2, user3]
             ... )
             '''Fix this @user1, then send to @user2
             @user3'''
             ```
-            
+
         Example:
             ```python
                 >>> card.comment('Need Fix', mentions=card2.users)
@@ -321,43 +331,43 @@ class Card(PlankaModel[schemas.Card]):
             ```
         """
         # Store inline mentions to prevent additional mention in postfix
-        _mentioned: list[User] = []
+        inline_mentions: list[User] = []
         if '@' in comment:
             for u in self.board.users:
                 # Replace raw @ mentions with markdown formatted mentions
                 # Allow mentioning by name, username, or email
                 if f'@{u.email}' in comment:
                     comment = comment.replace(f'@{u.email}', f'@[{u.email}]({u.id})')
-                    _mentioned.append(u)
+                    inline_mentions.append(u)
                 elif f'@{u.name}' in comment:
                     comment = comment.replace(f'@{u.name}', f'@[{u.name}]({u.id})')
-                    _mentioned.append(u)
+                    inline_mentions.append(u)
                 elif f'@{u.username}' in comment:
                     comment = comment.replace(f'@{u.username}', f'@[{u.username}]({u.id})')
-                    _mentioned.append(u)
-        
+                    inline_mentions.append(u)
+
         # Add additional postfix mentions
         if mentions:
-            mentions = [m for m in mentions if m not in _mentioned]
+            mentions = [m for m in mentions if m not in inline_mentions]
             comment = '\n'.join([comment, *[f"@[{u.name}]({u.id})" for u in mentions or []]])
         return Comment(self.endpoints.createComment(self.id, text=comment)['item'], self.session)
 
     def move(self, list: List, position: Position = 'top') -> Card:
         """Move the card to a new list (default to top of new list)"""
         self.update(
-            listId=list.id, 
-            boardId=list.board.id, 
+            listId=list.id,
+            boardId=list.board.id,
             position=get_position(list.cards, position),
         )
         return self
 
     def duplicate(self, position: Position = 'top', *, name: str | None = None, board: Board | None, lst: List | None) -> Card:
         """Duplicate the card in the current List
-        
+
         Args:
             position (Position): The position to place the new Card in (default: `top`)
             name (str|None): An optional name to give the new Card (default `{name} (copy)`)
-            board: THe Board to duplicate the card to
+            board: The Board to duplicate the card to
             lst: The List to duplicate the card to (if Board is unset, this List's Board will be used)
         """
         position = get_position(self.list.cards, position)
@@ -365,37 +375,37 @@ class Card(PlankaModel[schemas.Card]):
         board = board or lst.board
         return Card(
             self.endpoints.duplicateCard(
-                self.id, 
-                position=position, 
+                self.id,
+                position=position,
                 name=name or f'{self.name} (copy)',
                 boardId=board.id,
                 listId=lst.id,
-            )['item'], 
+            )['item'],
             self.session
         )
 
-    def restore(self, position: Position='top') -> Card:
+    def restore(self, position: Position = 'top') -> Card:
         """Restore the Card from arcive/trash to its previous list"""
         if self.prev_list is not None:
             self.move(self.prev_list, position)
         return self
-    
-    def add_attachment(self, attachment: str | bytes, 
-                       *, 
-                       cover: bool=False, 
-                       download_url: bool=False,
-                       name: str | None=None) -> Attachment:
+
+    def add_attachment(self, attachment: str | bytes,
+                       *,
+                       cover: bool = False,
+                       download_url: bool = False,
+                       name: str | None = None) -> Attachment:
         """Add an Attachment to the card
-        
+
         Args:
             attachment (str | bytes): The URL or raw bytes of the attachment
             cover (bool): Set the new attachment as the cover of the card
             download_url (bool): If a link is used, download the file from the link and attach it (default: `False`)
             name (str | None): The optional name of the attachment (default is `hash() + mimetypes.guess_type(attachment)`)
-            
+
         Returns:
             Attachment
-            
+
         Raises:
             HTTPStatusError: If the url cannot be downloaded
             OSError: If a local file cannot be opened and read
@@ -403,23 +413,23 @@ class Card(PlankaModel[schemas.Card]):
         # Force a PermissionError early if the user isn't a board editor
         if self.session.current_id not in [e.id for e in self.board.editors]:
             self.endpoints.createAttachment(self.id, type='link', url='nourl', name='NO_PERMISSION')
-        
+
         # Deferred import of mimetypes that is only used here
-        # This function takes so long anyways so the import delay 
+        # This function takes so long anyways so the import delay
         # isn't noticable
-        import mimetypes
-        
+        import mimetypes  # noqa: PLC0415
+
         # Handle filepath or URL
         mime_type = None
         extension = '.bin'
         if isinstance(attachment, str):
-            
+
             # Guess URL file type
             if attachment.startswith('http'):
                 mime_type, *_ = mimetypes.guess_type(attachment)
                 mime_type = mime_type or 'application/octet-stream'
                 extension = mimetypes.guess_extension(mime_type) or '.bin'
-                
+
                 # Download the file if requested
                 if download_url:
                     try:
@@ -428,51 +438,51 @@ class Card(PlankaModel[schemas.Card]):
                     except HTTPStatusError as status_error:
                         status_error.add_note(f'Unable to download attachment from {attachment}')
                         raise
-                
+
                 # Attach a link otherwise
                 else:
                     return Attachment(
                         self.endpoints.createAttachment(
-                            self.id, 
-                            type='link', 
-                            url=attachment, 
-                            name=name or f'{name or hash(attachment)}{extension}')['item'], 
+                            self.id,
+                            type='link',
+                            url=attachment,
+                            name=name or f'{name or hash(attachment)}{extension}')['item'],
                         self.session
                     )
-            
+
             # Guess local file type
             # And read Bytes
             else:
                 mime_type, *_ = mimetypes.guess_file_type(attachment)
                 mime_type = mime_type or 'application/octet-stream'
                 attachment = open(attachment, 'rb').read()
-            
+
         mime_type = mime_type or 'application/octet-stream'
         extension = mimetypes.guess_extension(mime_type) or '.bin'
         name = f'{name or hash(attachment)}'
         if not name.endswith(extension):
-            name = f'{name}{extension}'        
+            name = f'{name}{extension}'
         a = Attachment(
             self.endpoints.createAttachment(
-                self.id, 
+                self.id,
                 name=name,
                 type='file',
                 file=bytes(attachment),
-                requestId=str(abs(hash(datetime.now().isoformat()))),
+                requestId=str(abs(hash(datetime.now(tz=self.session.timezone).isoformat()))),
                 mime_type=mime_type,
-            )['item'], 
+            )['item'],
             self.session
         )
         if cover:
             self.cover = a
         return a
 
-    def get_field_values(self, *, with_groups: bool=False) -> dict[str, Any]:
+    def get_field_values(self, *, with_groups: bool = False) -> dict[str, Any]:
         """Get a mapping of CustomFields to CustomFieldValues
-        
+
         Args:
-            with_groups (bool): If set to `True`, 
-                return a nested dict with `{group: {field: value, ...}, ...}`, otherwise `{field: value ...}` (default: `False`)
+            with_groups (bool): If set to `True`,
+            return a nested dict with `{group: {field: value, ...}, ...}`, otherwise `{field: value ...}` (default: `False`)
         """
         if with_groups:
             return {
@@ -485,93 +495,93 @@ class Card(PlankaModel[schemas.Card]):
                 for cfv in self.custom_field_values
             }
 
-    def create_card_field_group(self, name: str, position: Position='top') -> CustomFieldGroup:
+    def create_card_field_group(self, name: str, position: Position = 'top') -> CustomFieldGroup:
         """Create a CustomFieldGroup in the Card
-        
+
         Args:
             name: The name of the group
             position: The position of the new group
         """
         return CustomFieldGroup(
                 self.endpoints.createCardCustomFieldGroup(
-                    self.id, 
-                    name=name, 
-                    position=get_position(self.custom_field_groups, position))['item'], 
+                    self.id,
+                    name=name,
+                    position=get_position(self.custom_field_groups, position))['item'],
                 self.session
             )
 
     def add_card_fields(self, *fields: str,
-                        group: str='Fields', 
-                        position: Position='top') -> CustomFieldGroup:
+                        group: str = 'Fields',
+                        position: Position = 'top') -> CustomFieldGroup:
         """Add fields directly to a Card
-        
+
         Args:
             *fields: Varargs of the Fieldnames to add to the Card
             group: An optional FieldGroup name to add the fields to (default: `Fields`)
             position: The position to add the Card field group at (default: `top`)
-        
+
         Returns:
             CustomFieldGroup
         """
         # Get an existing group if name matches
         cfg = (
-            self.custom_field_groups[{'name': group}].dpop() 
+            self.custom_field_groups[{'name': group}].dpop()
             or self.create_card_field_group(group, position)
         )
         # Add any fields that don't already exist in the Group
         cfg.add_fields(*(set(fields) ^ set(cfg.custom_fields.extract('name'))))
         return cfg
-        
-    def add_member(self, user: User, 
-                   *, 
-                   add_to_board: bool=False, 
-                   role: BoardRole='viewer', 
-                   can_comment: bool=False) -> CardMembership:
+
+    def add_member(self, user: User,
+                   *,
+                   add_to_board: bool = False,
+                   role: BoardRole = 'viewer',
+                   can_comment: bool = False) -> CardMembership:
         """Add a User to the Card
-        
+
         Args:
             user (User): The User to add to the Card
             add_to_board (bool): Add the User to the Board if they are not already a member
             role (BoardRole): If User is added to board, set role (default: `viewer`)
             can_comment (bool): If User is added as a `viewer`, set commenting status (default: `False`)
-        
+
         Note:
-            Default options for adding to Board abide by least privilege so role and comment must be set 
+            Default options for adding to Board abide by least privilege so role and comment must be set.
         """
         # User is already a member
         for membership in self.card_memberships:
             if membership.user == user:
                 return membership
-        
+
         # Add the user to the board
         if user not in self.board.users and add_to_board:
             self.board.add_member(user, role=role, can_comment=can_comment if role == 'viewer' else True)
-        
+
         return CardMembership(self.endpoints.createCardMembership(self.id, userId=user.id)['item'], self.session)
 
     @model_list
-    def add_members(self, users: Sequence[User], 
-                    *, 
-                    add_to_board: bool=False, 
-                    role: BoardRole='viewer', 
-                    can_comment: bool=False) -> list[CardMembership]:
+    def add_members(self, users: Sequence[User],
+                    *,
+                    add_to_board: bool = False,
+                    role: BoardRole = 'viewer',
+                    can_comment: bool = False) -> list[CardMembership]:
         """Add multiple members to a Card
-        
+
         Args:
             users (Sequence[User]): The Users to add to the Card
             add_to_board (bool): Add the User to the Board if they are not already a member
             role (Literal['viewer', 'editor']): If User is added to board, set role (default: `viewer`)
             can_comment (bool): If User is added as a `viewer`, set commenting status (default: `False`)
-        
+
         Note:
             Default options for adding to Board abide by least privilege so role and comment must be set
 
         """
         return [
             self.add_member(
-                user, 
-                add_to_board=add_to_board, 
-                role=role, 
+                user,
+                add_to_board=add_to_board,
+                role=role,
                 can_comment=can_comment,
             )
             for user in users
@@ -579,10 +589,10 @@ class Card(PlankaModel[schemas.Card]):
 
     def remove_member(self, user: User) -> User | None:
         """Remove a User member from the Card
-        
+
         Args:
             user (User): The User to remove
-        
+
         Returns:
             (User | None): The removed User or None if tha User was not a member
         """
@@ -594,16 +604,16 @@ class Card(PlankaModel[schemas.Card]):
     @model_list
     def remove_members(self, users: Sequence[User]) -> list[User]:
         """Remove multiple members from a Card
-        
+
         Args:
             users (Sequence[User]): The Users to remove from the Card
-        
+
         Returns:
             list[User]: The Users that were removed from the card
-            
+
         Note:
-            If a User in the `users` sequence is not a member of the card, 
-            They will be excluded from this list
+            If a User in the `users` sequence is not a member of the card,
+             they will be excluded from this list
         """
         return [
             user
@@ -611,18 +621,18 @@ class Card(PlankaModel[schemas.Card]):
             if self.remove_member(user) is not None
         ]
 
-    def add_label(self, label: Label, 
-                  *, 
-                  add_to_board: bool=False) -> CardLabel:
+    def add_label(self, label: Label,
+                  *,
+                  add_to_board: bool = False) -> CardLabel:
         """Add a Label to the Card
-        
+
         Args:
             label (Label): The Label to add to the card
             add_to_board (bool): If the Label is not in the board, add it (default: `False`)
-        
+
         Returns:
             CardLabel: The CardLabel relationship
-        
+
         Note:
             When using `add_to_board` The label position will default to the top of the label list
         """
@@ -634,37 +644,37 @@ class Card(PlankaModel[schemas.Card]):
         # Handle adding Label if it doesn't exist
         if label not in self.board.labels and add_to_board:
             label = label.add_to_board(self.board)
-        
+
         # Create new CardLabel relationship
         return CardLabel(self.endpoints.createCardLabel(self.id, labelId=label.id)['item'], self.session)
-    
+
     @model_list
-    def add_labels(self, labels: Sequence[Label], 
+    def add_labels(self, labels: Sequence[Label],
                    *,
-                   add_to_board: bool=False) -> list[CardLabel]:
+                   add_to_board: bool = False) -> list[CardLabel]:
         """Add multiple Labels to the Card
-        
+
         Args:
             labels (Sequence[Label]): The Labels to add (must be associated with the card.board)
             add_to_board (bool): If a Label is not in the board, add it (default: `False`)
-        
+
         Returns:
             list[CardLabel]: The added CardLabel relations
-            
+
         Note:
             Any labels that are not on the Card's Board will be skipped
         """
         return [
             self.add_label(
-                label, 
+                label,
                 add_to_board=add_to_board
             )
             for label in labels
         ]
-    
+
     def remove_label(self, label: Label) -> Label | None:
         """Remove the Label from the Card
-        
+
         Args:
             label (Label): The label to remove (must be associated with the Card)
         """
@@ -676,20 +686,20 @@ class Card(PlankaModel[schemas.Card]):
     @model_list
     def remove_labels(self, labels: Sequence[Label]) -> list[Label]:
         """Remove the Label from the Card
-        
+
         Args:
             labels (Sequence[Label]): The labels to remove (must be associated with the Card)
         """
         return [removed for label in labels if (removed := self.remove_label(label))]
 
-    def create_task_list(self, 
-                      *, 
+    def create_task_list(self,
+                      *,
                       name: str,
-                      position: Position | int='top',
-                      show_on_card: bool=False,
-                      hide_completed: bool=False) -> TaskList:
+                      position: Position | int = 'top',
+                      show_on_card: bool = False,
+                      hide_completed: bool = False) -> TaskList:
         """Create a NEW TaskList to the Card
-        
+
         Args:
             name str: Name for the TaskList
             postion (Position | int): The position of the TaskList in the Card (default: `top`)
@@ -697,27 +707,27 @@ class Card(PlankaModel[schemas.Card]):
             hide_completed: bool: Hide completed tasks (default: `False`)
 
         Returns:
-            The TaskList 
+            The TaskList
         """
         return TaskList(
             self.endpoints.createTaskList(
-                self.id, 
-                position=get_position(self.task_lists, position), 
-                name=name, 
-                showOnFrontOfCard=show_on_card, 
+                self.id,
+                position=get_position(self.task_lists, position),
+                name=name,
+                showOnFrontOfCard=show_on_card,
                 hideCompletedTasks=hide_completed,
-            )['item'], 
+            )['item'],
             self.session
         )
 
-    def add_task_list(self, task_list: TaskList, 
-                      *, 
-                      name: str | None=None,
-                      position: Position | int='top',
-                      show_on_card: bool | None=None,
-                      hide_completed: bool | None=None) -> TaskList:
+    def add_task_list(self, task_list: TaskList,
+                      *,
+                      name: str | None = None,
+                      position: Position | int = 'top',
+                      show_on_card: bool | None = None,
+                      hide_completed: bool | None = None) -> TaskList:
         """Add a TaskList to the Card
-        
+
         Args:
             task_list (TaskList): The TaskList to add
             name (str | None): Name override, None will use input name (default: `None`)
@@ -726,18 +736,18 @@ class Card(PlankaModel[schemas.Card]):
             hide_completed: bool | None): Hide Completed override , None will use input hide (default: `None`)
 
         Returns:
-            The TaskList 
+            The TaskList
         """
         return self.create_task_list(
             name=name or task_list.name,
             position=get_position(self.task_lists, position),
             show_on_card=show_on_card or task_list.show_on_front_of_card,
-            hide_completed=hide_completed or task_list.hide_completed_tasks, 
+            hide_completed=hide_completed or task_list.hide_completed_tasks,
         )
-    
+
     def add_location(self, lat: float, lon: float, name: str, position: Position | int) -> CustomFieldGroup:
         """Add a point location to a card as a FieldGroup
-        
+
         Args:
             lat (float): Latitude of the location
             lon (float): Longitude of the location
@@ -759,95 +769,96 @@ class Stopwatch:
     def __init__(self, card: Card) -> None:
         self.card = card
         self.tz = card.session.timezone
-    
+
     @property
     def schema(self):
         return self.card.schema['stopwatch'] or {'startedAt': None, 'total': 0}
-    
+
     @property
     def enabled(self):
         """If the stopwatch is enabled for the card (visible on front)"""
         self.sync()
         return self.card.schema['stopwatch'] is not None
+
     @enabled.setter
     def enabled(self, enabled: bool):
         """Enable/Disable the stopwatch"""
         self.sync()
         self.card.update(stopwatch=self.schema if enabled and not self.enabled else None)
         return self.schema
-            
+
     @property
     def total(self) -> timedelta:
         self.card.sync()
         # Get the stored total seconds
         total = self.schema['total']
-        
-        # If the stopwatch is running, 
+
+        # If the stopwatch is running,
         # compute the time delta in seconds and add to total
-        # The `total` attribute is only incremented when `startedAt` 
+        # The `total` attribute is only incremented when `startedAt`
         # is set to None/null
         if self.is_running:
             now = datetime.now(tz=self.tz)
             total += (now - (self.last_started or now)).total_seconds()
-            
+
         return timedelta(seconds=total)
-    
+
     @total.setter
     def total(self, total: timedelta | int) -> None:
         """Set the total of the stopwatch using seconds or a timedelta"""
         self.update(total=total)
-    
+
     @property
     def last_started(self) -> datetime | None:
         """The time a running stopwatch was started (None if the stopwatch is stopped)"""
         self.card.sync()
         if started := self.schema.get('startedAt'):
             return dtfromiso(started, default_timezone=self.tz)
-    
+
     @property
     def is_running(self) -> bool:
         """If the stopwatch is currently running"""
         return self.last_started is not None
-    
+
     def start(self) -> datetime | None:
         """Start the stopwatch and return the current datetime (None if the stopwatch is started)"""
         if self.is_running:
-           return None
+            return None
         return datetime.now(tz=self.card.session.timezone)
-    
+
     def stop(self) -> datetime | None:
         """Stop a running stopwatch and return the time it was last started"""
         started = self.last_started
         self.update(started_at=None)
         return started
-    
-    def update(self, started_at: datetime | str | None=None, total: timedelta | int | None=None) -> None:
-        """Update the stopwatch"""        
+
+    def update(self, started_at: datetime | str | None = None, total: timedelta | int | None = None) -> None:
+        """Update the stopwatch"""
         current = self.schema
         if started_at:
             current['startedAt'] = str(
-                dttoiso(started_at, default_timezone=self.tz) 
-                if isinstance(started_at, datetime) 
+                dttoiso(started_at, default_timezone=self.tz)
+                if isinstance(started_at, datetime)
                 else started_at
             )
         if total:
-            current['total'] = int(round( # Round seconds
-                total.total_seconds() 
-                if isinstance(total, timedelta) 
+            current['total'] = round(  # Round seconds
+                total.total_seconds()
+                if isinstance(total, timedelta)
                 else total
-            ))
+            )
         self.card.update(stopwatch=current)
-    
+
     def sync(self):
         self.card.sync()
-        
+
     def __repr__(self) -> str:
         return f'Stopwatch(Card({self.card.name}), total={self.total}, running={self.is_running})'
-    
+
     def json(self) -> str:
-        import json
+        import json  # noqa: PLC0415
         return json.dumps(self.schema)
-    
+
 
 from .action import Action
 from .attachment import Attachment

--- a/src/plankapy/v2/models/card.py
+++ b/src/plankapy/v2/models/card.py
@@ -846,6 +846,7 @@ class Stopwatch:
         self.card.update(stopwatch=current)
 
     def sync(self):
+        """Sync the Stopwatch (alias for `self.card.sync()`)"""
         self.card.sync()
 
     def __repr__(self) -> str:

--- a/src/plankapy/v2/models/card_label.py
+++ b/src/plankapy/v2/models/card_label.py
@@ -38,6 +38,11 @@ class CardLabel(PlankaModel[schemas.CardLabel]):
         """When the card-label association was last updated"""
         return dtfromiso(self.schema['updatedAt'], self.session.timezone)
 
+    # Special Methods
+    def sync(self):
+        """Sync the CardLabel with the Planka server"""
+        self.schema = self.card.board.card_labels[self].dpop(default=self).schema
+
     def delete(self):
         """Delete the CardLabel"""
         return self.endpoints.deleteCardLabel(cardId=self.schema['cardId'], labelId=self.schema['labelId'])

--- a/src/plankapy/v2/models/card_label.py
+++ b/src/plankapy/v2/models/card_label.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-__all__ = ('CardLabel', )
-
 from datetime import datetime
 
 from ..api import events, schemas
@@ -10,10 +8,7 @@ from ._helpers import dtfromiso
 
 # Deferred Model imports at bottom of file
 
-TYPE_CHECKING = False
-if TYPE_CHECKING:
-    ...
-    # from models import *
+__all__ = ('CardLabel', )
 
 
 class CardLabel(PlankaModel[schemas.CardLabel]):

--- a/src/plankapy/v2/models/card_label.py
+++ b/src/plankapy/v2/models/card_label.py
@@ -3,18 +3,19 @@ from __future__ import annotations
 __all__ = ('CardLabel', )
 
 from datetime import datetime
+
+from ..api import events, schemas
 from ._base import PlankaModel
 from ._helpers import dtfromiso
-from ..api import schemas, events
 
 # Deferred Model imports at bottom of file
 
 TYPE_CHECKING = False
 if TYPE_CHECKING:
     ...
-    #from models import *
+    # from models import *
 
- 
+
 class CardLabel(PlankaModel[schemas.CardLabel]):
     """Python interface for Planka CardLabels"""
 

--- a/src/plankapy/v2/models/card_membership.py
+++ b/src/plankapy/v2/models/card_membership.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-__all__ = ('CardMembership', )
-
 from datetime import datetime
 
 from ..api import events, schemas
@@ -10,10 +8,7 @@ from ._helpers import dtfromiso
 
 # Deferred Model imports at bottom of file
 
-TYPE_CHECKING = False
-if TYPE_CHECKING:
-    ...
-    # from models import *
+__all__ = ('CardMembership', )
 
 
 class CardMembership(PlankaModel[schemas.CardMembership]):
@@ -31,9 +26,8 @@ class CardMembership(PlankaModel[schemas.CardMembership]):
     @property
     def user(self) -> User:
         """The User who is a member of the Card (Raise LookupError if the User is no longer on the Board)"""
-        usrs = [u for u in self.card.board.users if self.schema['userId'] == u.id]
-        if usrs:
-            return usrs.pop()
+        if usr := self.card.board.users[{'id': self.schema['userId']}].dpop():
+            return usr
         raise LookupError(f"Cannot find User: {self.schema['userId']}")
 
     @property

--- a/src/plankapy/v2/models/card_membership.py
+++ b/src/plankapy/v2/models/card_membership.py
@@ -3,16 +3,17 @@ from __future__ import annotations
 __all__ = ('CardMembership', )
 
 from datetime import datetime
+
+from ..api import events, schemas
 from ._base import PlankaModel
 from ._helpers import dtfromiso
-from ..api import schemas, events
 
 # Deferred Model imports at bottom of file
 
 TYPE_CHECKING = False
 if TYPE_CHECKING:
     ...
-    #from models import *
+    # from models import *
 
 
 class CardMembership(PlankaModel[schemas.CardMembership]):
@@ -21,7 +22,7 @@ class CardMembership(PlankaModel[schemas.CardMembership]):
     __events__ = events.CardMembershipEvent
 
     # CardMembership properties
-    
+
     @property
     def card(self) -> Card:
         """The Card the User is a member of"""
@@ -30,9 +31,9 @@ class CardMembership(PlankaModel[schemas.CardMembership]):
     @property
     def user(self) -> User:
         """The User who is a member of the Card (Raise LookupError if the User is no longer on the Board)"""
-        _usrs = [u for u in self.card.board.users if self.schema['userId'] == u.id]
-        if _usrs:
-            return _usrs.pop()
+        usrs = [u for u in self.card.board.users if self.schema['userId'] == u.id]
+        if usrs:
+            return usrs.pop()
         raise LookupError(f"Cannot find User: {self.schema['userId']}")
 
     @property

--- a/src/plankapy/v2/models/card_membership.py
+++ b/src/plankapy/v2/models/card_membership.py
@@ -40,6 +40,11 @@ class CardMembership(PlankaModel[schemas.CardMembership]):
         """When the card membership was last updated"""
         return dtfromiso(self.schema['updatedAt'], self.session.timezone)
 
+    # Special Methods
+    def sync(self):
+        """Sync the CardMembership with the Planka server"""
+        self.schema = self.card.board.card_memberships[self].dpop(default=self).schema
+
     def delete(self):
         """Delete the CardMembership"""
         return self.endpoints.deleteCardMembership(userId=self.user.id, cardId=self.card.id)

--- a/src/plankapy/v2/models/comment.py
+++ b/src/plankapy/v2/models/comment.py
@@ -3,21 +3,22 @@ from __future__ import annotations
 __all__ = ('Comment', )
 
 from datetime import datetime
+
+from ..api import events, schemas, typ
 from ._base import PlankaModel
 from ._helpers import dtfromiso
-from ..api import schemas, paths, events
 
 # Deferred Model imports at bottom of file
 
 TYPE_CHECKING = False
 if TYPE_CHECKING:
     from typing import Unpack
-    #from models import *
+    # from models import *
 
 
 class Comment(PlankaModel[schemas.Comment]):
     """Python interface for Planka Comments"""
-    
+
     __events__ = events.CommentEvent
 
     # Comment properties
@@ -26,17 +27,17 @@ class Comment(PlankaModel[schemas.Comment]):
     def card(self) -> Card:
         """The Card the Comment belongs to"""
         return Card(self.endpoints.getCard(self.schema['cardId'])['item'], self.session)
-    
+
     @property
     def user(self) -> User:
         """The User who created the Comment"""
         return self.card.board.users[self.schema['userId']]
-    
+
     @property
     def text(self) -> str:
         """Content of the Comment"""
         return self.schema['text']
-    
+
     @property
     def created_at(self) -> datetime:
         """When the comment was created"""
@@ -50,11 +51,11 @@ class Comment(PlankaModel[schemas.Comment]):
     # Special Methods
     def sync(self):
         """Sync the Comment with the Planka server"""
-        _cm = [cm for cm in self.card.comments if cm == self]
-        if _cm:
-            self.schema = _cm.pop().schema
+        cm = [cm for cm in self.card.comments if cm == self]
+        if cm:
+            self.schema = cm.pop().schema
 
-    def update(self, **kwargs: Unpack[paths.Request_updateComments]):
+    def update(self, **kwargs: Unpack[typ.Request_updateComments]):
         """Update the Comment (must be the comment Creator or an Admin)"""
         self.endpoints.updateComments(self.id, **kwargs)
 

--- a/src/plankapy/v2/models/comment.py
+++ b/src/plankapy/v2/models/comment.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
-__all__ = ('Comment', )
-
 from datetime import datetime
+from typing import Unpack
 
 from ..api import events, schemas, typ
 from ._base import PlankaModel
@@ -10,10 +9,7 @@ from ._helpers import dtfromiso
 
 # Deferred Model imports at bottom of file
 
-TYPE_CHECKING = False
-if TYPE_CHECKING:
-    from typing import Unpack
-    # from models import *
+__all__ = ('Comment', )
 
 
 class Comment(PlankaModel[schemas.Comment]):
@@ -51,9 +47,7 @@ class Comment(PlankaModel[schemas.Comment]):
     # Special Methods
     def sync(self):
         """Sync the Comment with the Planka server"""
-        cm = [cm for cm in self.card.comments if cm == self]
-        if cm:
-            self.schema = cm.pop().schema
+        self.schema = self.card.comments[self].dpop(default=self).schema
 
     def update(self, **kwargs: Unpack[typ.Request_updateComments]):
         """Update the Comment (must be the comment Creator or an Admin)"""

--- a/src/plankapy/v2/models/config.py
+++ b/src/plankapy/v2/models/config.py
@@ -1,22 +1,22 @@
 from __future__ import annotations
 
-__all__ = ('Config', )
-
+from ..api import events, schemas
 from ._base import PlankaModel
-from ..api import schemas, events
+
+__all__ = ('Config', )
 
 
 # NOTE: schemas.Config is now used for SMTP Config, App Config is now Bootstrap
 class Config(PlankaModel[schemas.Bootstrap]):
     """Python interface for Planka Config"""
-    
+
     __events__ = events.ConfigEvents
 
     @property
     def version(self) -> str | None:
         """Current version of the PLANKA application"""
         return self.schema.get('version')
-    
+
     @property
     def activeUsersLimit(self) -> int | None:
         """Maximum number of active users allowed (conditionally added for admins if configured)"""

--- a/src/plankapy/v2/models/custom_field.py
+++ b/src/plankapy/v2/models/custom_field.py
@@ -71,6 +71,7 @@ class CustomField(PlankaModel[schemas.CustomField]):
     # Special Methods
     def sync(self):
         """Sync the CustomField with the Planka server"""
+        self.schema = self.custom_field_group.custom_fields[self].dpop(default=self).schema
 
     def update(self, **kwargs: Unpack[typ.Request_updateCustomField]):
         """Update the CustomField"""

--- a/src/plankapy/v2/models/custom_field.py
+++ b/src/plankapy/v2/models/custom_field.py
@@ -1,18 +1,13 @@
 from __future__ import annotations
 
 from datetime import datetime
+from typing import Unpack
 
 from ..api import events, schemas, typ
 from ._base import PlankaModel
 from ._helpers import dtfromiso
 
 # Deferred Model imports at bottom of file
-
-TYPE_CHECKING = False
-if TYPE_CHECKING:
-    from typing import Unpack
-    # from models import *
-
 
 __all__ = ('CustomField', )
 
@@ -25,7 +20,7 @@ class CustomField(PlankaModel[schemas.CustomField]):
     # CustomField props
 
     @property
-    def base_custom_field_group(self) -> BaseCustomFieldGroup:
+    def base_custom_field_group(self) -> BaseCustomFieldGroup | None:
         """The BaseCustomFieldGroup the custom field belongs to"""
         return self.custom_field_group.base_custom_field_group
 

--- a/src/plankapy/v2/models/custom_field.py
+++ b/src/plankapy/v2/models/custom_field.py
@@ -1,41 +1,44 @@
 from __future__ import annotations
 
-__all__ = ('CustomField', )
-
 from datetime import datetime
+
+from ..api import events, schemas, typ
 from ._base import PlankaModel
 from ._helpers import dtfromiso
-from ..api import schemas, paths, events
 
 # Deferred Model imports at bottom of file
 
 TYPE_CHECKING = False
 if TYPE_CHECKING:
     from typing import Unpack
-    from models import *
+    # from models import *
+
+
+__all__ = ('CustomField', )
 
 
 class CustomField(PlankaModel[schemas.CustomField]):
     """Python interface for Planka CustomFields"""
-    
+
     __events__ = events.CustomFieldEvents
 
     # CustomField props
-    
+
     @property
     def base_custom_field_group(self) -> BaseCustomFieldGroup:
         """The BaseCustomFieldGroup the custom field belongs to"""
         return self.custom_field_group.base_custom_field_group
-    
+
     @property
     def custom_field_group(self) -> CustomFieldGroup:
         """The CustomFieldGroup the CustomField belongs to"""
         return CustomFieldGroup(self.endpoints.getCustomFieldGroup(self.schema['customFieldGroupId'])['item'], self.session)
-    
+
     @property
     def position(self) -> int:
         """Position of the CustomField within the CustomFieldGroup"""
         return self.schema['position']
+
     @position.setter
     def position(self, position: int) -> None:
         """Set the position of the CustomField within the CustomFieldGroup"""
@@ -45,6 +48,7 @@ class CustomField(PlankaModel[schemas.CustomField]):
     def name(self) -> str:
         """Name/title of the custom field"""
         return self.schema['name']
+
     @name.setter
     def name(self, name: str) -> None:
         self.update(name=name)
@@ -53,6 +57,7 @@ class CustomField(PlankaModel[schemas.CustomField]):
     def show_on_front_of_card(self) -> bool:
         """Whether to show the CustomField on the front of Cards"""
         return self.schema['showOnFrontOfCard']
+
     @show_on_front_of_card.setter
     def show_on_front_of_card(self, show_on_front_of_card: bool) -> None:
         """Set Wwether to show the CustomField on the front of Cards"""
@@ -72,15 +77,14 @@ class CustomField(PlankaModel[schemas.CustomField]):
     def sync(self):
         """Sync the CustomField with the Planka server"""
 
-    def update(self, **kwargs: Unpack[paths.Request_updateCustomField]):
+    def update(self, **kwargs: Unpack[typ.Request_updateCustomField]):
         """Update the CustomField"""
         self.schema = self.endpoints.updateCustomField(self.id, **kwargs)['item']
-    
+
     def delete(self):
         """Delete the CustomField"""
         self.endpoints.deleteCustomField(self.id)
 
 
 from .base_custom_field_group import BaseCustomFieldGroup
-from .custom_field import CustomField
 from .custom_field_group import CustomFieldGroup

--- a/src/plankapy/v2/models/custom_field_group.py
+++ b/src/plankapy/v2/models/custom_field_group.py
@@ -3,21 +3,22 @@ from __future__ import annotations
 __all__ = ('CustomFieldGroup', )
 
 from datetime import datetime
+
+from ..api import events, schemas, typ
 from ._base import PlankaModel
 from ._helpers import Position, dtfromiso, get_position, model_list
-from ..api import schemas, paths, events
 
 # Deferred Model imports at bottom of file
 
 TYPE_CHECKING = False
 if TYPE_CHECKING:
     from typing import Unpack
-    #from models import *
+    # from models import *
 
 
 class CustomFieldGroup(PlankaModel[schemas.CustomFieldGroup]):
     """Python interface for Planka CustomFieldGroups"""
-    
+
     __events__ = events.CustomFieldGroupEvents
 
     # CustomFieldGroup included
@@ -42,31 +43,33 @@ class CustomFieldGroup(PlankaModel[schemas.CustomFieldGroup]):
     def board(self) -> Board:
         """The Board the CustomFieldGroup belongs to"""
         return Board(self.endpoints.getBoard(self.schema['boardId'])['item'], self.session)
-    
+
     @property
     def card(self) -> Card:
         """The Card the CustomFieldGroup belongs to"""
         return Card(self.endpoints.getCard(self.schema['cardId'])['item'], self.session)
-    
+
     @property
     def base_custom_field_group(self) -> BaseCustomFieldGroup:
         """The BaseCustomFieldGroup used as a template"""
-        _bcfgs = [bcfg for bcfg in self.board.project.base_custom_field_groups if bcfg.id == self.schema['baseCustomFieldGroupId']]
-        return _bcfgs.pop()
-    
+        bcfgs = [bcfg for bcfg in self.board.project.base_custom_field_groups if bcfg.id == self.schema['baseCustomFieldGroupId']]
+        return bcfgs.pop()
+
     @property
     def position(self) -> int:
         """Position of the CustomFieldGroup within the Board/Card"""
         return self.schema['position']
+
     @position.setter
     def position(self, position: int) -> None:
         """Set the CustomFieldGroup position within the Board/Card"""
-        self.update(position=position) 
+        self.update(position=position)
 
     @property
     def name(self) -> str:
         """Name/title of the CustomFieldGroup"""
         return self.schema['name']
+
     @name.setter
     def name(self, name: str) -> None:
         """Set the CustomFieldGroup name"""
@@ -76,7 +79,7 @@ class CustomFieldGroup(PlankaModel[schemas.CustomFieldGroup]):
     def created_at(self) -> datetime:
         """When the CustomFieldGroup was created"""
         return dtfromiso(self.schema['createdAt'], self.session.timezone)
-    
+
     @property
     def updated_at(self) -> datetime:
         """When the CustomFieldGroup was last updated"""
@@ -86,8 +89,8 @@ class CustomFieldGroup(PlankaModel[schemas.CustomFieldGroup]):
     def sync(self):
         """Sync the CustomFieldGroup with the Planka server"""
         self.schema = self.endpoints.getCustomFieldGroup(self.id)['item']
-    
-    def update(self, **kwargs: Unpack[paths.Request_updateCustomFieldGroup]):
+
+    def update(self, **kwargs: Unpack[typ.Request_updateCustomFieldGroup]):
         """Update the CustomFieldGroup"""
         self.schema = self.endpoints.updateCustomFieldGroup(self.id, **kwargs)['item']
 
@@ -97,68 +100,68 @@ class CustomFieldGroup(PlankaModel[schemas.CustomFieldGroup]):
 
     def add_to_card(self, card: Card) -> CustomFieldGroup:
         """Add the CustomFieldGroup to a Card
-        
+
         Args:
             card (Card): The Card to add the CustomFieldGroup to
         """
         # Replace the Current cardId with the ID of the Card we are adding to
-        _schema = self.schema.copy()
-        _schema['cardId'] = card.id
-        return CustomFieldGroup(self.endpoints.createCardCustomFieldGroup(**_schema)['item'], self.session)
-    
+        schema = self.schema.copy()
+        schema['cardId'] = card.id
+        return CustomFieldGroup(self.endpoints.createCardCustomFieldGroup(**schema)['item'], self.session)
+
     def make_base_group(self, project: Project) -> BaseCustomFieldGroup:
         """Convert a CustomFieldGroup into a BaseCustomFieldGroup for a Project or Board
-        
+
         Args:
             project (Project): The project to add the BaseCustomFieldGroup to
-        
+
         Returns:
             BaseCustomFieldGroup: The new BaseCustomFieldGroup
         """
         return BaseCustomFieldGroup(self.endpoints.createBaseCustomFieldGroup(project.id, name=self.name)['item'], self.session)
-    
+
     def add_field(self, name: str,
                   *,
-                  position: Position='top',
-                  show_on_card: bool=False) -> CustomField:
+                  position: Position = 'top',
+                  show_on_card: bool = False) -> CustomField:
         """Add a Field to the CustomFieldGroup
-        
+
         Args:
             name (str): The name of the Field to add
             position (Position): The position of the field within the group (default: `top`)
             show_on_card (bool): Show the field on the Card front (default: `False`)
-        
+
         Returns:
             CustomField: If the Field aleady exists, that Field is returned
         """
         # Return existing field
-        _existing_field = [cf for cf in self.custom_fields if cf.name == name]
-        if _existing_field:
-            return _existing_field.pop()
-        
+        existing_field = [cf for cf in self.custom_fields if cf.name == name]
+        if existing_field:
+            return existing_field.pop()
+
         return CustomField(
             self.endpoints.createCustomFieldInGroup(
                 self.id,
                 name=name,
                 position=get_position(self.custom_fields, position),
-                showOnFrontOfCard=show_on_card, 
+                showOnFrontOfCard=show_on_card,
             )['item'], self.session
         )
-  
+
     def add_fields(self,
                    *names: str,
-                   position: Position='top',
-                   show_on_card: bool=False) -> list[CustomField]:
+                   position: Position = 'top',
+                   show_on_card: bool = False) -> list[CustomField]:
         """Add fields to the CustomFieldGroup
-        
+
         Args:
             *names (str): Varargs of the names to add
             position (Position): The position of the field within the group (default: `top`)
             show_on_card (bool): Show the field on the Card front (default: `False`)
-            
+
         Returns:
             list[CustomField] : The fields added
-            
+
         Note:
             Field positions will be calculated in the order passed
         """
@@ -166,10 +169,10 @@ class CustomFieldGroup(PlankaModel[schemas.CustomFieldGroup]):
             self.add_field(name=name, position=position, show_on_card=show_on_card)
             for name in names
         ]
-  
+
     def remove_field(self, field: CustomField) -> None:
         """Remove the field from the CustomFieldGroup
-        
+
         Args:
             field (CustomField): The CustomField to remove (must be in this Group)
         """

--- a/src/plankapy/v2/models/custom_field_group.py
+++ b/src/plankapy/v2/models/custom_field_group.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
-__all__ = ('CustomFieldGroup', )
-
 from datetime import datetime
+from typing import Unpack
 
 from ..api import events, schemas, typ
 from ._base import PlankaModel
@@ -10,10 +9,7 @@ from ._helpers import Position, dtfromiso, get_position, model_list
 
 # Deferred Model imports at bottom of file
 
-TYPE_CHECKING = False
-if TYPE_CHECKING:
-    from typing import Unpack
-    # from models import *
+__all__ = ('CustomFieldGroup', )
 
 
 class CustomFieldGroup(PlankaModel[schemas.CustomFieldGroup]):
@@ -50,10 +46,9 @@ class CustomFieldGroup(PlankaModel[schemas.CustomFieldGroup]):
         return Card(self.endpoints.getCard(self.schema['cardId'])['item'], self.session)
 
     @property
-    def base_custom_field_group(self) -> BaseCustomFieldGroup:
+    def base_custom_field_group(self) -> BaseCustomFieldGroup | None:
         """The BaseCustomFieldGroup used as a template"""
-        bcfgs = [bcfg for bcfg in self.board.project.base_custom_field_groups if bcfg.id == self.schema['baseCustomFieldGroupId']]
-        return bcfgs.pop()
+        return self.board.project.base_custom_field_groups[{'id': self.schema['baseCustomFieldGroupId']}].dpop()
 
     @property
     def position(self) -> int:
@@ -135,9 +130,8 @@ class CustomFieldGroup(PlankaModel[schemas.CustomFieldGroup]):
             CustomField: If the Field aleady exists, that Field is returned
         """
         # Return existing field
-        existing_field = [cf for cf in self.custom_fields if cf.name == name]
-        if existing_field:
-            return existing_field.pop()
+        if existing_field := self.custom_fields[{'name': name}].dpop():
+            return existing_field
 
         return CustomField(
             self.endpoints.createCustomFieldInGroup(

--- a/src/plankapy/v2/models/custom_field_value.py
+++ b/src/plankapy/v2/models/custom_field_value.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
-__all__ = ('CustomFieldValue', )
-
 from datetime import datetime
+from typing import Unpack
 
 from ..api import events, schemas, typ
 from ._base import PlankaModel
@@ -10,10 +9,7 @@ from ._helpers import dtfromiso
 
 # Deferred Model imports at bottom of file
 
-TYPE_CHECKING = False
-if TYPE_CHECKING:
-    from typing import Unpack
-    # from models import *
+__all__ = ('CustomFieldValue', )
 
 
 class CustomFieldValue(PlankaModel[schemas.CustomFieldValue]):
@@ -36,8 +32,9 @@ class CustomFieldValue(PlankaModel[schemas.CustomFieldValue]):
     @property
     def custom_field(self) -> CustomField:
         """The CustomField the CustomFieldValue belongs to"""
-        cfs = [cf for cf in self.custom_field_group.custom_fields if cf.id == self.schema['customFieldId']]
-        return cfs.pop()
+        cf = self.custom_field_group.custom_fields[{'id': self.schema['customFieldId']}].dpop()
+        assert cf, 'Custom Field not found (this should be unreachable)'
+        return cf
 
     @property
     def content(self) -> str:
@@ -62,9 +59,7 @@ class CustomFieldValue(PlankaModel[schemas.CustomFieldValue]):
     # Special Methods
     def sync(self):
         """Sync the CustomFieldValue with the Planka server"""
-        cfvs = [cfv for cfv in self.card.custom_field_values if cfv.id == self.id]
-        if cfvs:
-            self.schema = cfvs.pop().schema
+        self.schema = self.card.custom_field_values[self].dpop(default=self).schema
 
     def update(self, **kwargs: Unpack[typ.Request_updateCustomFieldValue]):
         """Update the CustomFieldValue"""

--- a/src/plankapy/v2/models/custom_field_value.py
+++ b/src/plankapy/v2/models/custom_field_value.py
@@ -3,21 +3,22 @@ from __future__ import annotations
 __all__ = ('CustomFieldValue', )
 
 from datetime import datetime
+
+from ..api import events, schemas, typ
 from ._base import PlankaModel
 from ._helpers import dtfromiso
-from ..api import schemas, paths, events
 
 # Deferred Model imports at bottom of file
 
 TYPE_CHECKING = False
 if TYPE_CHECKING:
     from typing import Unpack
-    #from models import *
+    # from models import *
 
 
 class CustomFieldValue(PlankaModel[schemas.CustomFieldValue]):
     """Python interface for Planka CustomFieldValues"""
-    
+
     __events__ = events.CustomFieldValueEvents
 
     # CustomFieldValue props
@@ -26,7 +27,7 @@ class CustomFieldValue(PlankaModel[schemas.CustomFieldValue]):
     def card(self) -> Card:
         """The Card the CustomFieldValue belongs to"""
         return Card(self.endpoints.getCard(self.schema['cardId'])['item'], self.session)
-    
+
     @property
     def custom_field_group(self) -> CustomFieldGroup:
         """The CustomFieldGroup the CustomFieldValue belongs to"""
@@ -35,13 +36,14 @@ class CustomFieldValue(PlankaModel[schemas.CustomFieldValue]):
     @property
     def custom_field(self) -> CustomField:
         """The CustomField the CustomFieldValue belongs to"""
-        _cfs = [cf for cf in self.custom_field_group.custom_fields if cf.id == self.schema['customFieldId']]
-        return _cfs.pop()
+        cfs = [cf for cf in self.custom_field_group.custom_fields if cf.id == self.schema['customFieldId']]
+        return cfs.pop()
 
     @property
     def content(self) -> str:
         """Content/value of the custom field"""
         return self.schema['content']
+
     @content.setter
     def content(self, content: str) -> None:
         """Set the content value of the CustomFieldValue"""
@@ -51,7 +53,7 @@ class CustomFieldValue(PlankaModel[schemas.CustomFieldValue]):
     def created_at(self) -> datetime:
         """When the CustomFieldValue was created"""
         return dtfromiso(self.schema['createdAt'], self.session.timezone)
-    
+
     @property
     def updated_at(self) -> datetime:
         """When the CustomFieldValue was last updated"""
@@ -60,18 +62,18 @@ class CustomFieldValue(PlankaModel[schemas.CustomFieldValue]):
     # Special Methods
     def sync(self):
         """Sync the CustomFieldValue with the Planka server"""
-        _cfvs = [cfv for cfv in self.card.custom_field_values if cfv.id == self.id]
-        if _cfvs:
-            self.schema = _cfvs.pop().schema
+        cfvs = [cfv for cfv in self.card.custom_field_values if cfv.id == self.id]
+        if cfvs:
+            self.schema = cfvs.pop().schema
 
-    def update(self, **kwargs: Unpack[paths.Request_updateCustomFieldValue]):
+    def update(self, **kwargs: Unpack[typ.Request_updateCustomFieldValue]):
         """Update the CustomFieldValue"""
         self.schema = self.endpoints.updateCustomFieldValue(
             cardId=self.schema['cardId'],
             customFieldGroupId=self.schema['customFieldGroupId'],
             customFieldId=self.schema['customFieldId'],
             **kwargs)['item']
-    
+
     def delete(self):
         """Delete the CustomFieldValue"""
         self.endpoints.deleteCustomFieldValue(

--- a/src/plankapy/v2/models/label.py
+++ b/src/plankapy/v2/models/label.py
@@ -1,37 +1,41 @@
 from __future__ import annotations
 
-__all__ = ('Label', )
-
 from datetime import datetime
 from random import choice
+
+from ..api import events, schemas, typ
 from ._base import PlankaModel
 from ._helpers import Position, dtfromiso, get_position, model_list
-from ..api import schemas, paths, events
 from ._literals import LabelColors
 
 # Deferred Model imports at bottom of file
 
 TYPE_CHECKING = False
 if TYPE_CHECKING:
-    from typing import Unpack, Literal
-    #from models import *
+    from typing import Literal, Unpack
+
+    # from models import *
     from ._literals import LabelColor
+
+
+__all__ = ('Label', )
 
 
 class Label(PlankaModel[schemas.Label]):
     """Python interface for Planka Labels"""
-    
+
     __events__ = events.LabelEvents
 
     @property
     def board(self) -> Board:
         """The Board the Label belongs to"""
         return Board(self.endpoints.getBoard(self.schema['boardId'])['item'], self.session)
-    
+
     @property
     def position(self) -> int:
         """Position of the Label within the Board"""
         return self.schema['position']
+
     @position.setter
     def position(self, position: int) -> None:
         """Set the position of the Label within the Board"""
@@ -41,38 +45,40 @@ class Label(PlankaModel[schemas.Label]):
     def name(self) -> str:
         """Name/title of the Label"""
         return self.schema['name']
+
     @name.setter
     def name(self, name: str) -> None:
         """Set the name/title of the Label"""
         self.update(name=name)
 
     @property
-    def color(self) -> LabelColor: 
+    def color(self) -> LabelColor:
         """Color of the label"""
         return self.schema['color']
+
     @color.setter
-    def color(self, color: LabelColor|Literal['random']) -> None:
+    def color(self, color: LabelColor | Literal['random']) -> None:
         """Set the Label color"""
-        self.update(color=color if color != 'random' else choice(LabelColors))
+        self.update(color=color if color != 'random' else choice(LabelColors))  # noqa: S311
 
     @property
     def created_at(self) -> datetime:
         """When the label was created"""
         return dtfromiso(self.schema['createdAt'], self.session.timezone)
-    
+
     @property
     def updated_at(self) -> datetime:
         """When the label was last updated"""
         return dtfromiso(self.schema['updatedAt'], self.session.timezone)
-    
+
     # Special Methods
     def sync(self):
         """Sync the Label with the Planka server"""
-        _lbls = [l for l in self.board.labels if l == self]
-        if _lbls:
-            self.schema = _lbls.pop().schema
+        lbls = [lbl for lbl in self.board.labels if lbl == self]
+        if lbls:
+            self.schema = lbls.pop().schema
 
-    def update(self, **kwargs: Unpack[paths.Request_updateLabel]):
+    def update(self, **kwargs: Unpack[typ.Request_updateLabel]):
         """Update the Label"""
         self.schema = self.endpoints.updateLabel(self.id, **kwargs)['item']
 
@@ -80,43 +86,43 @@ class Label(PlankaModel[schemas.Label]):
         """Delete the Label"""
         return self.endpoints.deleteLabel(self.id)
 
-    def add_to_board(self, board: Board, 
-                     *, 
-                     position: Position='top',
-                     color: LabelColor|None=None) -> Label:
+    def add_to_board(self, board: Board,
+                     *,
+                     position: Position = 'top',
+                     color: LabelColor | None = None) -> Label:
         """Add the Label to a Board or return a matching Label from the Board.
-        
+
         Args:
             board (Board): The Board to add the Label to
             position (Position): The position of the Label within the Board (default: `top`)
             color (LabelColor | None): Optionally change the LabelColor in the new Board
-        
+
         Returns:
             Label: The new Label or the matching Label (same color and name)
-        
+
         Note:
-            Matching is determines by name and color, if a Label matches on the board, but a color 
-            override is set, a new label will be created. If the label is already on the board, the 
-            input label is returned
+            Matching is determines by name and color, if a Label matches on the board, but a color
+             override is set, a new label will be created. If the label is already on the board, the
+             input label is returned
         """
         # Don't re-add label to same board
         if board == self.board:
             return self
-        
+
         # Don't add the Label if one with matching name and color exists
         # If a color override is set, allow the creation of a new label
         for lbl in board.labels:
             if (lbl.name, lbl.color) == (self.name, self.color) and color == self.color:
                 return lbl
-        
-        _schema = self.schema.copy()
-        _schema['boardId'] = board.id
-        _schema['position'] = get_position(board.labels, position)
-        
+
+        schema = self.schema.copy()
+        schema['boardId'] = board.id
+        schema['position'] = get_position(board.labels, position)
+
         # Update color
         if color is not None:
-            _schema['color'] = color
-        return Label(self.endpoints.createLabel(**_schema)['item'], self.session)
+            schema['color'] = color
+        return Label(self.endpoints.createLabel(**schema)['item'], self.session)
 
     @model_list
     def get_cards(self) -> list[Card]:

--- a/src/plankapy/v2/models/label.py
+++ b/src/plankapy/v2/models/label.py
@@ -32,7 +32,7 @@ class Label(PlankaModel[schemas.Label]):
     @position.setter
     def position(self, position: int) -> None:
         """Set the position of the Label within the Board"""
-        self.update()
+        self.update(position=position)
 
     @property
     def name(self) -> str:

--- a/src/plankapy/v2/models/label.py
+++ b/src/plankapy/v2/models/label.py
@@ -1,22 +1,15 @@
 from __future__ import annotations
 
 from datetime import datetime
-from random import choice
+from secrets import choice
+from typing import Literal, Unpack
 
 from ..api import events, schemas, typ
 from ._base import PlankaModel
 from ._helpers import Position, dtfromiso, get_position, model_list
-from ._literals import LabelColors
+from ._literals import LabelColor, LabelColors
 
 # Deferred Model imports at bottom of file
-
-TYPE_CHECKING = False
-if TYPE_CHECKING:
-    from typing import Literal, Unpack
-
-    # from models import *
-    from ._literals import LabelColor
-
 
 __all__ = ('Label', )
 
@@ -59,7 +52,7 @@ class Label(PlankaModel[schemas.Label]):
     @color.setter
     def color(self, color: LabelColor | Literal['random']) -> None:
         """Set the Label color"""
-        self.update(color=color if color != 'random' else choice(LabelColors))  # noqa: S311
+        self.update(color=color if color != 'random' else choice(LabelColors))
 
     @property
     def created_at(self) -> datetime:
@@ -74,9 +67,7 @@ class Label(PlankaModel[schemas.Label]):
     # Special Methods
     def sync(self):
         """Sync the Label with the Planka server"""
-        lbls = [lbl for lbl in self.board.labels if lbl == self]
-        if lbls:
-            self.schema = lbls.pop().schema
+        self.schema = self.board.labels[self].dpop(default=self).schema
 
     def update(self, **kwargs: Unpack[typ.Request_updateLabel]):
         """Update the Label"""

--- a/src/plankapy/v2/models/list_.py
+++ b/src/plankapy/v2/models/list_.py
@@ -1,12 +1,18 @@
 from __future__ import annotations
 
-__all__ = ('List', )
-
 from datetime import datetime, timedelta
 from random import choice, shuffle
+
+from ..api import events, schemas, typ
 from ._base import PlankaModel
-from ._helpers import Position, dtfromiso, dttoiso, get_position, model_list, POSITION_GAP
-from ..api import schemas, paths, events
+from ._helpers import (
+    POSITION_GAP,
+    Position,
+    dtfromiso,
+    dttoiso,
+    get_position,
+    model_list,
+)
 from ._literals import ListColors
 
 # Deferred Model imports at bottom of file
@@ -14,51 +20,55 @@ from ._literals import ListColors
 TYPE_CHECKING = False
 if TYPE_CHECKING:
     from collections.abc import Callable, Sequence
-    from typing import Unpack, Literal, Any
-    #from models import *
-    from ._literals import UserListType, ListColor, CardType
+    from typing import Any, Literal, Unpack
+
+    # from models import *
+    from ._literals import CardType, ListColor, UserListType
+
+
+__all__ = ('List', )
 
 
 class List(PlankaModel[schemas.List]):
     """Python interface for Planka Lists"""
-    
+
     __events__ = events.ListEvents
 
     # List Included
     @property
     def _included(self):
         return self.endpoints.getList(self.id)['included']
-    
+
     @property
     @model_list
     def users(self) ->  list[User]:
         """Users associated with the List"""
         return [User(u, self.session) for u in self._included['users']]
-    
+
     @property
     @model_list
     def cards(self) -> list[Card]:
         """Cards associated with the List"""
         return [Card(c, self.session) for c in self._included['cards']]
-    
+
     @property
     @model_list
     def card_memberships(self) -> list[CardMembership]:
         """CardMemberships associated with the List"""
         return [CardMembership(cm, self.session) for cm in self._included['cardMemberships']]
-    
+
     @property
     @model_list
     def card_labels(self) -> list[CardLabel]:
         """CardLabels associated with the List"""
         return [CardLabel(cl, self.session) for cl in self._included['cardLabels']]
-    
+
     @property
     @model_list
     def task_lists(self) -> list[TaskList]:
         """TaskLists associated with the List"""
         return [TaskList(tl, self.session) for tl in self._included['taskLists']]
-    
+
     @property
     @model_list
     def tasks(self) ->  list[Task]:
@@ -94,18 +104,19 @@ class List(PlankaModel[schemas.List]):
     def board(self) -> Board:
         """The Board the List belongs to"""
         return Board(self.endpoints.getBoard(self.schema['boardId'])['item'], self.session)
-    
+
     @property
-    def type(self): 
+    def type(self):
         """Type/status of the list"""
         return self.schema['type']
+
     @type.setter
     # ['archive', 'trash'] are system types and cannot be set
     def type(self, type: UserListType) -> None:
         """Set the List type"""
         self.update(type=type)
-    
-    @property 
+
+    @property
     def position(self) -> int:
         """Position of the List within the Board"""
         return self.schema['position']
@@ -114,53 +125,54 @@ class List(PlankaModel[schemas.List]):
     def name(self) -> str:
         """Name/title of the List"""
         return self.schema['name']
-    
+
     @property
     def color(self) -> ListColor:
         """Color for the List"""
         return self.schema['color']
+
     @color.setter
     def color(self, color: ListColor | Literal['random'] | None) -> None:
         """Set the List color"""
         if color == 'random':
-            color = choice(ListColors)
+            color = choice(ListColors)  # noqa: S311
         self.update(color=color)
 
-    @property    
+    @property
     def created_at(self) -> datetime:
         """When the List was created"""
         return dtfromiso(self.schema['createdAt'], self.session.timezone)
-    
+
     @property
     def updated_at(self) -> datetime:
         """When the List was last updated"""
         return dtfromiso(self.schema['updatedAt'], self.session.timezone)
-    
+
     # Special Methods
     def sync(self):
         """Sync the List with the Planka server"""
         self.schema = self.endpoints.getList(self.id)['item']
-    
-    def update(self, **list: Unpack[paths.Request_updateList]):
+
+    def update(self, **list: Unpack[typ.Request_updateList]):
         """Update the List"""
         self.endpoints.updateList(self.id, **list)
-    
+
     def delete(self):
         """Delete the List"""
         return self.endpoints.deleteList(self.id)
 
-    def create_card(self, 
+    def create_card(self,
                     *,
                     name: str,
-                    position: Position='bottom',
-                    type: CardType='project',
-                    description: str|None=None,
-                    due_date: datetime|None=None,
-                    due_date_completed: bool=False,
-                    stopwatch_duration: timedelta|None=None,
-                    stopwatch_started: datetime|Literal['now']|None=None) -> Card:
+                    position: Position = 'bottom',
+                    type: CardType = 'project',
+                    description: str | None = None,
+                    due_date: datetime | None = None,
+                    due_date_completed: bool = False,
+                    stopwatch_duration: timedelta | None = None,
+                    stopwatch_started: datetime | Literal['now'] | None = None) -> Card:
         """Create a new card in the List
-        
+
         Args:
             name: The name of the Card
             position: The position of the card within the List
@@ -172,7 +184,7 @@ class List(PlankaModel[schemas.List]):
             stopwatch_started: The start time for the runnung stopwatch (None is paused)
 
         """
-        args: paths.Request_createCard = {
+        args: typ.Request_createCard = {
             'name': name,
             'position': get_position(self.cards, position),
             'type': type
@@ -195,26 +207,26 @@ class List(PlankaModel[schemas.List]):
                 else:
                     t = dttoiso(stopwatch_started, default_timezone=self.session.timezone)
                 args['stopwatch']['startedAt'] = t
-        
+
         return Card(
-            self.endpoints.createCard(\
-                self.id, 
-                **args)['item'], 
+            self.endpoints.createCard(
+                self.id,
+                **args)['item'],
                 self.session
             )
-    
+
     @model_list
-    def sort_cards(self, **kwargs: Unpack[paths.Request_sortList]) -> list[Card]:
+    def sort_cards(self, **kwargs: Unpack[typ.Request_sortList]) -> list[Card]:
         """Sort all cards in the List and return the sorted Cards"""
         return [Card(c, self.session) for c in self.endpoints.sortList(self.id, **kwargs)['included']['cards']]
-    
+
     @model_list
     def archive_cards(self) -> list[Card]:
         """Move all cards in the List to the Board archive"""
         return [
             Card(c, self.session)
             for c in self.endpoints.moveListCards(
-                self.id, 
+                self.id,
                 listId=self.board.archive_list.id
                 )['included']['cards']
         ]
@@ -222,9 +234,9 @@ class List(PlankaModel[schemas.List]):
     def delete_cards(self) -> None:
         """Delete all Cards in the List (must be a trash list)"""
         self.endpoints.clearList(self.id)['item']
-    
+
     @model_list
-    def move_cards(self, list: List, position: Position='top') -> list[Card]:
+    def move_cards(self, list: List, position: Position = 'top') -> list[Card]:
         """Move all Cards in this List to another List"""
         cards = self.cards
         for c in self.cards:
@@ -237,20 +249,20 @@ class List(PlankaModel[schemas.List]):
         cards = self.cards
         shuffle(cards)
         for pos, card in enumerate(cards, start=1):
-            card.position = pos*POSITION_GAP
+            card.position = pos * POSITION_GAP
         return cards
 
     @model_list
-    def sort(self, key: Callable[[Card], Any]|None=None, reverse: bool=False) -> list[Card]:
+    def sort(self, key: Callable[[Card], Any] | None = None, reverse: bool = False) -> list[Card]:
         """Sort the list using a sort function
-        
+
         Args:
             key: The sorting function to use (default is `card.name`)
             reverse: Reverse the sort order
-        
+
         Note:
-            If sorting on fields that may have comparison errors (e.g. `due_date`) 
-            make sure your sort key properly accounts for that: 
+            If sorting on fields that may have comparison errors (e.g. `due_date`)
+             make sure your sort key properly accounts for that:
             ```python
             >>> lst.sort(lambda c: c.due_date)
             Exception ... # Can't compare NoneType and datetime
@@ -263,23 +275,25 @@ class List(PlankaModel[schemas.List]):
             ```
         """
         if key is None:
-            key = lambda c: c.name
+            def _key(c: Card):
+                return c.name
+            key = _key
         cards = self.cards
         cards.sort(key=key, reverse=reverse)
         for pos, card in enumerate(cards, start=1):
-            card.position = pos*POSITION_GAP
+            card.position = pos * POSITION_GAP
         return cards
 
     @model_list
-    def filter(self, 
+    def filter(self,
                *,
-               search: str|None=None,
-               users: User|Sequence[User]|None=None,
-               labels: Label|Sequence[Label]|None=None,
-               card_before: Card|None=None,
-               changed_before: datetime|None=None) -> list[Card]:
+               search: str | None = None,
+               users: User | Sequence[User] | None = None,
+               labels: Label | Sequence[Label] | None = None,
+               card_before: Card | None = None,
+               changed_before: datetime | None = None) -> list[Card]:
         """Apply a filter to the list
-        
+
         Args:
             search: A search term to apply to the cards
             users: A list of Users to filter the cards by
@@ -287,7 +301,7 @@ class List(PlankaModel[schemas.List]):
             card_before: Limit filter to only cards before this card
             changed_before: A time filter that filters on `list_changed_at`
         """
-        
+
         kwargs: dict[str, Any] = {}
         if search:
             kwargs['search'] = search
@@ -298,21 +312,21 @@ class List(PlankaModel[schemas.List]):
         if labels:
             if isinstance(labels, Label):
                 labels = [labels]
-            kwargs['labelIds '] = ','.join(l.id for l in labels)
+            kwargs['labelIds '] = ','.join(lbl.id for lbl in labels)
         if card_before:
             kwargs['before_id'] = card_before.id
         if changed_before:
             kwargs['before_listChangedAt'] = dttoiso(changed_before, default_timezone=self.session.timezone)
-            
+
         return [
-            Card(c, self.session) 
+            Card(c, self.session)
             for c in self.endpoints.getCards(
-                self.id, 
+                self.id,
                 **kwargs,
             )['items']
         ]
-    
-        
+
+
 from .attachment import Attachment
 from .board import Board
 from .card import Card

--- a/src/plankapy/v2/models/list_.py
+++ b/src/plankapy/v2/models/list_.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
+from collections.abc import Callable, Sequence
 from datetime import datetime, timedelta
-from random import choice, shuffle
+from random import shuffle
+from secrets import choice
+from typing import Any, Literal, Unpack
 
 from ..api import events, schemas, typ
 from ._base import PlankaModel
@@ -13,18 +16,9 @@ from ._helpers import (
     get_position,
     model_list,
 )
-from ._literals import ListColors
+from ._literals import CardType, ListColor, ListColors, UserListType
 
 # Deferred Model imports at bottom of file
-
-TYPE_CHECKING = False
-if TYPE_CHECKING:
-    from collections.abc import Callable, Sequence
-    from typing import Any, Literal, Unpack
-
-    # from models import *
-    from ._literals import CardType, ListColor, UserListType
-
 
 __all__ = ('List', )
 
@@ -135,7 +129,7 @@ class List(PlankaModel[schemas.List]):
     def color(self, color: ListColor | Literal['random'] | None) -> None:
         """Set the List color"""
         if color == 'random':
-            color = choice(ListColors)  # noqa: S311
+            color = choice(ListColors)
         self.update(color=color)
 
     @property

--- a/src/plankapy/v2/models/notification.py
+++ b/src/plankapy/v2/models/notification.py
@@ -3,101 +3,104 @@ from __future__ import annotations
 __all__ = ('Notification', )
 
 from datetime import datetime
+
+from ..api import events, schemas, typ
 from ._base import PlankaModel
 from ._helpers import dtfromiso, model_list
-from ..api import schemas, paths, events
 
 # Deferred Model imports at bottom of file
 
 TYPE_CHECKING = False
 if TYPE_CHECKING:
     from typing import Any, Unpack
-    #from models import *
+
+    # from models import *
     from ._literals import NotificationType
 
 
 class Notification(PlankaModel[schemas.Notification]):
     """Python interface for Planka Notifications"""
-    
+
     __events__ = events.NotificationEvents
 
     # Notification included
     @property
     def _included(self):
         return self.endpoints.getNotification(self.id)['included']
-    
+
     @property
     @model_list
     def users(self) -> list[User]:
         """All Users associated with the Notification"""
         return [User(u, self.session) for u in self._included['users']]
-    
+
     # Notification props
     @property
     def user(self) -> User:
         """The User who receives the Notification"""
         return [u for u in self.users if self.schema['userId'] == u.id].pop()
-    
+
     @property
     def creator(self) -> User:
         """The User who created the Notification"""
         return [u for u in self.users if self.schema['creatorUserId'] == u.id].pop()
-        
+
     @property
     def board(self) -> Board:
         """The Board associated with the Notification (denormalized)"""
         return Board(self.endpoints.getBoard(self.schema['boardId'])['item'], self.session)
-    
+
     @property
     def card(self) -> Card:
         """The Card associated with the Notification"""
         return Card(self.endpoints.getCard(self.schema['cardId'])['item'], self.session)
-    
+
     @property
     def comment(self) -> Comment:
         """The Comment associated with the Notification"""
         return [c for c in self.card.comments if c.id == self.schema['commentId']].pop()
-    
+
     @property
     def action(self) -> Action:
         """The Action associated with the Notification"""
         return [a for a in self.card.actions if a.id == self.schema['actionId']].pop()
-        
+
     @property
     def type(self) -> NotificationType:
         """Type of the Notification"""
         return self.schema['type']
-    
+
     @property
     def data(self) -> dict[str, Any]:
         """Notification specific data (varies by type)"""
         return self.schema['data']
-        
+
     @property
     def is_read(self) -> bool:
         """Whether the Notification has been read"""
         return self.schema['isRead']
+
     @is_read.setter
     def is_read(self, is_read: bool) -> None:
         """Set the read status of the Notification"""
         self.update(isRead=is_read)
-    
+
     @property
     def created_at(self) -> datetime:
         """When the Notification was created"""
         return dtfromiso(self.schema['createdAt'], self.session.timezone)
-    
+
     @property
     def updated_at(self) -> datetime:
         """When the Notification was last updated"""
         return dtfromiso(self.schema['updatedAt'], self.session.timezone)
-    
+
     # Special Methods
     def sync(self):
         """Sync the Notification with the Planka server"""
         self.schema = self.endpoints.getNotification(self.id)['item']
- 
-    def update(self, **kwargs: Unpack[paths.Request_updateNotification]) -> None:
+
+    def update(self, **kwargs: Unpack[typ.Request_updateNotification]) -> None:
         """Update the Notification"""
         self.schema = self.endpoints.updateNotification(self.id, **kwargs)['item']
 

--- a/src/plankapy/v2/models/notification.py
+++ b/src/plankapy/v2/models/notification.py
@@ -1,21 +1,16 @@
 from __future__ import annotations
 
-__all__ = ('Notification', )
-
 from datetime import datetime
+from typing import Any, Unpack
 
 from ..api import events, schemas, typ
 from ._base import PlankaModel
 from ._helpers import dtfromiso, model_list
+from ._literals import NotificationType
 
 # Deferred Model imports at bottom of file
 
-TYPE_CHECKING = False
-if TYPE_CHECKING:
-    from typing import Any, Unpack
-
-    # from models import *
-    from ._literals import NotificationType
+__all__ = ('Notification', )
 
 
 class Notification(PlankaModel[schemas.Notification]):

--- a/src/plankapy/v2/models/notification_service.py
+++ b/src/plankapy/v2/models/notification_service.py
@@ -1,20 +1,14 @@
 from __future__ import annotations
 
 from datetime import datetime
+from typing import Unpack
 
 from ..api import events, schemas, typ
 from ._base import PlankaModel
 from ._helpers import dtfromiso
+from ._literals import NotificationServiceFormat
 
 # Deferred Model imports at bottom of file
-
-TYPE_CHECKING = False
-if TYPE_CHECKING:
-    from typing import Unpack
-
-    # from models import *
-    from ._literals import NotificationServiceFormat
-
 
 __all__ = ('NotificationService', )
 
@@ -69,9 +63,7 @@ class NotificationService(PlankaModel[schemas.NotificationService]):
     # Special Methods
     def sync(self):
         """Sync the NotificationService with the Planka server"""
-        nss = [ns for ns in self.board.project.notification_services if ns == self]
-        if nss:
-            self.schema = nss.pop().schema
+        self.schema = self.board.project.notification_services[self].dpop(default=self).schema
 
     def update(self, **kwargs: Unpack[typ.Request_updateNotificationService]):
         """Update the NotificationService"""

--- a/src/plankapy/v2/models/notification_service.py
+++ b/src/plankapy/v2/models/notification_service.py
@@ -1,33 +1,36 @@
 from __future__ import annotations
 
-__all__ = ('NotificationService', )
-
 from datetime import datetime
+
+from ..api import events, schemas, typ
 from ._base import PlankaModel
 from ._helpers import dtfromiso
-from ..api import schemas, paths, events
 
 # Deferred Model imports at bottom of file
 
 TYPE_CHECKING = False
 if TYPE_CHECKING:
     from typing import Unpack
-    #from models import *
+
+    # from models import *
     from ._literals import NotificationServiceFormat
+
+
+__all__ = ('NotificationService', )
 
 
 class NotificationService(PlankaModel[schemas.NotificationService]):
     """Python interface for Planka NotificationServices"""
-    
+
     __events__ = events.NotificationServiceEvents
 
     # NotificationService props
-    
+
     @property
     def user(self) -> User:
         """The User the NotificationService is associated with"""
         return [u for u in self.board.users if self.schema['userId'] == u.id].pop()
-    
+
     @property
     def board(self) -> Board:
         """The Board the NotificationService is associated with"""
@@ -37,20 +40,22 @@ class NotificationService(PlankaModel[schemas.NotificationService]):
     def url(self) -> str:
         """URL endpoint for Notifications"""
         return self.schema['url']
+
     @url.setter
     def url(self, url: str) -> None:
         """Set the NotificationService url"""
         self.update(url=url)
-    
+
     @property
-    def format(self) -> NotificationServiceFormat: 
+    def format(self) -> NotificationServiceFormat:
         """Format for notification messages"""
         return self.schema['format']
+
     @format.setter
     def format(self, format: NotificationServiceFormat) -> None:
         """Set the NotificationService format"""
         self.update(format=format)
-    
+
     @property
     def created_at(self) -> datetime:
         """When the NotificationService was created"""
@@ -60,18 +65,18 @@ class NotificationService(PlankaModel[schemas.NotificationService]):
     def updated_at(self) -> datetime:
         """When the NotificationService was last updated"""
         return dtfromiso(self.schema['updatedAt'], self.session.timezone)
-    
+
     # Special Methods
     def sync(self):
         """Sync the NotificationService with the Planka server"""
-        _nss = [ns for ns in self.board.project.notification_services if ns == self]
-        if _nss:
-            self.schema = _nss.pop().schema
-        
-    def update(self, **kwargs: Unpack[paths.Request_updateNotificationService]):
+        nss = [ns for ns in self.board.project.notification_services if ns == self]
+        if nss:
+            self.schema = nss.pop().schema
+
+    def update(self, **kwargs: Unpack[typ.Request_updateNotificationService]):
         """Update the NotificationService"""
         self.schema = self.endpoints.updateNotificationService(self.id, **kwargs)['item']
-    
+
     def delete(self):
         """Delete the NotificationService"""
         self.endpoints.deleteNotificationService(self.id)

--- a/src/plankapy/v2/models/project.py
+++ b/src/plankapy/v2/models/project.py
@@ -1,99 +1,104 @@
 from __future__ import annotations
 
-__all__ = ('Project', )
-
-from pathlib import Path
-from httpx import HTTPStatusError
 from datetime import datetime
+from pathlib import Path
+
+from httpx import HTTPStatusError
+
+from ..api import events, schemas, typ
 from ._base import PlankaModel
 from ._helpers import Position, dtfromiso, get_position, model_list
-from ..api import schemas, paths, events
 
 # Deferred Model imports at bottom of file
 
 TYPE_CHECKING = False
 if TYPE_CHECKING:
     from typing import Unpack
-    #from models import *
+
+    # from models import *
     from ._literals import BackgroundGradient, BackgroundType, BoardImportType
+
+
+__all__ = ('Project', )
 
 
 class Project(PlankaModel[schemas.Project]):
     """Python interface for Planka Projects"""
-    
+
     __events__ = events.ProjectEvents
 
     # Project Included
-    
+
     @property
     def _included(self):
         return self.endpoints.getProject(self.id)['included']
-    
+
     @property
     @model_list
     def users(self) -> list[User]:
         """Get Users associated with the Project"""
         return [User(u, self.session) for u in self._included['users']]
-    
+
     @property
     @model_list
     def project_managers(self) -> list[ProjectManager]:
         """Get project manager Users associated with the Project"""
         return [ProjectManager(pm, self.session) for pm in self._included['projectManagers']]
-    
+
     @property
     @model_list
     def background_images(self) -> list[BackgroundImage]:
         """Get BackgroundImages associated with the Project"""
         return [BackgroundImage(bgi, self.session) for bgi in self._included['backgroundImages']]
-    
+
     @property
     @model_list
     def base_custom_field_groups(self) -> list[BaseCustomFieldGroup]:
         """Get BaseCustomFieldGroups associated with the Project"""
         return [BaseCustomFieldGroup(bcfg, self.session) for bcfg in self._included['baseCustomFieldGroups']]
-    
+
     @property
     @model_list
     def boards(self) -> list[Board]:
         """Get Boards associated with the Project"""
         return [Board(b, self.session) for b in self._included['boards']]
-    
+
     @property
     @model_list
     def board_memberships(self) -> list[BoardMembership]:
         """Get BoardMemberships associated with the Project"""
         return [BoardMembership(bm, self.session) for bm in self._included['boardMemberships']]
-    
+
     @property
     @model_list
     def custom_fields(self) -> list[CustomField]:
         """Get CustomFields associated with the Project"""
         return [CustomField(cf, self.session) for cf in self._included['customFields']]
-    
+
     @property
     @model_list
     def notification_services(self) -> list[NotificationService]:
         """Get NotificationServices associated with the Project"""
         return [NotificationService(ns, self.session) for ns in self._included['notificationServices']]
-    
+
     # Project Properties
     @property
     def favorite(self) -> bool:
         """Whether the project is in the current User's favorites"""
         return self.endpoints.getProject(self.id)['item'].get('isFavorite', False)
+
     @favorite.setter
     def favorite(self, is_favorite: bool) -> None:
         """Set/Unset the Project in the current User's favorites"""
         self.update(isFavorite=is_favorite)
-        
+
     @property
     def owner(self) -> User | None:
         """The User who owns the project (Raises LookupError if the User cannot be found)"""
-        _usrs = [pm for pm in self.project_managers if self.schema['ownerProjectManagerId'] == pm.id]
-        if _usrs:
-            return _usrs.pop().user
-        #return User(self.endpoints.getUser(self.schema['ownerProjectManagerId'])['item'], self.session)
+        usrs = [pm for pm in self.project_managers if self.schema['ownerProjectManagerId'] == pm.id]
+        if usrs:
+            return usrs.pop().user
+        # return User(self.endpoints.getUser(self.schema['ownerProjectManagerId'])['item'], self.session)
 
     @property
     def background_image(self) -> BackgroundImage | None:
@@ -102,6 +107,7 @@ class Project(PlankaModel[schemas.Project]):
         if not bgis:
             return None
         return bgis.pop()
+
     @background_image.setter
     def background_image(self, background_image: BackgroundImage | None) -> None:
         """Set the Project BackgroundImage"""
@@ -109,38 +115,42 @@ class Project(PlankaModel[schemas.Project]):
             self.remove_background()
         else:
             self.update(backgroundImageId=background_image.id, backgroundType='image')
-    
+
     @property
     def name(self) -> str:
         """Name/title of the Project"""
         return self.schema['name']
+
     @name.setter
     def name(self, name: str) -> None:
         """Set the Project name"""
         self.update(name=name)
-        
+
     @property
     def description(self) -> str:
         """Detailed description of the Project"""
         return self.schema['description']
+
     @description.setter
     def description(self, description: str) -> None:
         """Set the Project description"""
         self.update(description=description)
-    
+
     @property
     def background_type(self):
         """Type of background for the project"""
         return self.schema['backgroundType']
+
     @background_type.setter
     def background_type(self, type: BackgroundType):
         """Set the background type"""
         self.update(backgroundType=type)
-        
+
     @property
     def background_gradient(self) -> BackgroundGradient | None:
         """Gradient background for the project"""
         return self.schema['backgroundGradient']
+
     @background_gradient.setter
     def background_gradient(self, gradient: BackgroundGradient | None) -> None:
         """Set the Project background gradient"""
@@ -148,57 +158,57 @@ class Project(PlankaModel[schemas.Project]):
             self.remove_background()
         else:
             self.update(backgroundGradient=gradient, backgroundType='gradient')
-    
+
     @property
     def hidden(self) -> bool:
         """Whether the project is hidden"""
         return self.schema['isHidden']
+
     @hidden.setter
     def hidden(self, is_hidden: bool) -> None:
         """Set/Unset the Project as hidden"""
         self.update(isHidden=is_hidden)
-    
+
     @property
     def created_at(self) -> datetime:
         """When the project was created"""
         return dtfromiso(self.schema['createdAt'], self.session.timezone)
-    
+
     @property
     def updated_at(self) -> datetime:
         """When the project was last updated"""
         return dtfromiso(self.schema['updatedAt'], self.session.timezone)
-    
+
     # Special Methods
     def sync(self):
         self.schema = self.endpoints.getProject(self.id)['item']
-        
-    def update(self, **project: Unpack[paths.Request_updateProject]) -> None:
+
+    def update(self, **project: Unpack[typ.Request_updateProject]) -> None:
         """Update the Project"""
         self.schema = self.endpoints.updateProject(self.id, **project)['item']
-        
+
     def delete(self) -> None:
         """Delete the Project"""
         self.endpoints.deleteProject(self.id)
-    
+
     def add_project_manager(self, user: User) -> ProjectManager:
         """Add a User to the Project as a ProjectManager"""
         return ProjectManager(self.endpoints.createProjectManager(self.id, userId=user.id)['item'], self.session)
-    
+
     def update_background_image(self, background: BackgroundImage | Path | str | bytes | None) -> BackgroundImage | None:
-        """Update the Project Background Image,
-        
-        Only Admins and ProjectManagers can update the Background Image
-        
+        """Update the Project Background Image.
+         Only Admins and ProjectManagers can update the Background Image
+
         Args:
-            background (BackgroundImage | Path | str | bytes | None): Existing Image or filepath/url or raw bytes or None to unset
-            
+            background: Existing Image or filepath/url or raw bytes or None to unset
+
         Returns:
-            (BackgroundImage | None): If a backround image was set or created
+            BackroundImage if it was set or created
         """
         # Force a PermissionError early if this user isn't the current user or an admin
         if self.id != self.session.current_id and self.session.current_role != 'admin':
-            self.endpoints.createBackgroundImage(self.id, **{'file': b'NO_PERMISSION'})
-        
+            self.endpoints.createBackgroundImage(self.id, file=b'NO_PERMISSION')
+
         if background is None:
             self.remove_background()
             return
@@ -207,7 +217,7 @@ class Project(PlankaModel[schemas.Project]):
             # Assign the image if it is in this project
             if background in self.background_images:
                 self.background_image = background
-            
+
             # Re-Upload to this project
             else:
                 self.update_background_image(background.url)
@@ -218,10 +228,10 @@ class Project(PlankaModel[schemas.Project]):
             background = str(background.resolve())
 
         # Deferred import of mimetypes that is only used here
-        # This function takes so long anyways so the import delay 
+        # This function takes so long anyways so the import delay
         # isn't noticable
-        import mimetypes
-        
+        import mimetypes  # noqa: PLC0415
+
         # Handle filepath or URL
         mime_type = None
         if isinstance(background, str):
@@ -242,17 +252,17 @@ class Project(PlankaModel[schemas.Project]):
                 mime_type, *_ = mimetypes.guess_file_type(background)
                 mime_type = mime_type or 'application/octet-stream'
                 background = open(background, 'rb').read()
-        
+
         mime_type = mime_type or 'application/octet-stream'
         return BackgroundImage(
             self.endpoints.createBackgroundImage(
-                self.id, 
-                file=bytes(background), 
+                self.id,
+                file=bytes(background),
                 mime_type=mime_type,
             )['item'],
             self.session
         )
-    
+
     def remove_background(self) -> None:
         """Reset the Project background to the default grey"""
         self.update(backgroundType=None)
@@ -268,40 +278,40 @@ class Project(PlankaModel[schemas.Project]):
             else:
                 # If User not in managers, do nothing
                 return
-        
+
         if project_manager.project == self:
             # Only delete ProjectManager if it is for this Project
             # Defer deletion to the ProjectManager object
             project_manager.delete()
 
-    def create_board(self, 
-                     *, 
-                     name: str, 
-                     position: Position | int ='top') -> Board:
+    def create_board(self,
+                     *,
+                     name: str,
+                     position: Position | int = 'top') -> Board:
         """Create a new Board in the Project
-        
+
         Args:
             name: The name of the Board
             position: The position of the board within the project
         """
         return Board(
             self.endpoints.createBoard(
-                self.id, 
-                name=name, 
+                self.id,
+                name=name,
                 position=get_position(self.boards, position)
-            )['item'], 
+            )['item'],
             self.session
         )
 
-    def import_board(self, 
-                     *, 
-                     name: str, 
-                     import_file: bytes, 
-                     position: Position | int='top', 
-                     import_type: BoardImportType='trello',
-                     request_id: str|None=None) -> Board:
+    def import_board(self,
+                     *,
+                     name: str,
+                     import_file: bytes,
+                     position: Position | int = 'top',
+                     import_type: BoardImportType = 'trello',
+                     request_id: str | None = None) -> Board:
         """Import a board from a file (currently supports trello imports only)
-        
+
         Args:
             name: The name of the imported Board
             position: The position of the imported Board within the Project
@@ -315,33 +325,33 @@ class Project(PlankaModel[schemas.Project]):
                 position=get_position(self.boards, position),
                 importType=import_type,
                 importFile=import_file,
-                requestId=request_id or datetime.now().isoformat(),
+                requestId=request_id or datetime.now(self.session.timezone).isoformat(),
             )['item'],
             self.session
         )
 
-    def create_base_custom_field_group(self, 
-                                       *, 
+    def create_base_custom_field_group(self,
+                                       *,
                                        name: str) -> BaseCustomFieldGroup:
         """Create a BaseCustomFieldGroup in the Project
-        
+
         Args:
             name: The name of the new BaseCustomFieldGroup
         """
         return BaseCustomFieldGroup(
             self.endpoints.createBaseCustomFieldGroup(
-                self.id, 
+                self.id,
                 name=name,
-            )['item'], 
+            )['item'],
             self.session
         )
 
 
-from .board import Board
-from .user import User
-from .project_manager import ProjectManager
 from .background_image import BackgroundImage
 from .base_custom_field_group import BaseCustomFieldGroup
+from .board import Board
 from .board_membership import BoardMembership
 from .custom_field import CustomField
 from .notification_service import NotificationService
+from .project_manager import ProjectManager
+from .user import User

--- a/src/plankapy/v2/models/project.py
+++ b/src/plankapy/v2/models/project.py
@@ -2,22 +2,16 @@ from __future__ import annotations
 
 from datetime import datetime
 from pathlib import Path
+from typing import Unpack
 
 from httpx import HTTPStatusError
 
 from ..api import events, schemas, typ
 from ._base import PlankaModel
 from ._helpers import Position, dtfromiso, get_position, model_list
+from ._literals import BackgroundGradient, BackgroundType, BoardImportType
 
 # Deferred Model imports at bottom of file
-
-TYPE_CHECKING = False
-if TYPE_CHECKING:
-    from typing import Unpack
-
-    # from models import *
-    from ._literals import BackgroundGradient, BackgroundType, BoardImportType
-
 
 __all__ = ('Project', )
 
@@ -93,20 +87,16 @@ class Project(PlankaModel[schemas.Project]):
         self.update(isFavorite=is_favorite)
 
     @property
-    def owner(self) -> User | None:
+    def owner(self) -> User:
         """The User who owns the project (Raises LookupError if the User cannot be found)"""
-        usrs = [pm for pm in self.project_managers if self.schema['ownerProjectManagerId'] == pm.id]
-        if usrs:
-            return usrs.pop().user
-        # return User(self.endpoints.getUser(self.schema['ownerProjectManagerId'])['item'], self.session)
+        if pm := self.project_managers[{'id': self.schema['ownerProjectManagerId']}].dpop():
+            return pm.user
+        raise LookupError(f'Could not find Owner {self.schema['ownerProjectManagerId']}')
 
     @property
     def background_image(self) -> BackgroundImage | None:
         """The current BackgroundImage of the Project"""
-        bgis = [bgi for bgi in self.background_images if bgi.id == self.schema['backgroundImageId']]
-        if not bgis:
-            return None
-        return bgis.pop()
+        return self.background_images[{'id': self.schema['backgroundImageId']}].dpop()
 
     @background_image.setter
     def background_image(self, background_image: BackgroundImage | None) -> None:

--- a/src/plankapy/v2/models/project.py
+++ b/src/plankapy/v2/models/project.py
@@ -171,6 +171,7 @@ class Project(PlankaModel[schemas.Project]):
 
     # Special Methods
     def sync(self):
+        """Sync the Project with the Planka server"""
         self.schema = self.endpoints.getProject(self.id)['item']
 
     def update(self, **project: Unpack[typ.Request_updateProject]) -> None:

--- a/src/plankapy/v2/models/project_manager.py
+++ b/src/plankapy/v2/models/project_manager.py
@@ -43,10 +43,7 @@ class ProjectManager(PlankaModel[schemas.ProjectManager]):
     # Special Methods
     def sync(self):
         """Sync the ProjectManager with the Planka server"""
-        pms = self.project.project_managers
-        for pm in pms:
-            if pm.id == self.id:
-                self.schema = pm.schema
+        self.schema = self.project.project_managers[{'id': self.id}].dpop(default=self).schema
 
     def delete(self):
         self.endpoints.deleteProjectManager(self.id)

--- a/src/plankapy/v2/models/project_manager.py
+++ b/src/plankapy/v2/models/project_manager.py
@@ -8,12 +8,6 @@ from ._helpers import dtfromiso
 
 # Deferred Model imports at bottom of file
 
-TYPE_CHECKING = False
-if TYPE_CHECKING:
-    ...
-    # from models import *
-
-
 __all__ = ('ProjectManager', )
 
 
@@ -32,9 +26,8 @@ class ProjectManager(PlankaModel[schemas.ProjectManager]):
     @property
     def user(self) -> User:
         """The User assigned as ProjectManager (Raises LookupError if the User cannot be found)"""
-        usrs = [u for u in self.project.users if self.schema['userId'] == u.id]
-        if usrs:
-            return usrs.pop()
+        if usr := self.project.users['id': self.schema['userId']].dpop():
+            return usr
         raise LookupError(f"Cannot find User: {self.schema['userId']}")
 
     @property

--- a/src/plankapy/v2/models/project_manager.py
+++ b/src/plankapy/v2/models/project_manager.py
@@ -1,49 +1,52 @@
 from __future__ import annotations
 
-__all__ = ('ProjectManager', )
-
 from datetime import datetime
+
+from ..api import events, schemas
 from ._base import PlankaModel
 from ._helpers import dtfromiso
-from ..api import schemas, events
 
 # Deferred Model imports at bottom of file
 
 TYPE_CHECKING = False
 if TYPE_CHECKING:
     ...
-    #from models import *
+    # from models import *
+
+
+__all__ = ('ProjectManager', )
 
 
 class ProjectManager(PlankaModel[schemas.ProjectManager]):
     """Python interface for Planka ProjectManagers"""
-    
+
     __events__ = events.ProjectManagerEvents
 
     # ProjectManager Properties
-    
+
     @property
     def project(self) -> Project:
         """The Project associated with the ProjectManager"""
         return Project(self.endpoints.getProject(self.schema['projectId'])['item'], self.session)
+
     @property
     def user(self) -> User:
         """The User assigned as ProjectManager (Raises LookupError if the User cannot be found)"""
-        _usrs = [u for u in self.project.users if self.schema['userId'] == u.id]
-        if _usrs:
-            return _usrs.pop()
+        usrs = [u for u in self.project.users if self.schema['userId'] == u.id]
+        if usrs:
+            return usrs.pop()
         raise LookupError(f"Cannot find User: {self.schema['userId']}")
-    
+
     @property
     def created_at(self) -> datetime:
         """When the ProjectManager was created"""
         return dtfromiso(self.schema['createdAt'], self.session.timezone)
-    
+
     @property
     def updated_at(self) -> datetime:
         """When the ProjectManager was last updated"""
         return dtfromiso(self.schema['updatedAt'], self.session.timezone)
-    
+
     # Special Methods
     def sync(self):
         """Sync the ProjectManager with the Planka server"""
@@ -51,7 +54,7 @@ class ProjectManager(PlankaModel[schemas.ProjectManager]):
         for pm in pms:
             if pm.id == self.id:
                 self.schema = pm.schema
-                
+
     def delete(self):
         self.endpoints.deleteProjectManager(self.id)
 

--- a/src/plankapy/v2/models/project_manager.py
+++ b/src/plankapy/v2/models/project_manager.py
@@ -43,7 +43,7 @@ class ProjectManager(PlankaModel[schemas.ProjectManager]):
     # Special Methods
     def sync(self):
         """Sync the ProjectManager with the Planka server"""
-        self.schema = self.project.project_managers[{'id': self.id}].dpop(default=self).schema
+        self.schema = self.project.project_managers[self].dpop(default=self).schema
 
     def delete(self):
         self.endpoints.deleteProjectManager(self.id)

--- a/src/plankapy/v2/models/project_manager.py
+++ b/src/plankapy/v2/models/project_manager.py
@@ -26,7 +26,7 @@ class ProjectManager(PlankaModel[schemas.ProjectManager]):
     @property
     def user(self) -> User:
         """The User assigned as ProjectManager (Raises LookupError if the User cannot be found)"""
-        if usr := self.project.users['id': self.schema['userId']].dpop():
+        if usr := self.project.users[{'id': self.schema['userId']}].dpop():
             return usr
         raise LookupError(f"Cannot find User: {self.schema['userId']}")
 

--- a/src/plankapy/v2/models/task.py
+++ b/src/plankapy/v2/models/task.py
@@ -1,18 +1,20 @@
 from __future__ import annotations
 
-__all__ = ('Task', )
-
 from datetime import datetime
+
+from ..api import events, schemas, typ
 from ._base import PlankaModel
 from ._helpers import dtfromiso
-from ..api import schemas, paths, events
 
 # Deferred Model imports at bottom of file
 
 TYPE_CHECKING = False
 if TYPE_CHECKING:
     from typing import Unpack
-    #from models import *
+    # from models import *
+
+
+__all__ = ('Task', )
 
 
 class Task(PlankaModel[schemas.Task]):
@@ -26,6 +28,7 @@ class Task(PlankaModel[schemas.Task]):
     def task_list(self) -> TaskList:
         """The TaskList the Task belongs to"""
         return TaskList(self.endpoints.getTaskList(self.schema['taskListId'])['item'], self.session)
+
     @task_list.setter
     def task_list(self, task_list: TaskList) -> None:
         """Move the Task to a different TaskList"""
@@ -39,10 +42,11 @@ class Task(PlankaModel[schemas.Task]):
     @property
     def assignee(self) -> User | None:
         """The User assigned to the Task if there is one"""
-        _usrs = [u for u in self.card.board.users if self.schema['assigneeUserId'] == u.id]
-        if _usrs:
-            return _usrs.pop()
+        usrs = [u for u in self.card.board.users if self.schema['assigneeUserId'] == u.id]
+        if usrs:
+            return usrs.pop()
         raise LookupError(f"Cannot find User: {self.schema['assigneeUserId']}")
+
     @assignee.setter
     def assignee(self, assignee: User | None) -> None:
         """Assign a User to the Task"""
@@ -50,21 +54,23 @@ class Task(PlankaModel[schemas.Task]):
         if assignee is not None:
             self.update(assigneeUserId=assignee.id)
         else:
-            self.update(assigneeUserId=None) # type: ignore
+            self.update(assigneeUserId=None)  # type: ignore
 
     @property
     def position(self) -> int:
         """Position of the Task within the TaskList"""
         return self.schema['position']
+
     @position.setter
     def position(self, position: int) -> None:
         """Set the position of the Task within the TaskList"""
         self.update(position=position)
-        
+
     @property
     def name(self) -> str:
         """Name/title of the Task"""
         return self.schema['name']
+
     @name.setter
     def name(self, name: str) -> None:
         """Set the Task name"""
@@ -74,8 +80,9 @@ class Task(PlankaModel[schemas.Task]):
     def is_completed(self) -> bool:
         """Whether the Task is completed"""
         return self.schema['isCompleted']
+
     @is_completed.setter
-    def is_completed(self, is_completed: bool) -> None: 
+    def is_completed(self, is_completed: bool) -> None:
         """Set whether the Task is completed"""
         self.update(isCompleted=is_completed)
 
@@ -92,11 +99,11 @@ class Task(PlankaModel[schemas.Task]):
     # Special Methods
     def sync(self):
         """Sync the Task with the Planka server"""
-        _tsks = [tsk for tsk in self.task_list.tasks if tsk == self]
-        if _tsks:
-            self.schema = _tsks.pop().schema
+        tsks = [tsk for tsk in self.task_list.tasks if tsk == self]
+        if tsks:
+            self.schema = tsks.pop().schema
 
-    def update(self, **kwargs: Unpack[paths.Request_updateTask]):
+    def update(self, **kwargs: Unpack[typ.Request_updateTask]):
         """Update the Task"""
         self.schema = self.endpoints.updateTask(self.id, **kwargs)['item']
 
@@ -106,5 +113,5 @@ class Task(PlankaModel[schemas.Task]):
 
 
 from .card import Card
-from .user import User
 from .task_list import TaskList
+from .user import User

--- a/src/plankapy/v2/models/task.py
+++ b/src/plankapy/v2/models/task.py
@@ -1,18 +1,13 @@
 from __future__ import annotations
 
 from datetime import datetime
+from typing import Unpack
 
 from ..api import events, schemas, typ
 from ._base import PlankaModel
 from ._helpers import dtfromiso
 
 # Deferred Model imports at bottom of file
-
-TYPE_CHECKING = False
-if TYPE_CHECKING:
-    from typing import Unpack
-    # from models import *
-
 
 __all__ = ('Task', )
 
@@ -42,9 +37,8 @@ class Task(PlankaModel[schemas.Task]):
     @property
     def assignee(self) -> User | None:
         """The User assigned to the Task if there is one"""
-        usrs = [u for u in self.card.board.users if self.schema['assigneeUserId'] == u.id]
-        if usrs:
-            return usrs.pop()
+        if usr := self.card.board.users[{'id': self.schema['assigneeUserId']}].dpop():
+            return usr
         raise LookupError(f"Cannot find User: {self.schema['assigneeUserId']}")
 
     @assignee.setter
@@ -99,9 +93,7 @@ class Task(PlankaModel[schemas.Task]):
     # Special Methods
     def sync(self):
         """Sync the Task with the Planka server"""
-        tsks = [tsk for tsk in self.task_list.tasks if tsk == self]
-        if tsks:
-            self.schema = tsks.pop().schema
+        self.schema = self.task_list.tasks[self].dpop(default=self).schema
 
     def update(self, **kwargs: Unpack[typ.Request_updateTask]):
         """Update the Task"""

--- a/src/plankapy/v2/models/task_list.py
+++ b/src/plankapy/v2/models/task_list.py
@@ -1,18 +1,13 @@
 from __future__ import annotations
 
 from datetime import datetime
+from typing import Unpack
 
 from ..api import events, schemas, typ
 from ._base import PlankaModel
 from ._helpers import Position, dtfromiso, get_position, model_list
 
 # Deferred Model imports at bottom of file
-
-TYPE_CHECKING = False
-if TYPE_CHECKING:
-    from typing import Unpack
-    # from models import *
-
 
 __all__ = ('TaskList', )
 

--- a/src/plankapy/v2/models/task_list.py
+++ b/src/plankapy/v2/models/task_list.py
@@ -1,23 +1,25 @@
 from __future__ import annotations
 
-__all__ = ('TaskList', )
-
 from datetime import datetime
+
+from ..api import events, schemas, typ
 from ._base import PlankaModel
 from ._helpers import Position, dtfromiso, get_position, model_list
-from ..api import schemas, paths, events
 
 # Deferred Model imports at bottom of file
 
 TYPE_CHECKING = False
 if TYPE_CHECKING:
     from typing import Unpack
-    #from models import *
+    # from models import *
+
+
+__all__ = ('TaskList', )
 
 
 class TaskList(PlankaModel[schemas.TaskList]):
     """Python interface for Planka TaskLists"""
-    
+
     __events__ = events.TaskListEvents
 
     # TaskList included
@@ -25,7 +27,7 @@ class TaskList(PlankaModel[schemas.TaskList]):
     @property
     def _included(self):
         return self.endpoints.getTaskList(self.id)['included']
-    
+
     @property
     @model_list
     def tasks(self) -> list[Task]:
@@ -38,11 +40,12 @@ class TaskList(PlankaModel[schemas.TaskList]):
     def card(self) -> Card:
         """The Card the TaskList belongs to"""
         return Card(self.endpoints.getCard(self.schema['cardId'])['item'], self.session)
-    
+
     @property
     def position(self) -> int:
         """Position of the TaskList within the Card"""
         return self.schema['position']
+
     @position.setter
     def positon(self, position: int) -> None:
         """Set the TaskList position within the Card"""
@@ -52,6 +55,7 @@ class TaskList(PlankaModel[schemas.TaskList]):
     def name(self) -> str:
         """Name/title of the TaskList"""
         return self.schema['name']
+
     @name.setter
     def name(self, name: str) -> None:
         """Set the name of the TaskList"""
@@ -61,6 +65,7 @@ class TaskList(PlankaModel[schemas.TaskList]):
     def show_on_front_of_card(self) -> bool:
         """Whether to show the TaskList on the front of the Card"""
         return self.schema['showOnFrontOfCard']
+
     @show_on_front_of_card.setter
     def show_on_front_of_card(self, show_on_front_of_card: bool) -> None:
         """Set whether to show TaskList on the front of the Card"""
@@ -69,6 +74,7 @@ class TaskList(PlankaModel[schemas.TaskList]):
     def hide_completed_tasks(self) -> bool:
         """Whether to hide completed Tasks"""
         return self.schema['hideCompletedTasks']
+
     @hide_completed_tasks.setter
     def hide_completed_tasks(self, hide_completed_tasks: bool) -> None:
         """Set whether to hide completed Tasks"""
@@ -78,7 +84,7 @@ class TaskList(PlankaModel[schemas.TaskList]):
     def created_at(self) -> datetime:
         """When the TaskList was created"""
         return dtfromiso(self.schema['createdAt'], self.session.timezone)
-    
+
     @property
     def updated_at(self) -> datetime:
         """When the TaskList was last updated"""
@@ -89,7 +95,7 @@ class TaskList(PlankaModel[schemas.TaskList]):
         """Sync the TaskList with the Planka server"""
         self.schema = self.endpoints.getTaskList(self.id)['item']
 
-    def update(self, **kwargs: Unpack[paths.Request_updateTaskList]):
+    def update(self, **kwargs: Unpack[typ.Request_updateTaskList]):
         """Update the TaskList"""
         self.schema = self.endpoints.updateTaskList(self.id, **kwargs)['item']
 
@@ -97,19 +103,19 @@ class TaskList(PlankaModel[schemas.TaskList]):
         """Delete the TaskList"""
         self.endpoints.deleteTaskList(self.id)
 
-    def add_task(self, name: str, *, 
-                 is_completed: bool=False, 
-                 position: Position='top',
-                 linked_card: Card|None=None) -> Task:
+    def add_task(self, name: str, *,
+                 is_completed: bool = False,
+                 position: Position = 'top',
+                 linked_card: Card | None = None) -> Task:
         """Create a new Task in the TaskList
-        
+
         Args:
             name (str): The name of the task
             is_completed (bool): Is the task completed or not (default: `False`)
             position (Position | int): Position of the task in the TaskList (default: `top`)
             linked_card (Card|None): Optional Card to link the Task to (default: `None`)
         """
-        args = { # type: ignore
+        args = {  # type: ignore
             'name': name,
             'position': get_position(self.tasks, position),
             'isCompleted': is_completed
@@ -119,9 +125,9 @@ class TaskList(PlankaModel[schemas.TaskList]):
 
         return Task(
             self.endpoints.createTask(
-                self.id, 
-                **args, # type: ignore
-                )['item'],  
+                self.id,
+                **args,  # type: ignore
+                )['item'],
             self.session
         )
 

--- a/src/plankapy/v2/models/task_list.py
+++ b/src/plankapy/v2/models/task_list.py
@@ -64,6 +64,7 @@ class TaskList(PlankaModel[schemas.TaskList]):
     @show_on_front_of_card.setter
     def show_on_front_of_card(self, show_on_front_of_card: bool) -> None:
         """Set whether to show TaskList on the front of the Card"""
+        self.update(showOnFrontOfCard=show_on_front_of_card)
 
     @property
     def hide_completed_tasks(self) -> bool:

--- a/src/plankapy/v2/models/user.py
+++ b/src/plankapy/v2/models/user.py
@@ -1,32 +1,26 @@
 from __future__ import annotations
 
 from datetime import datetime
+from typing import Any, Literal, Unpack
 
 from httpx import HTTPStatusError
 
 from ..api import events, schemas, typ
 from ._base import PlankaModel
 from ._helpers import dtfromiso, model_list
+from ._literals import (
+    BoardRole,
+    EditorMode,
+    HomeView,
+    Language,
+    LockableField,
+    NotificationServiceFormat,
+    ProjectOrdering,
+    TermsType,
+    UserRole,
+)
 
 # Deferred Model imports at bottom of file
-
-TYPE_CHECKING = False
-if TYPE_CHECKING:
-    from typing import Any, Literal, Unpack
-
-    # from models import *
-    from ._literals import (
-        BoardRole,
-        EditorMode,
-        HomeView,
-        Language,
-        LockableField,
-        NotificationServiceFormat,
-        ProjectOrdering,
-        TermsType,
-        UserRole,
-    )
-
 
 __all__ = ('User', )
 

--- a/src/plankapy/v2/models/user.py
+++ b/src/plankapy/v2/models/user.py
@@ -1,31 +1,34 @@
 from __future__ import annotations
 
+from datetime import datetime
+
 from httpx import HTTPStatusError
 
-__all__ = ('User', )
-
-from datetime import datetime
+from ..api import events, schemas, typ
 from ._base import PlankaModel
 from ._helpers import dtfromiso, model_list
-from ..api import schemas, paths, events
 
 # Deferred Model imports at bottom of file
 
 TYPE_CHECKING = False
 if TYPE_CHECKING:
-    from typing import Any, Unpack, Literal
-    #from models import *
+    from typing import Any, Literal, Unpack
+
+    # from models import *
     from ._literals import (
-        UserRole, 
-        EditorMode, 
-        HomeView, 
-        Language, 
-        LockableField, 
-        ProjectOrdering, 
-        BoardRole, 
-        TermsType,
+        BoardRole,
+        EditorMode,
+        HomeView,
+        Language,
+        LockableField,
         NotificationServiceFormat,
+        ProjectOrdering,
+        TermsType,
+        UserRole,
     )
+
+
+__all__ = ('User', )
 
 
 class User(PlankaModel[schemas.User]):
@@ -43,6 +46,7 @@ class User(PlankaModel[schemas.User]):
     def email(self) -> str | None:
         """Email address for login and notifications (private field)"""
         return self.schema.get('email')
+
     @email.setter
     def email(self, email: str) -> None:
         """Set the User email (Direct assignment only allowed for Admin users)"""
@@ -50,7 +54,8 @@ class User(PlankaModel[schemas.User]):
 
     @property
     def password(self) -> None:
-        raise AttributeError(f'Passwords can only be set by Admin Users and read by nobody')
+        raise AttributeError('Passwords can only be set by Admin Users and read by nobody')
+
     @password.setter
     def password(self, password: str) -> None:
         """Set a User's password (Admin only)"""
@@ -60,6 +65,7 @@ class User(PlankaModel[schemas.User]):
     def role(self):
         """User role defining access permissions"""
         return self.schema.get('role', 'boardUser')
+
     @role.setter
     def role(self, role: UserRole) -> None:
         """Set the User role"""
@@ -69,6 +75,7 @@ class User(PlankaModel[schemas.User]):
     def name(self) -> str:
         """Full display name of the user"""
         return self.schema['name']
+
     @name.setter
     def name(self, name: str) -> None:
         """Set the User's name"""
@@ -83,20 +90,22 @@ class User(PlankaModel[schemas.User]):
     def avatar(self) -> dict[str, Any]:
         """Avatar information for the user with generated URLs"""
         return self.schema['avatar']
+
     @avatar.setter
     def avatar(self, avatar: str | bytes | None) -> None:
         """Set the User's avatar using a URL, file bytes, or None to unset"""
-        self.update_avatar(avatar=avatar)  
-    
+        self.update_avatar(avatar=avatar)
+
     @property
     def gravatar_url(self) -> str | None:
         """Gravatar URL for the user (conditionally added if configured)"""
         return self.schema.get('gravatarUrl')
-    
+
     @property
     def phone(self) -> str:
         """Contact phone number"""
         return self.schema['phone']
+
     @phone.setter
     def phone(self, phone: str) -> None:
         """Set the User's phone"""
@@ -106,6 +115,7 @@ class User(PlankaModel[schemas.User]):
     def organization(self) -> str:
         """Organization or company name"""
         return self.schema['organization']
+
     @organization.setter
     def organization(self, organization: str) -> None:
         """Set the User's organization"""
@@ -115,6 +125,7 @@ class User(PlankaModel[schemas.User]):
     def language(self) -> Language | None:
         """Preferred language for user interface and notifications (personal field)"""
         return self.schema.get('language')
+
     @language.setter
     def language(self, language: Language) -> None:
         """Set the User's language"""
@@ -124,6 +135,7 @@ class User(PlankaModel[schemas.User]):
     def subscribe_to_own_cards(self) -> bool:
         """Whether the user subscribes to their own cards (personal field)"""
         return self.schema.get('subscribeToOwnCards', False)
+
     @subscribe_to_own_cards.setter
     def subscribe_to_own_cards(self, subscribe_to_own_cards: bool) -> None:
         """Set Whether the user subscribes to their own cards (personal field)"""
@@ -133,6 +145,7 @@ class User(PlankaModel[schemas.User]):
     def subscribe_to_card_when_commenting(self) -> bool:
         """Whether the user subscribes to cards when commenting (personal field)"""
         return self.schema.get('subscribeToCardWhenCommenting', False)
+
     @subscribe_to_card_when_commenting.setter
     def subscribe_to_card_when_commenting(self, subscribe_to_card_when_commenting: bool) -> None:
         """Set whether the user subscribes to cards when commenting (personal field)"""
@@ -142,6 +155,7 @@ class User(PlankaModel[schemas.User]):
     def turn_off_recent_card_highlighting(self) -> bool:
         """Whether recent card highlighting is disabled (personal field)"""
         return self.schema.get('turnOffRecentCardHighlighting', False)
+
     @turn_off_recent_card_highlighting.setter
     def turn_off_recent_card_highlighting(self, turn_off_recent_card_highlighting: bool) -> None:
         """Set whether recent card highlighting is disabled (personal field)"""
@@ -151,6 +165,7 @@ class User(PlankaModel[schemas.User]):
     def enable_favorites_by_default(self) -> bool:
         """Whether favorites are enabled by default (personal field)"""
         return self.schema.get('enableFavoritesByDefault', False)
+
     @enable_favorites_by_default.setter
     def enable_favorites_by_default(self, enable_favorites_by_default: bool) -> None:
         """Set whether favorites are enabled by default (personal field)"""
@@ -160,6 +175,7 @@ class User(PlankaModel[schemas.User]):
     def default_editor_mode(self) -> EditorMode:
         """Default markdown editor mode (personal field)"""
         return self.schema.get('defaultEditorMode', 'wysiwyg')
+
     @default_editor_mode.setter
     def default_editor_mode(self, default_editor_mode: EditorMode) -> None:
         """Set default markdown editor mode (personal field)"""
@@ -169,6 +185,7 @@ class User(PlankaModel[schemas.User]):
     def default_home_view(self) -> HomeView | None:
         """Default view mode for the home page (personal field)"""
         return self.schema.get('defaultHomeView')
+
     @default_home_view.setter
     def default_home_view(self, default_home_view: HomeView) -> None:
         """Default view mode for the home page (personal field)"""
@@ -178,44 +195,46 @@ class User(PlankaModel[schemas.User]):
     def default_projects_order(self) -> ProjectOrdering | None:
         """Default sort order for projects display (personal field)"""
         return self.schema.get('defaultProjectsOrder')
+
     @default_projects_order.setter
     def default_projects_order(self, default_projects_order: ProjectOrdering) -> None:
         """Default sort order for projects display (personal field)"""
         self.update(defaultProjectsOrder=default_projects_order)
-    
+
     @property
     def terms_type(self) -> TermsType | None:
         """Type of terms applicable to the user based on role"""
         return self.schema.get('termsType')
-    
+
     @property
     def is_sso_user(self) -> bool:
         """Whether the user is SSO user (private field, can be unlinked by admins)"""
         return self.schema.get('isSsoUser', False)
+
     @is_sso_user.setter
     def is_sso_user(self, is_sso_user: Literal[False]) -> None:
         self.update(isSsoUser=is_sso_user)
-    
+
     @property
     def is_deactivated(self) -> bool:
         """Whether the user account is deactivated and cannot log in"""
         return self.schema['isDeactivated']
-    
+
     @property
     def is_default_admin(self) -> bool:
         """Whether the user is the default admin (visible only to current user or admin)"""
         return self.schema.get('isDefaultAdmin', False)
-    
+
     @property
     def locked_field_names(self) -> list[LockableField]:
         """List of fields locked from editing (visible only to current user or admin)"""
         return self.schema.get('lockedFieldNames', [])
-    
+
     @property
     def created_at(self) -> datetime:
         """When the user was created"""
         return dtfromiso(self.schema['createdAt'], self.session.timezone)
-    
+
     @property
     def updated_at(self) -> datetime:
         """When the user was last updated"""
@@ -227,39 +246,39 @@ class User(PlankaModel[schemas.User]):
         if self.id == self.session.me.id:
             self.schema = self.session.me.schema
 
-    def update(self, **kwargs: Unpack[paths.Request_updateUser]):
+    def update(self, **kwargs: Unpack[typ.Request_updateUser]):
         """Update the User"""
         self.schema = self.endpoints.updateUser(self.id, **kwargs)['item']
 
     def delete(self):
         """Delete the User"""
         return self.endpoints.deleteUser(self.id)
-    
+
     def update_avatar(self, avatar: str | bytes | None) -> User:
         """Update the User avatar
-        
-        You can pass a filepath, URL, raw bytes, or None to the avatar argument. 
-        Only Admins can update other User's avatars
-        
+
+        You can pass a filepath, URL, raw bytes, or None to the avatar argument.
+         Only Admins can update other User's avatars
+
         Args:
-            avatar (str | bytes | None): filepath/URL or file bytes or None to clear
-        
+            avatar: filepath/URL or file bytes or None to clear
+
         Returns:
-            User: The updated User
+            The updated User
         """
         # Force a PermissionError early if this user isn't the current user or an admin
         if self.id != self.session.current_id and self.session.current_role != 'admin':
-            self.endpoints.updateUserAvatar(self.id, **{'file': b'NO_PERMISSION'})
-        
+            self.endpoints.updateUserAvatar(self.id, file=b'NO_PERMISSION')
+
         if avatar is None:
             self.avatar = None
             return self
-        
+
         # Deferred import of mimetypes that is only used here
-        # This function takes so long anyways so the import delay 
+        # This function takes so long anyways so the import delay
         # isn't noticable
-        import mimetypes
-        
+        import mimetypes  # noqa: PLC0415
+
         # Handle filepath or URL
         mime_type = None
         if isinstance(avatar, str):
@@ -280,20 +299,20 @@ class User(PlankaModel[schemas.User]):
                 mime_type, *_ = mimetypes.guess_file_type(avatar)
                 mime_type = mime_type or 'application/octet-stream'
                 avatar = open(avatar, 'rb').read()
-        
+
         mime_type = mime_type or 'application/octet-stream'
         self.endpoints.updateUserAvatar(
-            self.id, 
-            file=bytes(avatar), 
+            self.id,
+            file=bytes(avatar),
             mime_type=mime_type,
         )
         return self
-    
-    def update_email(self, email: str, 
-                     *, 
-                     password: str|None=None) -> None:
-        """Update the current User's email
-        
+
+    def update_email(self, email: str,
+                     *,
+                     password: str | None = None) -> None:
+        """Update the current User's email.
+
         Args:
             password (str): The User's password (required if not admin)
 
@@ -302,30 +321,30 @@ class User(PlankaModel[schemas.User]):
             PermissionError: If the current user is not admin and the `password` arg is not set
             HTTPStatusError: If the password is wrong or the update operation fails
         """
-        
+
         # Allow Admins to set user email directly or ignore password kwarg
         if self.current_role == 'admin':
             self.endpoints.updateUserEmail(self.id, email=email)
             return
-        
+
         if self.current_id != self.id:
-            raise PermissionError(f'Cannot set other User emails unless admin')
-        
+            raise PermissionError('Cannot set other User emails unless admin')
+
         if not password:
-            raise PermissionError(f'User password required to update email!')
-        
+            raise PermissionError('User password required to update email!')
+
         self.endpoints.updateUserEmail(self.id, email=email, currentPassword=password)
 
-    def update_password(self, 
-                        *, 
-                        new_password: str, 
-                        current_password: str|None=None) -> None:
+    def update_password(self,
+                        *,
+                        new_password: str,
+                        current_password: str | None = None) -> None:
         """Update the User's password
-        
+
         Args:
             new_password (str): The new password to use
             current_password (str): The User's current password (required for non-admin)
-        
+
         Raises:
             PermissionError: If a non-admin attempts to update another user's password
             PermissionError: If a user attempts to update their own password without passing a `current_password`
@@ -335,79 +354,79 @@ class User(PlankaModel[schemas.User]):
         if self.current_role == 'admin':
             self.endpoints.updateUserPassword(self.id, password=new_password)
             return
-        
+
         # Users's cannot set other user's passwords
         if self.current_id != self.id:
-            raise PermissionError(f"Cannot set another User's password! (must be admin)")
-        
+            raise PermissionError("Cannot set another User's password! (must be admin)")
+
         # Password change required current password
         if not current_password:
-            raise PermissionError(f'Cannot set other User passwords unless admin')
+            raise PermissionError('Cannot set other User passwords unless admin')
 
         self.endpoints.updateUserPassword(self.id, password=new_password, currentPassword=current_password)
 
     def add_to_card(self, card: Card) -> None:
         """Add the User to a Card
-        
+
         Args:
             card (Card): The Card to add the user to (must be a member of the Card's Board)
-        
+
         Raises:
             PermissionError: If the User is not a member of the Card's Board
-        
+
         Note:
             If the User is already a Card member, no changes will be made
         """
-        
+
         if self not in card.board.users:
-            raise PermissionError(f'User is not a member of the Board')
-        
+            raise PermissionError('User is not a member of the Board')
+
         if self not in card.members:
             self.endpoints.createCardMembership(card.id, userId=self.id)
-    
+
     def remove_from_card(self, card: Card) -> None:
         """Remove the User from a Card
-        
+
         Args:
             card (Card): The Card to remove the User from
-        
+
         Note:
             if the User is not a member of the Card, no change will be made
         """
         if self in card.members:
             card.remove_member(self)
-    
-    def add_to_board(self, board: Board, 
+
+    def add_to_board(self, board: Board,
                      *,
-                     role: BoardRole='viewer',
-                     can_comment: bool=False) -> None:
+                     role: BoardRole = 'viewer',
+                     can_comment: bool = False) -> None:
         """Add the User to a board
-        
+
         Args:
             role (Literal['viewer', 'editor']): The role of the User in the Board (default: `viewer`)
             can_comment (bool): The comment permission for the user if `role` is set to `viewer` (default: `False`)
-            
+
         Note:
-            If the User is already a Board member, but the role or comment permission are different, 
-            the User role and comment permission will be updated
+            If the User is already a Board member, but the role or comment permission are different,
+             the User role and comment permission will be updated
         """
         board.add_member(self, role=role, can_comment=can_comment)
-        
+
     def remove_from_board(self, board: Board) -> None:
         """Remove the User from a Board
-        
+
         Note:
             If the User is not a Board member, no change will be made
         """
         if self in board.users:
             board.remove_user(self)
 
-    def add_notification_service(self, notification_service: NotificationService, 
-                                 *, 
-                                 url: str|None=None, 
-                                 format: NotificationServiceFormat|None=None) -> NotificationService:
+    def add_notification_service(self, notification_service: NotificationService,
+                                 *,
+                                 url: str | None = None,
+                                 format: NotificationServiceFormat | None = None) -> NotificationService:
         """Add/Copy an existing NotificationService to this User
-        
+
         Args:
             notificaiton_service (NotificaitonService): The NotificaitonService to add
             url (str | None): Optional url override (default: from notification_service)
@@ -420,9 +439,9 @@ class User(PlankaModel[schemas.User]):
             )
         return notification_service
 
-    def create_notification_service(self, **kwargs: Unpack[paths.Request_createUserNotificationService]) -> NotificationService:
+    def create_notification_service(self, **kwargs: Unpack[typ.Request_createUserNotificationService]) -> NotificationService:
         """Create a NEW Notification Service
-        
+
         Args:
             url (str): The webhook URL for the NotificationService
             format (NotificationServiceFormat): The format of the NotificationService (default: `text`)
@@ -431,22 +450,22 @@ class User(PlankaModel[schemas.User]):
 
     def delete_notification_service(self, notification_service: NotificationService) -> None:
         """Deletes a NotificationService for a User
-        
+
         Args:
             notificaiton_service (NotificaitonService): The NotificaitonService to delete
         """
         if notification_service in self.notification_services:
             notification_service.delete()
-    
+
     def create_api_key(self, overwrite: bool = False) -> str | None:
         """Generate an API key for the user (must be admin or logged in user)
-        
+
         Args:
             overwrite: If the user already has an API Key, this will overwrite it with a new one and return the new key
-            
+
         Returns:
             A new API Key for the user (This is only sent once! so make sure to save it somewhere)
-            
+
         Raises:
             PermissionError if the user already has a key and `overwrite` is unset
         """
@@ -457,7 +476,8 @@ class User(PlankaModel[schemas.User]):
                 raise PermissionError('User already has an API Key, run again with `overwrite` enabled to create a new one')
         else:
             return self.endpoints.createUserApiKey(self.id)['included']['apiKey']
-    
-from .notification_service import NotificationService
-from .card import Card
+
+
 from .board import Board
+from .card import Card
+from .notification_service import NotificationService

--- a/src/plankapy/v2/models/webhook.py
+++ b/src/plankapy/v2/models/webhook.py
@@ -1,77 +1,82 @@
 from __future__ import annotations
 
-__all__ = ('Webhook', )
-
 from datetime import datetime
+
+from ..api import (
+    events as _events,
+    schemas,
+    typ,
+)
 from ._base import PlankaModel
 from ._helpers import dtfromiso
-from ..api import schemas, paths, events as _events
 
 # Deferred Model imports at bottom of file
 
 TYPE_CHECKING = False
 if TYPE_CHECKING:
     from typing import Unpack
-    #from models import *
+    # from models import *
+
+
+__all__ = ('Webhook', )
 
 
 class Webhook(PlankaModel[schemas.Webhook]):
     """Python interface for Planka Webhooks"""
-    
+
     __events__ = _events.WebhookEvents
 
     @property
     def name(self) -> str:
         """Name/title of the Webhook"""
         return self.schema['name']
-    
+
     @property
     def url(self) -> str:
         """URL endpoint for the Webhook"""
         return self.schema['url']
-    
+
     @property
     def access_token(self) -> str:
         """Access token for webhook authentication"""
         return self.schema['accessToken']
-    
+
     @property
     def events(self) -> list[_events.PlankaEvent]:
         """List of events that trigger the Webhook"""
         return self.schema['events']
-    
+
     @property
     def excluded_events(self) -> list[_events.PlankaEvent]:
         """List of events excluded from the Webhook"""
         return self.schema['excludedEvents']
-    
+
     @property
     def created_at(self) -> datetime:
         """When the Webhook was created"""
         return dtfromiso(self.schema['createdAt'], self.session.timezone)
-        
+
     @property
     def updated_at(self) -> datetime:
         """When the Webhook was last updated"""
         return dtfromiso(self.schema['updatedAt'], self.session.timezone)
-    
+
     # Special Methods
     def sync(self):
         """Sync the Webhook with the Planka server (admin only)"""
         if self.current_role == 'admin':
             self.schema = [
-                Webhook(w, self.session) 
-                for w in self.endpoints.getWebhooks()['items'] 
+                Webhook(w, self.session)
+                for w in self.endpoints.getWebhooks()['items']
                 if w['id'] == self.id
             ].pop().schema
-        
-    def update(self, **kwargs: Unpack[paths.Request_updateWebhook]):
+
+    def update(self, **kwargs: Unpack[typ.Request_updateWebhook]):
         """Update the Webhook (admin only)"""
         if self.current_role == 'admin':
             self.schema = self.endpoints.updateWebhook(self.id, **kwargs)['item']
-    
+
     def delete(self):
         """Delete the Webhook (admin only)"""
         if self.current_role == 'admin':
             self.endpoints.deleteWebhook(self.id)
-  

--- a/src/plankapy/v2/models/webhook.py
+++ b/src/plankapy/v2/models/webhook.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime
+from typing import Unpack
 
 from ..api import (
     events as _events,
@@ -11,12 +12,6 @@ from ._base import PlankaModel
 from ._helpers import dtfromiso
 
 # Deferred Model imports at bottom of file
-
-TYPE_CHECKING = False
-if TYPE_CHECKING:
-    from typing import Unpack
-    # from models import *
-
 
 __all__ = ('Webhook', )
 
@@ -63,20 +58,16 @@ class Webhook(PlankaModel[schemas.Webhook]):
 
     # Special Methods
     def sync(self):
-        """Sync the Webhook with the Planka server (admin only)"""
+        """Sync the Webhook with the Planka server (admin only, noop otherwise)"""
         if self.current_role == 'admin':
-            self.schema = [
-                Webhook(w, self.session)
-                for w in self.endpoints.getWebhooks()['items']
-                if w['id'] == self.id
-            ].pop().schema
+            self.schema = self.session.webhooks[self].dpop(default=self).schema
 
     def update(self, **kwargs: Unpack[typ.Request_updateWebhook]):
-        """Update the Webhook (admin only)"""
+        """Update the Webhook (admin only, noop otherwise)"""
         if self.current_role == 'admin':
             self.schema = self.endpoints.updateWebhook(self.id, **kwargs)['item']
 
     def delete(self):
-        """Delete the Webhook (admin only)"""
+        """Delete the Webhook (admin only, noop otherwise)"""
         if self.current_role == 'admin':
             self.endpoints.deleteWebhook(self.id)

--- a/src/plankapy/v2/utils.py
+++ b/src/plankapy/v2/utils.py
@@ -1,41 +1,50 @@
 """
 Utility functions for dealing with Planka objects
 """
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from itertools import zip_longest
-
 from pathlib import Path
 from typing import Any, Protocol, TypedDict
-from .models import *
-from .interface import Planka
 
-__all__ = ('due_in', 'board_to_csv', 'board_to_table', 'snapshot', 'PlankaSnapshot', )
+from .api import schemas
+from .interface import Planka
+from .models import (
+    Board,
+    CustomFieldGroup,
+    CustomFieldValue,
+    PlankaModel,
+)
+
+__all__ = ('PlankaSnapshot', 'board_to_csv', 'board_to_table', 'due_in', 'snapshot')
+
 
 class HasDueDate(Protocol):
     @property
     def due_date(self) -> datetime | None: ...
-    
-def due_in(hours: float=0, days: float=0, weeks: float=0):
+
+
+def due_in(hours: float = 0, days: float = 0, weeks: float = 0):
     """Decorated function for use with a [ModelList](plankapy.v2.models._helpers.ModelList)
-    That allows filtering by date
+     that allows filtering by date
     """
     def _inner(m: HasDueDate):
         if not m.due_date:
             return False
         by = timedelta(days=days, hours=hours, weeks=weeks)
-        return (m.due_date - by) <= datetime.now(tz=timezone.utc)
+        return (m.due_date - by) <= datetime.now(tz=UTC)
     return _inner
 
+
 def board_to_table(board: Board) -> list[list[str]]:
-    """Get a nested list/table for the board. 
-    Uses `name` attributes of cards and lists
-    
+    """Get a nested list/table for the board.
+     Uses `name` attributes of cards and lists
+
     Args:
         board: The board object to tablify
-    
+
     Returns:
-        A matrix of string lists with the first element being list names 
-        and the remaining elements being card names from left to right    
+        A matrix of string lists with the first element being list names
+         and the remaining elements being card names from left to right.
         ```
         [
             ['list1', 'list2'],
@@ -51,14 +60,15 @@ def board_to_table(board: Board) -> list[list[str]]:
         for lst in board.lists
     ]
     rows = zip_longest(*list_cards, fillvalue='')
-    return [headers]+[list(row) for row in rows]
+    return [headers] + [list(row) for row in rows]
 
-def board_to_csv(board: Board, outdir: str|Path='.', name: str|None=None):
+
+def board_to_csv(board: Board, outdir: str | Path = '.', name: str | None = None):
     """Write the current board state out to a csv file
 
-    Writes out a csv of the board state using `list.name` and `card.name` as 
-    the headers and values respectively. Will match visual state of the board.
-    
+    Writes out a csv of the board state using `list.name` and `card.name` as
+     the headers and values respectively. Will match visual state of the board.
+
     Args:
         board: The board to export
         outdir: A string or Path to the outpud directory (default: `cwd`)
@@ -67,11 +77,9 @@ def board_to_csv(board: Board, outdir: str|Path='.', name: str|None=None):
     outfile = Path(outdir) / f'{name or board.name}.csv'
     rows = board_to_table(board)
     with outfile.open('wt') as csv:
-        csv.writelines(','.join(row)+'\n' for row in rows)
+        csv.writelines(','.join(row) + '\n' for row in rows)
 
 
-# System level snapshot of all schemas
-from .api import schemas
 class PlankaSnapshot(TypedDict):
     projects: list[schemas.Project]
     """Project Schemas"""
@@ -120,21 +128,23 @@ class PlankaSnapshot(TypedDict):
     smtp_config: schemas.Config
     """SMTP Configuration"""
 
+
 def _get_schema[M: PlankaModel[Any]](models: list[M]):
     return [m.schema for m in models]
 
+
 def snapshot(planka: Planka) -> PlankaSnapshot:
     """Create a dictionary snapshot of a Planka object. (MUST BE ADMIN)
-    All associated schemas are dumped into a single dictionary. 
+     All associated schemas are dumped into a single dictionary.
 
     Note:
-        Since this required traversing all objecs in the system, it can be a very long process. 
-        This is best run at a time when not a lot of users are interacting with the board since 
-        a 5 minute snapshot could end up with sync errors if state changes over that time.
+        Since this required traversing all objecs in the system, it can be a very long process.
+         This is best run at a time when not a lot of users are interacting with the board since
+         a 5 minute snapshot could end up with sync errors if state changes over that time.
 
     Returns:
-        A dictonary with all object schemas. Each top level key is a 
-    
+        A dictonary with all object schemas. Each top level key is a snake cased schema name.
+
     Raises:
         PermissionError: If the logged in user is not an admin
     """
@@ -143,7 +153,7 @@ def snapshot(planka: Planka) -> PlankaSnapshot:
     projects = planka.projects
     boards = [b for p in projects for b in p.boards]
     cards = [c for b in boards for c in b.cards]
-    lists = [l for b in boards for l in b.lists]
+    lists = [lst for b in boards for lst in b.lists]
     card_labels = [cl for b in boards for cl in b.card_labels]
     card_memberships = [cm for b in boards for cm in b.card_memberships]
     task_lists = [tl for b in boards for tl in b.task_lists]
@@ -157,7 +167,7 @@ def snapshot(planka: Planka) -> PlankaSnapshot:
     users = planka.users
     board_memberships = [bm for b in boards for bm in b.board_memberships]
     project_managers = [pm for p in projects for pm in p.project_managers]
-    labels = [l for b in boards for l in b.labels]
+    labels = [lbl for b in boards for lbl in b.labels]
     notification_services = [ns for p in projects for ns in p.notification_services]
     actions = [a for c in cards for a in c.actions]
     config = planka.config
@@ -189,4 +199,5 @@ def snapshot(planka: Planka) -> PlankaSnapshot:
     }
     return snap
 
-from .interface import Planka
+
+from .interface import Planka  # noqa: E402


### PR DESCRIPTION
Major reformat to follow new ruff rules

Additionally use ModelList api when applicable instead of inline list comprehensions